### PR TITLE
feat: start a docker compose on startup

### DIFF
--- a/artifacts/autoinstall_ubuntu/build.sh
+++ b/artifacts/autoinstall_ubuntu/build.sh
@@ -21,11 +21,15 @@ BUILD_PATH="$SCRIPT_PATH/build/$TYPE"
 [[ "$CLEAN" == "--clean" ]] && rm -rf "$BUILD_PATH"
 [[ ! -d "$BUILD_PATH" ]] && mkdir -p "$BUILD_PATH"
 [[ ! -d "$BUILD_PATH/kernel" ]] && mkdir -p "$BUILD_PATH/kernel"
-
+[[ ! -d "$BUILD_PATH/custom" ]] && mkdir -p "$BUILD_PATH/custom"
 
 # Copy kernel
 KERNEL_CHECK=($SCRIPT_PATH/../kernel/build/$TYPE/linux-*.deb)
 [[ ${#KERNEL_CHECK[@]} == 0 ]] && echo "$TYPE kernel not found, run 'kernel/build.sh $TYPE' first" && exit 1
 cp $SCRIPT_PATH/../kernel/build/$TYPE/linux-*.deb "$BUILD_PATH/kernel/"
+
+# Copy cvm-agent and systemd startup script.
+cp $SCRIPT_PATH/../../cvm-agent/cvm-agent.sh "$BUILD_PATH/custom/"
+cp $SCRIPT_PATH/cvm-agent.service "$BUILD_PATH/custom/"
 
 docker run --rm --privileged -v "$SCRIPT_PATH:/iso" -it ubuntu:24.04 bash /iso/docker_build.sh $TYPE $SUBTYPE

--- a/artifacts/autoinstall_ubuntu/cvm-agent.service
+++ b/artifacts/autoinstall_ubuntu/cvm-agent.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Nillion CVM agent.
+
+[Service]
+Type=simple
+ExecStart=/opt/nillion/cvm-agent.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/artifacts/autoinstall_ubuntu/docker_build.sh
+++ b/artifacts/autoinstall_ubuntu/docker_build.sh
@@ -20,19 +20,17 @@ apt install -y xorriso curl 7zip
 ISO_NAME="ubuntu-24.04.2-live-server-amd64.iso"
 AUTOINSTALL_ISO_NAME="ubuntu-24.04.2-live-server-amd64-autoinstall-${NAME}.iso"
 
-
 UBUNTU_ISO_PATH="$SCRIPT_PATH/build/$ISO_NAME"
 [[ ! -f "${UBUNTU_ISO_PATH}" ]] && curl -L https://releases.ubuntu.com/noble/ubuntu-24.04.2-live-server-amd64.iso -o "$UBUNTU_ISO_PATH"
 
-
 [[ ! -d "$BUILD_PATH/iso/" ]] && mkdir -p "$BUILD_PATH/iso/"
-cd  "$BUILD_PATH/iso"
+cd "$BUILD_PATH/iso"
 
 [[ -d custom-iso ]] && rm -rf custom-iso
 [[ -d BOOT ]] && rm -rf BOOT
 
 7z -y x "$UBUNTU_ISO_PATH" -ocustom-iso
-mv  './custom-iso/[BOOT]' ./BOOT
+mv './custom-iso/[BOOT]' ./BOOT
 
 mkdir -p custom-iso/nocloud/
 cp $SCRIPT_PATH/user-data-$NAME.yaml ./custom-iso/nocloud/user-data
@@ -41,6 +39,9 @@ touch ./custom-iso/nocloud/meta-data
 # Add kernel to iso
 mkdir -p custom-iso/packages
 cp ../kernel/*.deb custom-iso/packages
+
+mkdir -p custom-iso/nillion
+cp ${BUILD_PATH}/custom/* custom-iso/nillion
 
 # add cuda-keyring to iso if guest gpu
 if [[ "$TYPE" == "guest" && "$SUBTYPE" == "gpu" ]]; then

--- a/artifacts/autoinstall_ubuntu/user-data-guest-cpu.yaml
+++ b/artifacts/autoinstall_ubuntu/user-data-guest-cpu.yaml
@@ -21,5 +21,20 @@ autoinstall:
     layout:
       name: lvm
 
+  user-data:
+    mounts:
+      - [ "/dev/sr0", "/media/cvm-agent-entrypoint", "udf,iso9660", "auto,ro,utf8", "0", "0" ]
+
   late-commands:
     - curtin in-target -- dpkg -i /cdrom/packages/*.deb
+    - curtin in-target -- apt update
+    - curtin in-target -- apt install -y docker-compose-v2
+    # Copy over cvm-agent.
+    - curtin in-target -- mkdir /opt/nillion
+    - curtin in-target -- cp /cdrom/nillion/cvm-agent.sh /opt/nillion
+    - curtin in-target -- chmod +x /opt/nillion/cvm-agent.sh
+    # Configure cvm-agent to auto start.
+    - curtin in-target -- cp /cdrom/nillion/cvm-agent.service /etc/systemd/system/
+    - curtin in-target -- systemctl daemon-reload
+    - curtin in-target -- systemctl enable cvm-agent.service
+

--- a/artifacts/autoinstall_ubuntu/user-data-guest-gpu.yaml
+++ b/artifacts/autoinstall_ubuntu/user-data-guest-gpu.yaml
@@ -21,10 +21,22 @@ autoinstall:
     layout:
       name: lvm
 
+  user-data:
+    mounts:
+      - [ "/dev/sr0", "/media/cvm-agent-entrypoint", "udf,iso9660", "auto,ro,utf8", "0", "0" ]
+
   late-commands:
     - curtin in-target -- dpkg -i /cdrom/packages/*.deb
     - curtin in-target -- apt-get update
-    - curtin in-target -- apt-get -y install nvidia-driver-550-server-open
+    - curtin in-target -- apt-get -y install nvidia-driver-550-server-open docker-compose-v2
     - curtin in-target -- echo "install nvidia /sbin/modprobe ecdsa_generic ecdh; /sbin/modprobe --ignore-install nvidia" > /etc/modprobe.d/nvidia-lkca.conf
     - curtin in-target -- sed -i "/^ExecStart=/d" /usr/lib/systemd/system/nvidia-persistenced.service
     - curtin in-target -- echo "ExecStart=/usr/bin/nvidia-persistenced --user nvidia-persistenced --uvm-persistence-mode --verbose" >> /usr/lib/systemd/system/nvidia-persistenced.service
+    # Copy over cvm-agent.
+    - curtin in-target -- mkdir /opt/nillion
+    - curtin in-target -- cp /cdrom/nillion/cvm-agent.sh /opt/nillion
+    - curtin in-target -- chmod +x /opt/nillion/cvm-agent.sh
+    # Configure cvm-agent to auto start.
+    - curtin in-target -- cp /cdrom/nillion/cvm-agent.service /etc/systemd/system/
+    - curtin in-target -- systemctl daemon-reload
+    - curtin in-target -- systemctl enable cvm-agent.service

--- a/cvm-agent/cvm-agent.sh
+++ b/cvm-agent/cvm-agent.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+ROOT_PATH="/media/cvm-agent-entrypoint"
+cd "${ROOT_PATH}"
+docker compose up -d


### PR DESCRIPTION
This adds an initial "cvm-agent" which is a dumb script that runs docker compose on a pre-defined path. The steps for this are:

* During the install phase:
  * We install docker compose.
  * We copy over the script and set it to autostart via systemd.
  * We set up a mount that will take a cdrom drive and mount it on `/media/cvm-agent-entrypoint`.
* When we start the qemu VM:
  * An ISO has to be included via `-cdrom <path>`.
  * The ISO must contain a `docker-compose.yaml` file at its root. You can generate such an ISO by creating a directory and then running `mkisofs -U -o <iso-path> <path-to-dir>` (the `-U` is important to preserve the file names).
  * The cvm-agent script will start, cd into the predefined cdrom directory under `/media` and `docker compose up -d`.

This starts the FE's docker compose file as is. In the next PR I'll add caddy to route request appropriately but I think this as it is now can already give us enough to start running FE's code, as long we add caddy to the docker-compose file.

To run do something like:

```bash
qemu-system-x86_64 -boot c -enable-kvm -m 4096 -hda <path-to-hard-disk> -cdrom <path-to-iso>
```