### PR TITLE
fix: expose /dev/sev-guest to nilcc-attester container

### DIFF
--- a/cvm-agent/services/docker-compose.yaml
+++ b/cvm-agent/services/docker-compose.yaml
@@ -2,6 +2,9 @@ services:
   nilcc-attester:
     image: ghcr.io/nillionnetwork/nilcc-attester:latest
     restart: unless-stopped
+    privileged: true
+    volumes:
+      - "/dev/sev-guest:/dev/sev-guest"
     environment:
       APP__SERVER__BIND_ENDPOINT: "0.0.0.0:80"
     healthcheck:


### PR DESCRIPTION
This exposes /dev/sev-guest to the nilcc-attester container and makes it a `privileged` container as these parameters are needed for attestations to work.