### PR TITLE
feat: allow passing in multiple drives and kernel/initrd

### DIFF
--- a/artifacts/vm_image/launch_vm.sh
+++ b/artifacts/vm_image/launch_vm.sh
@@ -62,14 +62,14 @@ $QEMU_BASE_PATH/usr/local/bin/qemu-system-x86_64 \
   -append "${KERNEL_ARGS}" \
   -drive file=$VM_IMAGE,if=none,id=disk0,format=qcow2 \
   -device virtio-scsi-pci,id=scsi0,disable-legacy=on,iommu_platform=true \
-  -device scsi-hd,drive=disk0,bootindex=1 \
+  -device scsi-hd,drive=disk0 \
   -drive file=$VM_IMAGE_HASH_DEV,if=none,id=root-disk,format=raw \
   -device virtio-scsi-pci,id=scsi1,disable-legacy=on,iommu_platform=true \
-  -device scsi-hd,drive=root-disk,bootindex=2 \
+  -device scsi-hd,drive=root-disk \
   -drive file=$STATE_DISK,if=none,id=state-disk,format=raw \
   -device virtio-scsi-pci,id=scsi2,disable-legacy=on,iommu_platform=true \
-  -device scsi-hd,drive=state-disk,bootindex=3 \
-  -drive file=$ISO_FILE,id=docker-compose-cdrom,if=none,readonly=true \
+  -device scsi-hd,drive=state-disk \
+  -drive file=$ISO_FILE,if=none,id=docker-compose-cdrom,readonly=true \
   -device virtio-scsi-pci,id=scsi3 \
   -device scsi-cd,bus=scsi3.0,drive=docker-compose-cdrom \
   -fw_cfg name=opt/ovmf/X-PciMmio64Mb,string=151072

--- a/nilcc-agent/src/main.rs
+++ b/nilcc-agent/src/main.rs
@@ -7,7 +7,7 @@ use nilcc_agent::{
     config::AgentConfig,
     iso::{ApplicationMetadata, ContainerMetadata, EnvironmentVariable, IsoMaker, IsoMetadata, IsoSpec},
     output::{serialize_error, serialize_output, SerializeAsAny},
-    qemu_client::{QemuClient, QemuClientError, VmDetails, VmSpec},
+    qemu_client::{HardDiskFormat, HardDiskSpec, QemuClient, QemuClientError, VmDetails, VmSpec},
 };
 use serde::Serialize;
 use std::{fs, ops::Deref, path::PathBuf};
@@ -77,16 +77,28 @@ enum VmCommand {
         #[clap(long = "portfwd")]
         port_forward: Vec<String>,
 
-        /// Optional Path to BIOS file
-        #[clap(long = "bios-path")]
+        /// Optional path to a BIOS file
+        #[clap(long)]
         bios_path: Option<PathBuf>,
 
+        /// Optional path to a kernel file
+        #[clap(long)]
+        kernel_path: Option<PathBuf>,
+
+        /// Optional path to a initrd file
+        #[clap(long)]
+        initrd_path: Option<PathBuf>,
+
+        /// Optional kernel parameters
+        #[clap(long)]
+        kernel_args: Option<String>,
+
         /// Show GTK ;display for VM, defaults to headless VM
-        #[clap(long = "display-gtk")]
+        #[clap(long)]
         display_gtk: bool,
 
         /// Enable CVM
-        #[clap(long = "enable-cvm")]
+        #[clap(long)]
         enable_cvm: bool,
     },
 
@@ -176,6 +188,9 @@ async fn run_vm_command(configs: AgentConfig, command: VmCommand) -> Result<Acti
             gpu,
             port_forward,
             bios_path,
+            kernel_path,
+            initrd_path,
+            kernel_args,
             display_gtk,
             enable_cvm,
         } => {
@@ -184,11 +199,14 @@ async fn run_vm_command(configs: AgentConfig, command: VmCommand) -> Result<Acti
             let spec = VmSpec {
                 cpu,
                 ram_mib,
-                disk_gib,
+                hard_disks: vec![HardDiskSpec::Create { gib: disk_gib, format: HardDiskFormat::Qcow2 }],
                 cdrom_iso_path,
                 gpu_enabled: gpu,
                 port_forwarding: pf,
                 bios_path,
+                kernel_path,
+                initrd_path,
+                kernel_args,
                 display_gtk,
                 enable_cvm,
             };


### PR DESCRIPTION
This PR adds missing parameters to the qemu client to be able to run VMs like the `launch_vm.sh`:

* Multiple drives are now supported, both generated on the fly and pointing to existing ones.
* The cdrom now is mounted via a scsi drive since that is needed for the mount to be found in initrd (at least this is what I originally ended up with in the .sh script).
* Adds the ability to pass in the initrd/kernel/kernel parameters.
* Parameters were re-arranged to mimic the shell script.

I tested creating a custom spec (not via the `nilcc-agent vm create` command) and run it inside latittude the same way the launch_vm.sh script does it and it worked. The `vm create` command doesn't have enough parameters to pass in multiple disks but I don't want to spend effort on that since we won't use it.

I also added a test to ensure the generated command looks like what it should since the existing test was not covering enough ground.