### PR TITLE
feat(nilcc-agent): detect nvidia gpu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,6 +968,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
+name = "humantime-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
+dependencies = [
+ "humantime",
+ "serde",
+]
+
+[[package]]
 name = "hyper"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1392,6 +1402,8 @@ dependencies = [
  "docker-compose-types",
  "erased-serde",
  "hex",
+ "humantime",
+ "humantime-serde",
  "libc",
  "metrics",
  "once_cell",

--- a/nilcc-agent/Cargo.toml
+++ b/nilcc-agent/Cargo.toml
@@ -28,6 +28,8 @@ chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.17.0", features = ["serde", "v4"] }
 sysinfo = { version = "0.35"}
 once_cell = "1.20"
+humantime = { version = "2.2.0"}
+humantime-serde = "1.1.1"
 
 [dev-dependencies]
 libc = "0.2"

--- a/nilcc-agent/nilcc-agent-config.sample.yaml
+++ b/nilcc-agent/nilcc-agent-config.sample.yaml
@@ -4,6 +4,4 @@ vm_store: /tmp
 nilcc_api_endpoint: "http://127.0.0.1:50051"
 nilcc_api_key: test
 
-gpu:
-  model: "NVIDIA H100"
-  count: 1
+sync_interval: 10s

--- a/nilcc-agent/src/config.rs
+++ b/nilcc-agent/src/config.rs
@@ -1,6 +1,6 @@
 use clap::Args;
-use serde::{Deserialize, Serialize};
-use std::{env, path::PathBuf};
+use serde::Deserialize;
+use std::{env, path::PathBuf, time::Duration};
 use users::{get_current_uid, get_user_by_uid, os::unix::UserExt};
 use uuid::Uuid;
 
@@ -70,14 +70,8 @@ pub struct AgentConfig {
     #[clap(long = "nilcc-api-key", short = 'k', env = "NILCC_API_KEY")]
     pub nilcc_api_key: Option<String>,
 
-    /// GPU details
-    #[clap(skip)]
-    #[serde(default)]
-    pub gpu: Option<GpuDetails>,
-}
-
-#[derive(Deserialize, Serialize, Debug, Clone)]
-pub struct GpuDetails {
-    pub model: String,
-    pub count: u32,
+    /// Interval for periodic synchronization task, defaults to 10 seconds
+    #[clap(long = "sync-interval", short = 's', default_value = "10sec", value_parser = humantime::parse_duration)]
+    #[serde(with = "humantime_serde::option")]
+    pub sync_interval: Option<Duration>,
 }

--- a/nilcc-agent/src/data_schemas.rs
+++ b/nilcc-agent/src/data_schemas.rs
@@ -4,7 +4,6 @@ use uuid::Uuid;
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct MetalInstanceDetails {
-    pub id: Uuid,
     pub agent_version: String,
     pub hostname: String,
     pub memory: u64,
@@ -12,6 +11,15 @@ pub struct MetalInstanceDetails {
     pub cpu: u32,
     pub gpu: Option<u32>,
     pub gpu_model: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct MetalInstance {
+    pub id: Uuid,
+
+    #[serde(flatten)]
+    pub details: MetalInstanceDetails,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/nilcc-agent/src/gpu.rs
+++ b/nilcc-agent/src/gpu.rs
@@ -1,0 +1,44 @@
+use anyhow::bail;
+use tokio::process::Command;
+
+pub const SUPPORTED_GPU_MODEL: &str = "H100";
+const NVIDIA_GPU_VENDOR_ID: &str = "10de";
+
+pub struct GpuGroup {
+    pub model: String,
+    pub addresses: Vec<String>,
+}
+
+/// Finds supported NVIDIA GPUs
+pub(crate) async fn find_gpus() -> anyhow::Result<Option<GpuGroup>> {
+    let output = Command::new("bash").arg("-c").arg(format!("lspci -d {NVIDIA_GPU_VENDOR_ID}:")).output().await?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("lspci command failed with status {}: {stderr}", output.status.code().unwrap_or_default());
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.lines().filter(|&line| !line.trim().is_empty()).collect();
+    if lines.is_empty() {
+        return Ok(None);
+    }
+
+    let mut addresses = Vec::new();
+
+    for line in lines {
+        if line.contains("H100") {
+            if let Some(bdf) = line.split_whitespace().next() {
+                addresses.push(bdf.to_string());
+            } else {
+                bail!(format!("Failed to parse BDF address from line: {line}"));
+            }
+        } else {
+            bail!(format!("Unsupported NVIDIA GPU found. All GPUs must be {SUPPORTED_GPU_MODEL}. Detected: {line}"));
+        }
+    }
+
+    addresses.sort();
+
+    Ok(Some(GpuGroup { model: SUPPORTED_GPU_MODEL.to_string(), addresses }))
+}

--- a/nilcc-agent/src/http_client.rs
+++ b/nilcc-agent/src/http_client.rs
@@ -1,4 +1,4 @@
-use crate::data_schemas::{EmptyResponse, MetalInstanceDetails, SyncRequest};
+use crate::data_schemas::{EmptyResponse, MetalInstance, SyncRequest};
 use anyhow::Context;
 use reqwest::{Client, Method, RequestBuilder as ReqwestRequestBuilder, Response as ReqwestResponse};
 use tracing::debug;
@@ -44,7 +44,7 @@ impl AgentHttpRestClient {
     }
 
     /// Registers an agent
-    pub async fn register(&self, payload: MetalInstanceDetails) -> anyhow::Result<EmptyResponse> {
+    pub async fn register(&self, payload: MetalInstance) -> anyhow::Result<EmptyResponse> {
         let endpoint_suffix = "/api/v1/metal-instances/~/register";
         let full_url = format!("{}{endpoint_suffix}", self.api_base_url,);
         debug!("Sending agent registration request to {full_url}: {payload:?}");

--- a/nilcc-agent/src/lib.rs
+++ b/nilcc-agent/src/lib.rs
@@ -2,6 +2,7 @@ pub mod agent_service;
 pub mod build_info;
 pub mod config;
 pub mod data_schemas;
+pub mod gpu;
 pub mod http_client;
 pub mod iso;
 pub mod output;

--- a/nilcc-agent/src/main.rs
+++ b/nilcc-agent/src/main.rs
@@ -41,6 +41,9 @@ enum Command {
         #[clap(long, short, default_value = "nilcc-agent-config.yaml")]
         config: PathBuf,
     },
+
+    /// Show metal instance information
+    Info,
 }
 
 #[derive(Subcommand)]
@@ -239,8 +242,8 @@ async fn run_daemon(config: AgentConfig) -> Result<()> {
 
     let mut agent_builder = AgentService::builder(agent_id, api_endpoint.clone(), api_key);
 
-    if let Some(gpu) = config.gpu {
-        agent_builder = agent_builder.gpu(gpu);
+    if let Some(sync_interval) = config.sync_interval {
+        agent_builder = agent_builder.sync_interval(sync_interval);
     }
 
     let mut agent_service = agent_builder.build().context("Building AgentService")?;
@@ -263,6 +266,10 @@ async fn run(cli: Cli) -> anyhow::Result<Box<dyn SerializeAsAny>> {
             let agent_config = load_config(config).context("Loading agent configuration")?;
             run_daemon(agent_config).await?;
             Ok(Box::new(()))
+        }
+        Command::Info => {
+            let instance_details = nilcc_agent::agent_service::gather_metal_instance_details().await?;
+            Ok(Box::new(instance_details))
         }
     }
 }


### PR DESCRIPTION
This change adds "naive" nvidia gpu detection:
- It lists, sorts and counts NVIDIA pcie addresses
- only "NVIDIA H100" GPUs are supported, if different ones found then throws an error
- added `info` command to print metal instance information

`➜  ~ nilcc-agent info`
```
{
  "agentVersion": "0.1.0+git.b9d16b0.build.20250609T123319Z",
  "hostname": "nilAI",
  "memory": 187,
  "disk": 3519,
  "cpu": 32,
  "gpu": 1,
  "gpuModel": "H100"
}
```

Note: 
- nilcc-agent right now only supports working with a single GPU; subsequent PR will add tracking and support of multiple GPUs.