### PR TITLE
feat: update and report workload status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1638,6 +1638,7 @@ dependencies = [
  "serde_yaml",
  "sha2",
  "sqlx",
+ "strum",
  "sysinfo",
  "tempfile",
  "test-with",
@@ -3123,6 +3124,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "subtle"

--- a/nilcc-agent/Cargo.toml
+++ b/nilcc-agent/Cargo.toml
@@ -17,6 +17,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
 sha2 = "0.10"
+strum = { version = "0.27", features = ["derive"] }
 sqlx = { version = "0.8", features = ["chrono", "migrate", "runtime-tokio", "sqlite", "uuid"] }
 tempfile = "3.19.1"
 thiserror = "2"

--- a/nilcc-agent/migrations/20250612171250_add_workload_status.sql
+++ b/nilcc-agent/migrations/20250612171250_add_workload_status.sql
@@ -1,0 +1,4 @@
+-- Add a `status` column to the `workloads` table
+
+ALTER TABLE workloads
+  ADD COLUMN status VARCHAR(64) NOT NULL;

--- a/nilcc-agent/src/tests.rs
+++ b/nilcc-agent/src/tests.rs
@@ -5,7 +5,7 @@ use crate::{
     services::vm::MockVmService,
 };
 use anyhow::Context;
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 use tracing::info;
 use tracing_test::traced_test;
 use uuid::Uuid;
@@ -41,7 +41,7 @@ async fn test_agent_registration_with_mock_server() -> anyhow::Result<()> {
 
     let api_client = Box::new(RestNilccApiClient::new(api_base_url, api_key.to_string())?);
     let db = SqliteDb::connect("sqlite://:memory:").await.expect("failed to create db");
-    let workload_repository = Box::new(SqliteWorkloadRepository::new(db));
+    let workload_repository = Arc::new(SqliteWorkloadRepository::new(db));
     let vm_service = Box::new(MockVmService::default());
     let args = AgentServiceArgs {
         agent_id,


### PR DESCRIPTION
This adds the logic to:

* Keep track of the workload status.
* Report the status during syncs.

Workloads are marked as "starting" before they're synced (e.g. whether they're being ran for the first time or updated) and "stopping" before stopped. Once they're started/stopped they're changed to "running" and "stopped" respectively. This will require changing the models in the API since I had to get rid of the notion of "pending" and add starting/stopping because otherwise we lose track of what's happening. e.g. "pending" means "some action is being applied" but we (nilcc agent and the API) don't know which.