### PR TITLE
feat: add config file/env support in attestation service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
 name = "asn1-rs"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,6 +164,7 @@ dependencies = [
  "async-trait",
  "axum",
  "clap",
+ "config",
  "hex",
  "openssl",
  "rand",
@@ -397,6 +404,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "config"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "595aae20e65c3be792d05818e8c63025294ac3cb7e200f11459063a352a6ef80"
+dependencies = [
+ "pathdiff",
+ "serde",
+ "winnow",
+ "yaml-rust2",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,6 +647,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -809,6 +834,18 @@ name = "hashbrown"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown",
+]
 
 [[package]]
 name = "heck"
@@ -1394,6 +1431,12 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
@@ -2787,6 +2830,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
+name = "winnow"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen-rt"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2817,6 +2869,17 @@ dependencies = [
  "rusticata-macros",
  "thiserror",
  "time",
+]
+
+[[package]]
+name = "yaml-rust2"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818913695e83ece1f8d2a1c52d54484b7b46d0f9c06beeb2649b9da50d9b512d"
+dependencies = [
+ "arraydeque",
+ "encoding_rs",
+ "hashlink",
 ]
 
 [[package]]

--- a/attestation-service/Cargo.toml
+++ b/attestation-service/Cargo.toml
@@ -8,6 +8,7 @@ anyhow = "1.0"
 async-trait = "0.1"
 axum = "0.8"
 clap = { version = "4.5", features = ["derive"] }
+config = { version = "0.15", default-features = false, features = ["yaml"] }
 hex = { version = "0.4", features = ["serde"] }
 openssl = { version = "^0.10", features = ["vendored"] }
 rand = "0.9"

--- a/attestation-service/src/config.rs
+++ b/attestation-service/src/config.rs
@@ -1,0 +1,47 @@
+use crate::verify::Processor;
+use anyhow::Context;
+use serde::Deserialize;
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+
+#[derive(Deserialize)]
+pub struct Config {
+    #[serde(default)]
+    pub server: ServerConfig,
+
+    #[serde(default)]
+    pub attestation: AttestationConfig,
+}
+
+impl Config {
+    pub fn load(path: Option<&str>) -> anyhow::Result<Self> {
+        let mut builder = config::Config::builder().add_source(config::Environment::with_prefix("APP").separator("__"));
+        if let Some(path) = path {
+            builder = builder.add_source(config::File::with_name(path))
+        }
+        let settings = builder.build().context("parsing config")?;
+        settings.try_deserialize().context("deserializing config")
+    }
+}
+
+#[derive(Deserialize)]
+pub struct ServerConfig {
+    #[serde(default = "default_bind_endpoint")]
+    pub bind_endpoint: SocketAddr,
+}
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        Self { bind_endpoint: default_bind_endpoint() }
+    }
+}
+
+#[derive(Deserialize, Default)]
+pub struct AttestationConfig {
+    #[serde(default)]
+    pub processor: Option<Processor>,
+}
+
+fn default_bind_endpoint() -> SocketAddr {
+    // 0.0.0.0:8080
+    SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 8080))
+}

--- a/attestation-service/src/lib.rs
+++ b/attestation-service/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod certs;
+pub mod config;
 pub mod report;
 pub mod routes;
 pub mod verify;

--- a/attestation-service/src/main.rs
+++ b/attestation-service/src/main.rs
@@ -1,42 +1,51 @@
 use attestation_service::{
     certs::{CertFetchPolicy, DefaultCertificateFetcher},
+    config::Config,
     report::request_hardware_report,
     routes::build_router,
-    verify::{Processor, ReportVerifier},
+    verify::ReportVerifier,
 };
 use clap::Parser;
-use std::net::SocketAddr;
 use tokio::net::TcpListener;
-use tracing::info;
+use tracing::{error, info};
 
 #[derive(Parser)]
 struct Cli {
-    /// The endpoint to bind to.
-    #[clap(short, long, default_value = "0.0.0.0:8080")]
-    bind_endpoint: SocketAddr,
+    /// The path to the config file.
+    #[clap(short, long)]
+    config_path: Option<String>,
 }
 
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt().init();
 
-    let Cli { bind_endpoint } = Cli::parse();
+    let Cli { config_path } = Cli::parse();
+    let config = match Config::load(config_path.as_deref()) {
+        Ok(config) => config,
+        Err(e) => {
+            error!("Failed to load config: {e:#}");
+            std::process::exit(1);
+        }
+    };
 
     info!("Getting report to use during initial verification");
     let report = request_hardware_report(rand::random()).expect("failed to get hardware report");
 
     info!("Verifying report");
     let fetcher = DefaultCertificateFetcher::new(CertFetchPolicy::PreferHardware);
-    ReportVerifier::new(Box::new(fetcher))
-        // TODO make configurable
-        .with_processor(Processor::Genoa)
-        .verify_report(report)
-        .await
-        .expect("failed to fetch certs");
+    let mut verifier = ReportVerifier::new(Box::new(fetcher));
+    if let Some(processor) = config.attestation.processor {
+        info!("Forcing processor to be {processor:?}");
+        verifier = verifier.with_processor(processor);
+    }
+    verifier.verify_report(report).await.expect("failed to fetch certs");
     info!("Verification succeeded");
 
-    let router = build_router();
+    let bind_endpoint = &config.server.bind_endpoint;
     info!("Running server on {bind_endpoint}");
+
+    let router = build_router();
     let listener = TcpListener::bind(bind_endpoint).await.expect("failed to bind");
     axum::serve(listener, router).await.expect("failed to run");
 }

--- a/attestation-service/src/verify.rs
+++ b/attestation-service/src/verify.rs
@@ -2,6 +2,7 @@ use crate::certs::{CertificateFetcher, Certs};
 use anyhow::{anyhow, bail, Context};
 use clap::ValueEnum;
 use openssl::{ecdsa::EcdsaSig, sha::Sha384};
+use serde::Deserialize;
 use sev::{
     certs::snp::{Certificate, Verifiable},
     firmware::{guest::AttestationReport, host::CertType},
@@ -230,7 +231,8 @@ impl ReportVerifier {
     }
 }
 
-#[derive(ValueEnum, Debug, Clone, PartialEq, Eq)]
+#[derive(ValueEnum, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
 pub enum Processor {
     /// 3rd Gen AMD EPYC Processor (Standard)
     Milan,


### PR DESCRIPTION
This adds config file support in the attestation service. Options can also be overridden via env vars like `APP__ATTESTATION__PROCESSOR=genoa`.