### PR TITLE
feat: check periodically whether VMs are running

### DIFF
--- a/nilcc-agent/src/agent_service.rs
+++ b/nilcc-agent/src/agent_service.rs
@@ -204,7 +204,6 @@ impl AgentService {
                     self.vm_service.sync_vm(workload).await;
                 }
                 WorkloadAction::Stop(id) => {
-                    self.workload_repository.delete(id).await?;
                     self.vm_service.stop_vm(id).await;
                 }
             };

--- a/nilcc-agent/src/repositories/sqlite.rs
+++ b/nilcc-agent/src/repositories/sqlite.rs
@@ -1,8 +1,8 @@
 use sqlx::{
-    sqlite::{SqliteConnectOptions, SqlitePoolOptions},
+    sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions},
     SqlitePool,
 };
-use std::path::Path;
+use std::{path::Path, str::FromStr};
 use tracing::info;
 
 #[derive(Clone)]
@@ -10,7 +10,7 @@ pub struct SqliteDb(SqlitePool);
 
 impl SqliteDb {
     pub async fn connect(url: &str) -> anyhow::Result<Self> {
-        let connect_options: SqliteConnectOptions = url.parse()?;
+        let connect_options = SqliteConnectOptions::from_str(url)?.journal_mode(SqliteJournalMode::Wal);
         let mut pool_options = SqlitePoolOptions::new();
         if connect_options.get_filename() == Path::new(":memory:") {
             // if we don't do this eventually the database gets dropped and tables disappear.


### PR DESCRIPTION
This changes the VM worker to periodically check that all workloads have a running VM. If a VM for a workload is not running, for now we delete it from the workloads repository which will cause the next sync to not send it to the API and will likely cause us to run it again unless the API does something smarter.

I also moved the logic to delete a workload to the worker as well, so this is the one in charge of creating/updating/deleting workloads from the database.