### PR TITLE
chore: remove 6.8 kernel

### DIFF
--- a/artifacts/autoinstall_ubuntu/user-data-guest-cpu.yaml
+++ b/artifacts/autoinstall_ubuntu/user-data-guest-cpu.yaml
@@ -25,6 +25,7 @@ autoinstall:
     - curtin in-target -- dpkg -i /cdrom/packages/*.deb
     - curtin in-target -- apt update
     - curtin in-target -- apt install -y docker-compose-v2 jq
+    - curtin in-target -- apt purge -y linux-image-6.8* linux-headers-6.8* linux-tools-6.8*
     # Copy over cvm-agent.
     - curtin in-target -- mkdir /opt/nillion
     - curtin in-target -- cp /cdrom/nillion/cvm-agent.sh /opt/nillion

--- a/artifacts/autoinstall_ubuntu/user-data-guest-gpu.yaml
+++ b/artifacts/autoinstall_ubuntu/user-data-guest-gpu.yaml
@@ -28,6 +28,7 @@ autoinstall:
     - curtin in-target -- bash -c 'echo "install nvidia /sbin/modprobe ecdsa_generic ecdh; /sbin/modprobe --ignore-install nvidia" > /etc/modprobe.d/nvidia-lkca.conf'
     - curtin in-target -- sed -i "/^ExecStart=/d" /usr/lib/systemd/system/nvidia-persistenced.service
     - curtin in-target -- bash -c 'echo "ExecStart=/usr/bin/nvidia-persistenced --user nvidia-persistenced --uvm-persistence-mode --verbose" >> /usr/lib/systemd/system/nvidia-persistenced.service'
+    - curtin in-target -- apt purge -y linux-image-6.8* linux-headers-6.8* linux-tools-6.8*
     # Copy over cvm-agent.
     - curtin in-target -- mkdir /opt/nillion
     - curtin in-target -- cp /cdrom/nillion/cvm-agent.sh /opt/nillion


### PR DESCRIPTION
This removes the default 6.8 kernel after install so we don't have an extra, unused, kernel in the image.

Closes #53