### PR TITLE
feat: allow creating a `.env` in the compose ISO

### DIFF
--- a/nilcc-agent/Cargo.toml
+++ b/nilcc-agent/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nilcc-agent"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
This changes the ISO maker command to allow passing in `--env` 0+ times that will end up landing on a `.env` in the ISO that the cvm-agent's `docker compose up` will pick up automatically.