### PR TITLE
feat: add feature flag to add stacktraces to http errors

### DIFF
--- a/nilcc-api/.env.test
+++ b/nilcc-api/.env.test
@@ -1,5 +1,5 @@
 APP_DB_URI=psql://postgres:postgres@localhost:35432/postgres
-APP_ENABLED_FEATURES=openapi,prometheus-metrics,migrations,response-validation,localstack,pretty-logs
+APP_ENABLED_FEATURES=openapi,prometheus-metrics,migrations,response-validation,localstack,pretty-logs,http-error-stacktrace
 APP_LOG_LEVEL=debug
 APP_METRICS_PORT=9091
 APP_HTTP_API_PORT=8080

--- a/nilcc-api/src/common/handler.ts
+++ b/nilcc-api/src/common/handler.ts
@@ -12,6 +12,7 @@ import {
   RemoveEntityError,
   UpdateEntityError,
 } from "#/common/errors";
+import { hasFeatureFlag } from "#/env";
 
 export type ApiSuccessResponse<T> = {
   data: T;
@@ -34,8 +35,13 @@ export function errorHandler(e: unknown, c: Context) {
     errors: string[],
     statusCode: ContentfulStatusCode,
   ): Response => {
-    const errorsTrace = e ? new TraceableError(e).toString() : undefined;
+    let errorsTrace = e ? new TraceableError(e).toString() : undefined;
     errorsTrace && c.env.log.debug(errorsTrace);
+    if (
+      !hasFeatureFlag(c.env.config.enabledFeatures, "http-error-stacktrace")
+    ) {
+      errorsTrace = undefined;
+    }
     const payload: ApiErrorResponse = {
       ts: Temporal.Now.instant().toString(),
       errors,

--- a/nilcc-api/src/env.ts
+++ b/nilcc-api/src/env.ts
@@ -18,6 +18,7 @@ export const FeatureFlag = {
   MIGRATIONS: "migrations",
   LOCALSTACK: "localstack",
   PRETTY_LOGS: "pretty-logs",
+  HTTP_ERROR_STACKTRACE: "http-error-stacktrace",
 } as const;
 
 export type FeatureFlag = (typeof FeatureFlag)[keyof typeof FeatureFlag];


### PR DESCRIPTION
Add feature flag to add stacktraces to http errors, as if done by default could leak codepaths and sensible info to the users