### PR TITLE
feat: add disk integrity checks on vm start

### DIFF
--- a/artifacts/initramfs/Dockerfile
+++ b/artifacts/initramfs/Dockerfile
@@ -12,7 +12,7 @@ COPY artifacts/initramfs/build/kernel/kernel.deb /tmp/
 
 RUN apt update \
   && apt upgrade -y \
-  && apt install -y kmod \
+  && apt install -y kmod cryptsetup-bin \
   && apt install -y /tmp/kernel.deb \
   && rm -rf /var/lib/apt/lists/* \
   && rm /tmp/kernel.deb

--- a/artifacts/initramfs/build.sh
+++ b/artifacts/initramfs/build.sh
@@ -37,7 +37,7 @@ docker build -t $DOCKER_IMG -f $SCRIPT_PATH/Dockerfile $SCRIPT_PATH/../../
 # Run the container. This will run and stop it immediately since it does nothing by default.
 echo "Running container ${DOCKER_CONTAINER}"
 docker run --name $DOCKER_CONTAINER $DOCKER_IMG
-trap cleanup EXIT
+trap cleanup EXIT SIGINT
 
 # Now export the stopped container's filesystem so we use that as a base for our inintrd.
 echo "Exporting filesystem"

--- a/artifacts/initramfs/init.sh
+++ b/artifacts/initramfs/init.sh
@@ -19,19 +19,61 @@ mkdir /dev/pts
 mount -t devpts -o noexec,nosuid,gid=5,mode=0620 devpts /dev/pts || true
 
 MNT_DIR=/root
-ROOT=/dev/sda2
-BOOT_PROOF_DIR=$MNT_DIR/etc/nilcc-boot
+BOOT_PROOF_DIR=$MNT_DIR/var/lib/nilcc-boot
 
-mount $ROOT $MNT_DIR
+# Parse command line options
+for x in $(cat /proc/cmdline); do
+  case $x in
+  root=*)
+    ROOT=${x#root=}
+    ;;
+  verity_disk=*)
+    VERITY_DISK=${x#verity_disk=}
+    ;;
+  verity_roothash=*)
+    VERITY_ROOT_HASH=${x#verity_roothash=}
+    ;;
+  state_disk=*)
+    STATE_DISK=${x#state_disk=}
+    ;;
+  esac
+done
 
-# Note, eventually we will want to not do this rm so `mkdir` fails. For now it's good to have it so we can
-# boot a vm multiple times from the same .cow2
-rm -rf $BOOT_PROOF_DIR
-mkdir $BOOT_PROOF_DIR
+# unlock verity device
+veritysetup open $ROOT root $VERITY_DISK $VERITY_ROOT_HASH
 
-head -c 64 /dev/urandom >$BOOT_PROOF_DIR/input
+# mount root disk as read-only
+mount -o ro,noload /dev/mapper/root $MNT_DIR
 
+# Generate a random password and use LUKS to encrypt the state disk with it.
+STATE_PASSWORD=$(head -c 64 /dev/random | base64 -w 0)
+echo "$STATE_PASSWORD" | cryptsetup luksFormat "$STATE_DISK"
+
+# Now open the disk and format it using ext4
+echo "$STATE_PASSWORD" | cryptsetup luksOpen "$STATE_DISK" state
+mkfs.ext4 /dev/mapper/state
+unset STATE_PASSWORD
+
+# Mount the now encrypted and formatted state disk on /var and clear it up.
+mount /dev/mapper/state "${MNT_DIR}/var"
+
+# Now copy over the original /var into the new one.
+cp -r "${MNT_DIR}/ro/var" "${MNT_DIR}/"
+
+# Create a tmpfs for /etc and copy over the /ro contents to it
+mount -t tmpfs -o size=1024M tmpfs "$MNT_DIR/etc"
+cp -r "${MNT_DIR}/ro/etc" "${MNT_DIR}/"
+
+# Create a tmpfs for /tmp.
+mount -t tmpfs -o size=1024M tmpfs "$MNT_DIR/tmp"
+
+# Create a mount where the cvm-agent will mount the docker-compose ISO.
+mount -t tmpfs -o size=4M tmpfs "$MNT_DIR/media/cvm-agent-entrypoint"
+
+# Generate an attestation using random data
 modprobe sev-guest
+mkdir -p $BOOT_PROOF_DIR
+head -c 64 /dev/urandom >$BOOT_PROOF_DIR/input
 /opt/nillion/initrd-helper report $BOOT_PROOF_DIR/report.json --data $(cat $BOOT_PROOF_DIR/input | base64 -w 0)
 
 mount --move /proc $MNT_DIR/proc

--- a/artifacts/vm_image/launch_vm.sh
+++ b/artifacts/vm_image/launch_vm.sh
@@ -10,10 +10,25 @@ SCRIPT_PATH=$(dirname $(realpath $0))
 VM_IMAGE="${1:-$SCRIPT_PATH/build/vm_images/ubuntu24.04-cpu.qcow2}"
 [[ ! -f "$VM_IMAGE" ]] && echo "VM image not found, run 'build.sh' first" && exit 1
 
+VM_IMAGE_HASH_DEV="${1:-$SCRIPT_PATH/build/vm_images/ubuntu24.04-cpu-verity/verity-hash-dev}"
+[[ ! -f "$VM_IMAGE_HASH_DEV" ]] && echo "VM disk hashes dev not found, run 'build.sh' first" && exit 1
+
+VM_IMAGE_ROOT_HASH=$(cat "${1:-$SCRIPT_PATH/build/vm_images/ubuntu24.04-cpu-verity/root-hash}")
+
 INITRD="${INITRD:-$SCRIPT_PATH/../initramfs/build/initramfs.cpio.gz}"
 [[ ! -f "$INITRD" ]] && echo "initrd not found, run '../initramfs/build.sh' first" && exit 1
 
+STATE_DISK=$(mktemp)
+
+cleanup() {
+  rm ${STATE_DISK}
+}
+
+trap cleanup EXIT SIGINT
+
 QEMU_BASE_PATH="$SCRIPT_PATH/build/qemu/"
+$QEMU_BASE_PATH/usr/local/bin/qemu-img create -f raw "$STATE_DISK" 10G
+
 $QEMU_BASE_PATH/usr/local/bin/qemu-system-x86_64 \
   -enable-kvm -nographic -no-reboot \
   -machine confidential-guest-support=sev0,vmport=off \
@@ -22,9 +37,15 @@ $QEMU_BASE_PATH/usr/local/bin/qemu-system-x86_64 \
   -bios $QEMU_BASE_PATH/usr/local/share/qemu/OVMF.fd \
   -kernel ${SCRIPT_PATH}/build/kernel/cpu/vmlinuz-6.11.0-snp-guest-98f7e32f20d2 \
   -initrd "${INITRD}" \
-  -append "console=ttyS0 earlyprintk=serial" \
+  -append "console=ttyS0 earlyprintk=serial root=/dev/sda2 verity_disk=/dev/sdb verity_roothash=${VM_IMAGE_ROOT_HASH} state_disk=/dev/sdc" \
   -drive file=$VM_IMAGE,if=none,id=disk0,format=qcow2 \
   -device virtio-scsi-pci,id=scsi0,disable-legacy=on,iommu_platform=true \
   -device scsi-hd,drive=disk0,bootindex=1 \
-  -drive file=/tmp/nilcc.iso,id=disk1,media=cdrom,readonly=true \
+  -drive file=$VM_IMAGE_HASH_DEV,if=none,id=disk1,format=raw \
+  -device virtio-scsi-pci,id=scsi1,disable-legacy=on,iommu_platform=true \
+  -device scsi-hd,drive=disk1,bootindex=2 \
+  -drive file=$STATE_DISK,if=none,id=disk2,format=raw \
+  -device virtio-scsi-pci,id=scsi2,disable-legacy=on,iommu_platform=true \
+  -device scsi-hd,drive=disk2,bootindex=3 \
+  -drive file=/tmp/nilcc.iso,id=disk3,media=cdrom,readonly=true \
   -fw_cfg name=opt/ovmf/X-PciMmio64Mb,string=151072

--- a/artifacts/vm_image/setup-verity.sh
+++ b/artifacts/vm_image/setup-verity.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ $# -ne 2 ]; then
+  echo "Usage: $0 <input-qcow2-image> <output-directory>"
+  exit 1
+fi
+
+SCRIPT_PATH=$(dirname $(realpath $0))
+
+QEMU_PATH=$SCRIPT_PATH/build/qemu/usr/local/bin
+INPUT_IMAGE=$1
+OUTPUT_DIR=$2
+NBD_DEVICE=/dev/nbd1
+
+cleanup() {
+  set +e
+  sudo "${QEMU_PATH}/qemu-nbd" --disconnect $NBD_DEVICE
+  sudo rmmod nbd
+}
+
+trap cleanup EXIT SIGINT
+
+mkdir -p "$OUTPUT_DIR"
+
+echo "Adding NBD kernel module"
+sudo modprobe nbd max_part=8
+
+echo "Connecting ${INPUT_IMAGE} image via NBD to ${NBD_DEVICE}"
+sudo "${QEMU_PATH}/qemu-nbd" --connect=$NBD_DEVICE $INPUT_IMAGE
+
+echo "Sleeping to let qemu-nbd finish setting up device"
+sleep 2
+
+MOUNT_POINT=${OUTPUT_DIR}/root
+# There's 2 partitions: the EFI one and the actual filesystem. Mount the second one.
+PARTITION=${NBD_DEVICE}p2
+
+echo "Mounting ${PARTITION} in ${MOUNT_POINT}"
+sudo mkdir "$MOUNT_POINT"
+sudo mount "${PARTITION}" "${MOUNT_POINT}"
+
+echo "Setting up filesystem"
+# Create a directory where we'll keep read only copies of mutable directories.
+RO_PATH=${MOUNT_POINT}/ro
+sudo mkdir "$RO_PATH"
+
+# Move /var and /etc to the read only directory
+sudo mv "${MOUNT_POINT}/var" "${MOUNT_POINT}/etc" "${RO_PATH}"
+
+# Create directories that initrd will populate on start.
+sudo mkdir "${MOUNT_POINT}/var" "${MOUNT_POINT}/etc" "${MOUNT_POINT}/media/cvm-agent-entrypoint"
+
+# Delete /tmp
+sudo rm -rf "${MOUNT_POINT}/tmp/*"
+
+echo "Unmounting ${MOUNT_POINT}"
+sudo umount "${MOUNT_POINT}"
+sudo rmdir "$MOUNT_POINT"
+
+echo "Generating hashes for ${PARTITION}. This may take some time.."
+sudo veritysetup format "${PARTITION}" "${OUTPUT_DIR}/verity-hash-dev" | grep "Root hash" | cut -f2 >"${OUTPUT_DIR}/root-hash"
+
+echo "Output generated in ${OUTPUT_DIR}"


### PR DESCRIPTION
This adds filesystem integrity checks on CVM start by using dm-verity. This was heavily inspired by how snp guard does this but was changed a bit to have an (arguably) better process.

As a TL;DR; of how dm-verity works: you give it a disk, you run `veritysetup` on it, that generates another disk that contains a merkle tree of all the blocks in the first disk, and it also prints a root hash (among other information). Then when you want to mount the original disk, instead of `mount`ing it directly you call `veritysetup open`, passing in both disks and the root hash and this will create a device under `/dev/mapper` iff the hash matches and is read only. This poses a challenge because of the read-only property, which is limiting, but we get around it by using separate mounts for mutable directories (more on that below).

The way this works is:

* At the end of the VM build process we run a new script `setup-verity.sh` that cleans up the VM image disk and generates the dm-verity merkle tree disk and root hash. This are stored somewhere and are now part of "the disk image", e.g. you can't just boot with the disk image now, you need the merkle tree disk and root hash to do so.\
  * Among the cleanups we do, we clean up certain directories (e.g. /tmp), and we move directories that we will want to mutate into a different path. e.g. `/var` and `/etc` are moved into `/ro/var` and `/ro/etc` respectively. More on this below.
  * Note that the code to build the image is considerably simpler than snp guard because they use LVM and we don't, plus they try to guess what partition you want to use. In our scripts we set things up in a particular way (e.g. the second partition is the one that contains the actual linux installation) so we don't have to run `fdisk` or any other tool to figure this out. We do still use `qemu-nbd` to mount a network device to do this, I couldn't find another way to do it unfortunately.
* When the VM is launched, a couple of parameters are passed in to initrd. Among those are the disk to boot from and the merkle tree disk (these could be hardcoded, really), and the root hash.
* Initrd will take these 3 parameters and mount the disk via `veritysetup open`; this will ensure the root hash is correct.

This allows us to have a verifiable image boot, where we're certain we're booting the image we want. However, this now gives us a 100% read only filesystem which is unusable. To get around this we do a couple of things:

* For directories that we don't expect to grow much we use a `tmpfs` which stores its contents in memory (encrypted because of snp). For example, `/etc` is mounted this way. When initrd runs, we copy over the contents of `/ro/etc` into `/etc` so we have a mutable `/etc` but that it starts with the contents that we originally had during the vm image build.
* For `/var` which we expect to grow a lot given docker stores everything in there, we create an external disk and plug it to the VM. Because this will store state and we don't want the host to be able to see it, initrd takes the disk and uses luks to encrypt it using a random key that we toss away and formats it using ext4. This gives the VM the ability to store state externally, but also makes it impossible for the host to see its contents because the disk itself is encrypted with a key that not even the VM (after boot) knows.

PS: note that /etc needs to be mutated now because of the way the ubuntu install works where it finishes being configured upon first boot. We could consider changing this in the future so as to have a read only `/etc` too but this makes it work for now.

Closes #46 #49