### PR TITLE
feat(nilcc-agent): add new commands to allow forceful stop and graceful restart

### DIFF
--- a/nilcc-agent/README.md
+++ b/nilcc-agent/README.md
@@ -12,3 +12,33 @@ A lightweight agent that provides CLI to create and manage VMs in QEMU
    4. `sudo apt install qemu-system-x86 qemu-utils qemu-kvm libvirt-daemon-system libvirt-clients ovmf`
 2. Test
    1. To be able to view VM console in window when testing: `GDK_BACKEND=wayland cargo test -- --nocapture`
+
+## Launch VM
+
+### Non-confidential VM
+
+- Create and run VM with name `vm-test-01`
+```bash
+nilcc-agent vm create --cpu 1 --ram-mib 512 --disk-gib 1 vm-test-01
+```
+
+- Gracefully stop VM - send ACPI shutdown signal and wait for it to stop
+```bash
+nilcc-agent vm stop vm-test-01
+```
+
+- Forcefully stop VM - power off VM straight away
+```bash
+nilcc-agent vm stop --force vm-test-01
+```
+
+### Confidential VM
+
+Running CVM execution requires root permissions and OVMF firmware with AMD SEV support.
+
+sudo example with PATH containing nilcc-agent: `sudo env "PATH=$PATH" nilcc-agent ...`
+
+- Create and run CVM with name `cvm-test-01`
+```bash
+nilcc-agent vm create --cpu 1 --ram-mib 512 --disk-gib 1 --enable-cvm --bios-path /home/ubuntu/shared/AMDSEV/usr/local/share/qemu/OVMF.fd cvm-test-01
+```

--- a/nilcc-agent/src/main.rs
+++ b/nilcc-agent/src/main.rs
@@ -107,8 +107,15 @@ enum VmCommand {
     /// Start already created VM
     Start { name: String },
 
-    /// Stop running VM
-    Stop { name: String },
+    /// Gracefully stop running VM or force stop if `force` is true
+    Stop {
+        name: String,
+        #[arg(short, long, help = "Force stop the VM (power-off)")]
+        force: bool,
+    },
+
+    /// Gracefully restart VM
+    Restart { name: String },
 
     /// Delete VM and all its files
     Delete { name: String },
@@ -219,8 +226,11 @@ async fn run_vm_command(configs: Configs, command: VmCommand) -> Result<ActionOu
         VmCommand::Start { name } => {
             client.start_vm(&name).await.map(|details| ActionOutput { status: "started".into(), details })
         }
-        VmCommand::Stop { name } => {
-            client.stop_vm(&name).await.map(|details| ActionOutput { status: "stopped".into(), details })
+        VmCommand::Stop { name, force } => {
+            client.stop_vm(&name, force).await.map(|details| ActionOutput { status: "stopped".into(), details })
+        }
+        VmCommand::Restart { name } => {
+            client.restart_vm(&name).await.map(|details| ActionOutput { status: "restarted".into(), details })
         }
         VmCommand::Delete { name } => {
             client.delete_vm(&name).await.map(|details| ActionOutput { status: "deleted".into(), details })


### PR DESCRIPTION
I was testing running VMs and came across cases where VM would ignore shut down signal and so will never stop; so added additional command to allow forcefully shutting down VM.

- qemu `quit` to forcefully stop VM (power off straightaway)
- qemu `system_restart` to gracefully restart VM (send restart signal)