### PR TITLE
feat: allow exposing reserved ports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,9 +566,9 @@ dependencies = [
 
 [[package]]
 name = "docker-compose-types"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f5e899a3da7a90647ef302f7e3050b00ed7f3f02c7b32683a04f3fbd9052541"
+checksum = "c8b52849aa393d1c8752e11fd5e1d8c802b442a8423611079f0b547684a79b70"
 dependencies = [
  "derive_builder",
  "indexmap",

--- a/nilcc-agent/Cargo.toml
+++ b/nilcc-agent/Cargo.toml
@@ -8,7 +8,7 @@ anyhow = "1.0"
 async-trait = "0.1"
 clap = { version = "4.5", features = ["derive", "env"] }
 dirs = "6"
-docker-compose-types = "0.16"
+docker-compose-types = "0.17"
 erased-serde = "0.4"
 hex = { version = "0.4", features = ["serde"] }
 metrics = "0.24"

--- a/nilcc-agent/src/iso.rs
+++ b/nilcc-agent/src/iso.rs
@@ -2,7 +2,10 @@ use docker_compose_types::{Compose, Ports};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 use std::{
-    fs, io, iter,
+    fmt,
+    fs::{self, File},
+    io::{self, BufWriter},
+    iter, mem,
     path::Path,
     process::{ExitStatus, Stdio},
     str::FromStr,
@@ -11,7 +14,7 @@ use tokio::{fs::create_dir_all, process::Command};
 use tracing::info;
 
 // The list of ports that can't be exported.
-static RESERVED_PORTS: &[u16] = &[443];
+static RESERVED_PORTS: &[u16] = &[80, 443];
 
 // The list of container names that are reserved.
 static RESERVED_CONTAINERS: &[&str] = &["nilcc-attester", "nilcc-proxy"];
@@ -58,10 +61,11 @@ impl IsoMaker {
     ) -> Result<IsoMetadata, ApplicationIsoError> {
         let IsoSpec { docker_compose_yaml, metadata } = spec;
         info!("Parsing docker compose YAML");
-        let compose: Compose = serde_yaml::from_str(&docker_compose_yaml)?;
+        let compose: Compose =
+            serde_yaml::from_str(&docker_compose_yaml).map_err(ApplicationIsoError::YamlDeserialize)?;
 
-        info!("Validating docker compose");
-        ComposeValidator { compose, api: &metadata.api }.validate()?;
+        info!("Sanitizing docker compose");
+        let compose = ComposeSanitizer { api: &metadata.api }.sanitize(compose)?;
 
         let tempdir = tempfile::TempDir::with_prefix("nilcc-agent").map_err(ApplicationIsoError::Tempdir)?;
         let input_path = tempdir.path().join("contents");
@@ -69,8 +73,10 @@ impl IsoMaker {
 
         info!("Writing files into temporary directory: {}", input_path.display());
         let metadata = serde_json::to_string(&metadata)?;
-        fs::write(input_path.join("docker-compose.yaml"), &docker_compose_yaml)
-            .map_err(ApplicationIsoError::FilesWrite)?;
+        let compose_file =
+            File::create(input_path.join("docker-compose.yaml")).map_err(ApplicationIsoError::FilesWrite)?;
+        let compose_file = BufWriter::new(compose_file);
+        serde_yaml::to_writer(compose_file, &compose).map_err(ApplicationIsoError::YamlSerialize)?;
         fs::write(input_path.join("metadata.json"), &metadata).map_err(ApplicationIsoError::FilesWrite)?;
 
         info!("Invoking mkisofs to generate ISO in {}", iso_path.display());
@@ -101,21 +107,20 @@ pub struct IsoMetadata {
     docker_compose_hash: [u8; 32],
 }
 
-struct ComposeValidator<'a> {
-    compose: Compose,
+struct ComposeSanitizer<'a> {
     api: &'a ContainerMetadata,
 }
 
-impl ComposeValidator<'_> {
-    fn validate(self) -> Result<(), ComposeValidationError> {
-        self.validate_services()?;
-        Ok(())
+impl ComposeSanitizer<'_> {
+    fn sanitize(self, compose: Compose) -> Result<Compose, ComposeValidationError> {
+        let compose = self.sanitize_services(compose)?;
+        Ok(compose)
     }
 
-    fn validate_services(&self) -> Result<(), ComposeValidationError> {
+    fn sanitize_services(&self, mut compose: Compose) -> Result<Compose, ComposeValidationError> {
         let mut found_api_container = false;
-        for (name, spec) in &self.compose.services.0 {
-            let spec = spec.as_ref().ok_or_else(|| ComposeValidationError::ServiceBodyMissing(name.clone()))?;
+        for (name, spec) in &mut compose.services.0 {
+            let spec = spec.as_mut().ok_or_else(|| ComposeValidationError::ServiceBodyMissing(name.clone()))?;
             // The container name is the one in `services:` and optionally also its
             // `container_name`, if any.
             let mut names = iter::once(name).chain(spec.container_name.as_ref());
@@ -127,36 +132,46 @@ impl ComposeValidator<'_> {
                 found_api_container = true;
             }
 
-            Self::validate_ports(&spec.ports)?;
+            spec.ports = Self::sanitize_ports(mem::take(&mut spec.ports))?;
         }
         if !found_api_container {
             return Err(ComposeValidationError::ApiContainerMissing);
         }
-        Ok(())
+        Ok(compose)
     }
 
-    fn validate_ports(ports: &Ports) -> Result<(), ComposeValidationError> {
-        let ports: Vec<u16> = match ports {
-            Ports::Short(ports) => ports
-                .iter()
-                .flat_map(|port| ExposedPorts::from_str(port).map(|p| p.exposed).transpose())
-                .collect::<Result<_, _>>()?,
-            Ports::Long(ports) => {
-                let all_ports: Vec<_> = ports
-                    .iter()
-                    .flat_map(|p| &p.published)
-                    .map(|p| PublishedPorts::try_from(p).map(|p| p.0))
-                    .collect::<Result<_, _>>()?;
-                all_ports.into_iter().flatten().collect()
+    fn sanitize_ports(ports: Ports) -> Result<Ports, ComposeValidationError> {
+        match ports {
+            Ports::Short(ports) => {
+                let mut sanitized_ports = Vec::new();
+                for port in ports {
+                    let mut parsed = ExposedPorts::from_str(&port)?;
+                    if let Some(port) = parsed.exposed {
+                        if RESERVED_PORTS.contains(&port) {
+                            parsed.exposed = None;
+                        }
+                    }
+                    sanitized_ports.push(parsed.to_string());
+                }
+                Ok(Ports::Short(sanitized_ports))
             }
-        };
-
-        for port in ports {
-            if RESERVED_PORTS.contains(&port) {
-                return Err(ComposeValidationError::PublishedPorts(port));
+            Ports::Long(mut ports) => {
+                for port in &mut ports {
+                    if let Some(published) = &port.published {
+                        let published = PublishedPorts::try_from(published)?;
+                        if let Some(reserved) = published.0.iter().find(|p| RESERVED_PORTS.contains(p)) {
+                            if published.0.len() == 1 {
+                                // If it's a single one we can take it out
+                                port.published = None;
+                            } else {
+                                return Err(ComposeValidationError::PublishedPorts(*reserved));
+                            }
+                        }
+                    }
+                }
+                Ok(Ports::Long(ports))
             }
         }
-        Ok(())
     }
 }
 
@@ -170,11 +185,14 @@ impl TryFrom<&docker_compose_types::PublishedPort> for PublishedPorts {
         match ports {
             Single(port) => Ok(PublishedPorts(vec![*port])),
             Range(spec) => {
-                let Some((from, to)) = spec.split_once(":") else {
+                let Some((from, to)) = spec.split_once("-") else {
                     return Err(ComposeValidationError::InvalidPorts);
                 };
                 let from: u16 = from.parse().map_err(|_| ComposeValidationError::InvalidPorts)?;
                 let to: u16 = to.parse().map_err(|_| ComposeValidationError::InvalidPorts)?;
+                if from > to {
+                    return Err(ComposeValidationError::InvalidPorts);
+                }
                 Ok(PublishedPorts((from..=to).collect()))
             }
         }
@@ -183,6 +201,7 @@ impl TryFrom<&docker_compose_types::PublishedPort> for PublishedPorts {
 
 struct ExposedPorts {
     exposed: Option<u16>,
+    target: u16,
 }
 
 impl FromStr for ExposedPorts {
@@ -199,11 +218,27 @@ impl FromStr for ExposedPorts {
             }
             None => s,
         };
-        let exposed = match s.split_once(':') {
-            Some((from, _)) => Some(from.parse().map_err(|_| InvalidPorts)?),
-            None => None,
+        let (exposed, target) = match s.split_once(':') {
+            Some((from, to)) => {
+                let from = from.parse().map_err(|_| InvalidPorts)?;
+                let to = to.parse().map_err(|_| InvalidPorts)?;
+                (Some(from), to)
+            }
+            None => {
+                let to = s.parse().map_err(|_| InvalidPorts)?;
+                (None, to)
+            }
         };
-        Ok(Self { exposed })
+        Ok(Self { exposed, target })
+    }
+}
+
+impl fmt::Display for ExposedPorts {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(port) = self.exposed {
+            write!(f, "{port}:")?;
+        }
+        write!(f, "{}", self.target)
     }
 }
 
@@ -214,7 +249,10 @@ pub enum ApplicationIsoError {
     Tempdir(io::Error),
 
     #[error("YAML model deserialization: {0}")]
-    YamlDeserialize(#[from] serde_yaml::Error),
+    YamlDeserialize(serde_yaml::Error),
+
+    #[error("YAML model serialization: {0}")]
+    YamlSerialize(serde_yaml::Error),
 
     #[error("JSON model serialization: {0}")]
     JsonSerialize(#[from] serde_json::Error),
@@ -260,22 +298,48 @@ mod tests {
     use rstest::rstest;
 
     #[rstest]
+    #[case::text(
+        r#"
+services:
+  api:
+    image: foo:latest
+    ports:
+      - "hello"
+"#
+    )]
+    #[case::too_many_colons(
+        r#"
+services:
+  api:
+    image: foo:latest
+    ports:
+      - "80:80:80"
+"#
+    )]
+    #[case::broken_range1(
+        r#"
+services:
+  api:
+    image: foo:latest
+    ports:
+      - target: 80
+        published: 80:79
+"#
+    )]
+    fn malformed_docker_compose_ports(#[case] input: &str) {
+        let compose: Compose = serde_yaml::from_str(input).expect("invalid docker compose");
+        let api = ContainerMetadata { container: "api".to_string(), port: 80 };
+        let err = ComposeSanitizer { api: &api }.sanitize(compose).expect_err("no failure");
+        assert_eq!(err, ComposeValidationError::InvalidPorts);
+    }
+
+    #[rstest]
     #[case::no_container(
         ComposeValidationError::ApiContainerMissing,
         r#"
 services:
   foo:
     image: foo:latest
-"#
-    )]
-    #[case::exposed_ports_short(
-        ComposeValidationError::PublishedPorts(443),
-        r#"
-services:
-  api:
-    image: foo:latest
-    ports:
-      - "443:80"
 "#
     )]
     #[case::exposed_ports_long(
@@ -286,7 +350,7 @@ services:
     image: foo:latest
     ports:
       - target: 80
-        published: 443
+        published: 443-444
 "#
     )]
     #[case::reserved_name_top_level(
@@ -309,8 +373,50 @@ services:
     fn invalid_docker_composes(#[case] expected_error: ComposeValidationError, #[case] input: &str) {
         let compose: Compose = serde_yaml::from_str(input).expect("invalid docker compose");
         let api = ContainerMetadata { container: "api".to_string(), port: 80 };
-        let err = ComposeValidator { compose, api: &api }.validate().expect_err("no failure");
+        let err = ComposeSanitizer { api: &api }.sanitize(compose).expect_err("no failure");
         assert_eq!(err, expected_error);
+    }
+
+    #[rstest]
+    #[case::exposed_ports_short(
+        r#"
+    services:
+      api:
+        image: foo:latest
+        ports:
+          - "443:443"
+    "#,
+        r#"
+    services:
+      api:
+        image: foo:latest
+        ports:
+          - "443"
+    "#
+    )]
+    #[case::exposed_ports_long(
+        r#"
+    services:
+      api:
+        image: foo:latest
+        ports:
+          - target: 80
+            published: 80
+    "#,
+        r#"
+    services:
+      api:
+        image: foo:latest
+        ports:
+          - target: 80
+    "#
+    )]
+    fn sanitized_docker_composes(#[case] input: &str, #[case] output: &str) {
+        let input: Compose = serde_yaml::from_str(input).expect("invalid docker compose");
+        let output: Compose = serde_yaml::from_str(output).expect("invalid docker compose");
+        let api = ContainerMetadata { container: "api".to_string(), port: 80 };
+        let sanitized = ComposeSanitizer { api: &api }.sanitize(input).expect("validation failed");
+        assert_eq!(sanitized, output);
     }
 
     #[rstest]
@@ -335,12 +441,33 @@ services:
   api:
     image: foo:latest
     ports:
-      - "80:80"
+      - "81:81"
+"#
+    )]
+    #[case::publish_port_long(
+        r#"
+services:
+  api:
+    image: foo:latest
+    ports:
+      - target: 81
+        published: 81-81
+"#
+    )]
+    #[case::publish_port_many(
+        r#"
+services:
+  api:
+    image: foo:latest
+    ports:
+      - target: 81
+        published: 81-100
 "#
     )]
     fn valid_docker_composes(#[case] input: &str) {
         let compose: Compose = serde_yaml::from_str(input).expect("invalid docker compose");
         let api = ContainerMetadata { container: "api".to_string(), port: 80 };
-        ComposeValidator { compose, api: &api }.validate().expect("validation failed");
+        let sanitized = ComposeSanitizer { api: &api }.sanitize(compose.clone()).expect("validation failed");
+        assert_eq!(sanitized, compose);
     }
 }


### PR DESCRIPTION
This changes the behavior when parsing the docker compose file to allow using reserved ports, but instead alter the compose file to not expose them. This way we can accept docker compose files that expose ports 80, 443 and whatever other port we decide is reserved and still run their code.