### PR TITLE
feat: report VM status on sync

### DIFF
--- a/nilcc-agent/src/data_schemas.rs
+++ b/nilcc-agent/src/data_schemas.rs
@@ -29,7 +29,23 @@ pub struct MetalInstance {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct SyncRequest {}
+pub struct SyncRequest {
+    pub(crate) id: Uuid,
+    pub(crate) workloads: Vec<SyncWorkload>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncWorkload {
+    pub(crate) id: Uuid,
+    pub(crate) status: SyncWorkloadStatus,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub enum SyncWorkloadStatus {
+    Running,
+}
 
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]

--- a/nilcc-agent/src/tests.rs
+++ b/nilcc-agent/src/tests.rs
@@ -5,7 +5,7 @@ use crate::{
     services::{sni_proxy::MockSniProxyService, vm::MockVmService},
 };
 use anyhow::Context;
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 use tracing::info;
 use tracing_test::traced_test;
 use uuid::Uuid;
@@ -41,7 +41,7 @@ async fn test_agent_registration_with_mock_server() -> anyhow::Result<()> {
 
     let api_client = Box::new(RestNilccApiClient::new(api_base_url, api_key.to_string())?);
     let db = SqliteDb::connect("sqlite://:memory:").await.expect("failed to create db");
-    let workload_repository = Box::new(SqliteWorkloadRepository::new(db));
+    let workload_repository = Arc::new(SqliteWorkloadRepository::new(db));
     let vm_service = Box::new(MockVmService::default());
     let sni_proxy_service = Box::new(MockSniProxyService::new());
     let args = AgentServiceArgs {


### PR DESCRIPTION
This adds the logic to report VM status on sync. The agent only keeps running workloads in the database so it will only report what is running, get back what it should be running, diff it, and start/update/stop (this logic was already there). The agent only reports the "running" status; the only other one that could happen is "error" but we agreed to figure that one out later since it needs more thought (e.g. we need to distinguish between transient errors and permanent ones).