### PR TITLE
chore: add tests for certificate verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,6 +162,7 @@ dependencies = [
  "openssl",
  "rand",
  "reqwest",
+ "rstest",
  "serde",
  "sev",
  "thiserror",

--- a/attestation-service/Cargo.toml
+++ b/attestation-service/Cargo.toml
@@ -9,13 +9,16 @@ async-trait = "0.1"
 axum = "0.8"
 clap = { version = "4.5", features = ["derive"] }
 hex = { version = "0.4", features = ["serde"] }
-openssl = { version = "^0.10", features = ["vendored"]}
+openssl = { version = "^0.10", features = ["vendored"] }
 rand = "0.9"
 reqwest = "0.12"
 serde = { version = "1.0", features = ["derive"] }
-sev = { version = "6.1", default-features = false, features = ['openssl','snp']}
+sev = { version = "6.1", default-features = false, features = ["openssl", "snp"] }
 thiserror = "2.0"
 tokio = { version = "1.45", features = ["rt-multi-thread", "macros"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
-x509-parser = { version = "0.17.0", features=["verify"] } 
+x509-parser = { version = "0.17.0", features = ["verify"] } 
+
+[dev-dependencies]
+rstest = { version = "0.25", default-features = false }


### PR DESCRIPTION
This adds tests for certification verification, in particular around certificate relationship and the attestation report's signature.