### PR TITLE
feat: perform attestation on boot

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,8 +2,11 @@
 
 !/nilcc-attester
 !/nilcc-agent
+!/initrd-helper
 !/attestation-verifier
 !/Cargo.toml
 !/Cargo.lock
+!/artifacts/initramfs/build/kernel/kernel.deb
+!/artifacts/initramfs/init.sh
 target
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1084,6 +1084,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "initrd-helper"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "base64",
+ "clap",
+ "serde_json",
+ "sev",
+]
+
+[[package]]
 name = "iocuddle"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 
 members = [
   "attestation-verifier",
+  "initrd-helper",
   "nilcc-attester",
   "nilcc-agent"
 ]

--- a/artifacts/initramfs/Dockerfile
+++ b/artifacts/initramfs/Dockerfile
@@ -1,7 +1,22 @@
+FROM rust:1.86-alpine AS build
+
+WORKDIR /opt/nillion
+RUN apk add --no-cache musl-dev
+
+COPY . .
+RUN cargo build --release --locked -p initrd-helper
+
 FROM ubuntu:24.04
+
+COPY artifacts/initramfs/build/kernel/kernel.deb /tmp/
 
 RUN apt update \
   && apt upgrade -y \
-  && rm -rf /var/lib/apt/lists/*
+  && apt install -y kmod \
+  && apt install -y /tmp/kernel.deb \
+  && rm -rf /var/lib/apt/lists/* \
+  && rm /tmp/kernel.deb
 
-COPY init.sh /init
+COPY artifacts/initramfs/init.sh /init
+COPY --from=build /opt/nillion/target/release/initrd-helper /opt/nillion/initrd-helper
+

--- a/artifacts/initramfs/build.sh
+++ b/artifacts/initramfs/build.sh
@@ -10,8 +10,15 @@ OUT="$BUILD_DIR/initramfs.cpio.gz"
 echo "Preparing directories.."
 rm -rf "$BUILD_DIR"
 INITRD_DIR=$BUILD_DIR/initramfs
+KERNEL_DIR=$BUILD_DIR/kernel
 
-mkdir -p $INITRD_DIR
+mkdir -p $INITRD_DIR $KERNEL_DIR
+
+KERNEL_DEB=$(ls $SCRIPT_PATH/../kernel/build/guest/linux-image-6.11.0-snp-guest-*.deb | grep -v 'dbg_6.11')
+[[ ${#KERNEL_DEB[@]} == 0 ]] && echo "Kernel not found, run 'kernel/build.sh guest' first" && exit 1
+[[ ${#KERNEL_DEB[@]} > 1 ]] && echo "More than one kernel package found, only one can be used" && exit 1
+
+cp "$KERNEL_DEB" $KERNEL_DIR/kernel.deb
 
 echo "Building Docker image"
 DOCKER_IMG="nilcc-initramfs"
@@ -25,7 +32,7 @@ cleanup() {
 }
 
 # Build our docker image.
-docker build -t $DOCKER_IMG $SCRIPT_PATH
+docker build -t $DOCKER_IMG -f $SCRIPT_PATH/Dockerfile $SCRIPT_PATH/../../
 
 # Run the container. This will run and stop it immediately since it does nothing by default.
 echo "Running container ${DOCKER_CONTAINER}"
@@ -38,9 +45,18 @@ docker export $DOCKER_CONTAINER | tar xpf - -C $INITRD_DIR
 
 # Clean up.
 echo "Removing unnecessary files and directories"
-rm -rf $INITRD_DIR/dev $INITRD_DIR/proc $INITRD_DIR/sys $INITRD_DIR/boot \
-  $INITRD_DIR/home $INITRD_DIR/media $INITRD_DIR/mnt $INITRD_DIR/opt \
-  $INITRD_DIR/root $INITRD_DIR/srv $INITRD_DIR/tmp $INITRD_DIR/.dockerenv
+rm -rf \
+  $INITRD_DIR/.dockerenv \
+  $INITRD_DIR/boot \
+  $INITRD_DIR/dev \
+  $INITRD_DIR/home \
+  $INITRD_DIR/media \
+  $INITRD_DIR/mnt \
+  $INITRD_DIR/proc \
+  $INITRD_DIR/root \
+  $INITRD_DIR/srv \
+  $INITRD_DIR/sys \
+  $INITRD_DIR/tmp
 
 # We need to clear the "s" permission bit from some executables like `mount`
 echo "Changing permissions"
@@ -52,7 +68,8 @@ pushd $INITRD_DIR >/dev/null
 find . -print0 | cpio --null -ov --format=newc 2>/dev/null | gzip -1 >$OUT
 popd >/dev/null
 
-echo "initrd image generated at $OUT"
+INITRD_SIZE=$(du -h $OUT | cut -f1)
+echo "initrd image generated at ${OUT}, size: ${INITRD_SIZE}"
 
 [[ ! -d $SCRIPT_PATH/../dist/initramfs ]] && mkdir -p $SCRIPT_PATH/../dist/initramfs
 cp "$OUT" "$SCRIPT_PATH/../dist/initramfs"

--- a/initrd-helper/Cargo.toml
+++ b/initrd-helper/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "initrd-helper"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anyhow = "1"
+base64 = "0.22"
+clap = { version = "4.5", features = ["derive"] }
+serde_json = "1.0"
+sev = "6.1.0"
+

--- a/initrd-helper/src/main.rs
+++ b/initrd-helper/src/main.rs
@@ -1,0 +1,61 @@
+use anyhow::{anyhow, Context};
+use base64::prelude::*;
+use clap::{Args, Parser, Subcommand};
+use sev::firmware::guest::{AttestationReport, Firmware};
+use std::{fs::File, io::BufWriter, path::PathBuf, process::exit};
+
+/// A helper that provides utilities for the initrd script.
+#[derive(Parser)]
+struct Cli {
+    #[clap(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Generate an attestation report and store it as a JSON file in the given path.
+    Report(ReportArgs),
+}
+
+#[derive(Args)]
+struct ReportArgs {
+    // A base64-encoded 64 byte string.
+    #[clap(short, long)]
+    data: String,
+
+    /// The path where the output report in JSON format will be written to.
+    output_path: PathBuf,
+}
+
+fn generate_report(args: ReportArgs) -> anyhow::Result<()> {
+    let ReportArgs { data, output_path } = args;
+
+    // Parse the input data as a 64 byte blob.
+    let data = BASE64_STANDARD.decode(&data).context("parsing data as base64")?;
+    let data: [u8; 64] = data.try_into().map_err(|_| anyhow!("data must be 64 bytes"))?;
+
+    // Get a report.
+    let mut firmware = Firmware::open().context("opening /dev/sev-guest")?;
+    let report = firmware.get_report(None, Some(data), None).context("creating attestation report")?;
+    let report = AttestationReport::from_bytes(&report).context("parsing attestation report")?;
+
+    // Write the report into the given path, as JSON.
+    let output_file = File::create(output_path).context("opening output path")?;
+    let output_file = BufWriter::new(output_file);
+    serde_json::to_writer(output_file, &report).context("writing report to the output file")?;
+    Ok(())
+}
+
+fn run(cli: Cli) -> anyhow::Result<()> {
+    match cli.command {
+        Command::Report(args) => generate_report(args),
+    }
+}
+
+fn main() {
+    let cli = Cli::parse();
+    if let Err(e) = run(cli) {
+        eprintln!("Failed to run: {e:#}");
+        exit(1);
+    }
+}


### PR DESCRIPTION
This generates an attestation on initrd when booting, making it available for later use. It's unclear exactly how we'll surface this, but the general idea is this lets us prove we're running in a CVM and lets us in the future expose this attestation somehow, potentially as proofs to FEs that we're running what we claim we're running.

The process to get this done is:
* Create a tiny rust app that allows generating attestations. I feel like we'll need something more here, hence the dedicated app. We technically could use snpguest but that doesn't produce JSON output and this is so little code I find it hard to justify not doing it this way.
* This app is built into the initrd image, building it within docker and copying the binary over to `/opt/nillion`.
* Copy/install the 6.11 kernel into the initrd container while preparing it. This is needed to be able to `modprobe sev-guest` in initrd.

Then in the init script:
* Create 64 bytes of random data and store them in `/etc/nilcc-boot/input`.
* Run the helper tool to generate an attestation and write its output, in JSON, into `/etc/nilcc-boot/report.json`.

Closes #47 

PS: the build is flaky but this is working.