### PR TITLE
feat: keep track of multiple GPUs

### DIFF
--- a/nilcc-agent/migrations/20250606204408_add_workloads_table.sql
+++ b/nilcc-agent/migrations/20250606204408_add_workloads_table.sql
@@ -8,7 +8,7 @@ CREATE TABLE workloads (
   public_container_port INT NOT NULL,
   memory_mb INT NOT NULL,
   cpus INT NOT NULL,
-  gpus INT NOT NULL,
+  gpus TEXT NOT NULL,
   disk_gb INT NOT NULL,
   metal_http_port INT NOT NULL,
   metal_https_port INT NOT NULL,

--- a/nilcc-agent/src/main.rs
+++ b/nilcc-agent/src/main.rs
@@ -117,7 +117,8 @@ async fn run_daemon(config: AgentConfig) -> Result<()> {
         .install()
         .context("Failed to start metrics exporter")?;
 
-    let metal_details = SystemResources::gather(config.resources.reserved).await.context("Failed to find resources")?;
+    let system_resources =
+        SystemResources::gather(config.resources.reserved).await.context("Failed to find resources")?;
     let api_client = Box::new(RestNilccApiClient::new(endpoint, key)?);
     debug!("sqlite db url: {}", config.db.url);
     let db = SqliteDb::connect(&config.db.url).await.context("Failed to create database")?;
@@ -150,7 +151,7 @@ async fn run_daemon(config: AgentConfig) -> Result<()> {
         sync_interval,
         start_port_range: config.sni_proxy.start_port_range,
         end_port_range: config.sni_proxy.end_port_range,
-        metal_details,
+        system_resources,
     };
     let agent_service = AgentService::new(args);
 

--- a/nilcc-agent/src/services/vm.rs
+++ b/nilcc-agent/src/services/vm.rs
@@ -166,7 +166,7 @@ impl Worker {
                 }
             }
             total_cpus = total_cpus.saturating_add(workload.cpus.into());
-            total_gpus = total_gpus.saturating_add(workload.gpus);
+            total_gpus = total_gpus.saturating_add(workload.gpus.len() as u16);
             total_memory = total_memory.saturating_add(workload.memory_mb);
         }
         info!("{running}/{expected} machines are running");
@@ -275,7 +275,7 @@ impl Worker {
                 HardDiskSpec { path: state_disk_path, format: HardDiskFormat::Raw },
             ],
             cdrom_iso_path: Some(iso_path),
-            gpu_enabled: false,
+            gpus: workload.gpus.clone(),
             port_forwarding: vec![(workload.metal_http_port, 80), (workload.metal_https_port, 443)],
             bios_path: Some(self.cvm_config.bios.clone()),
             initrd_path: Some(self.cvm_config.initrd.clone()),
@@ -432,7 +432,12 @@ mod tests {
     fn vm_spec() {
         let builder = WorkerBuilder::default();
         let docker_compose_hash = "deadbeef";
-        let workload = WorkloadModel { memory_mb: 1024, cpus: 2.try_into().unwrap(), gpus: 0, ..make_workload() };
+        let workload = WorkloadModel {
+            memory_mb: 1024,
+            cpus: 2.try_into().unwrap(),
+            gpus: vec!["addr".into()],
+            ..make_workload()
+        };
         let iso_path = PathBuf::from("/tmp/vm.iso");
         let filesystem_root_hash = &builder.cvm_config.verity_root_hash;
         let kernel_args = KernelArgs { docker_compose_hash, filesystem_root_hash }.to_string();
@@ -447,7 +452,7 @@ mod tests {
                 HardDiskSpec { path: state_disk_path.clone(), format: HardDiskFormat::Raw },
             ],
             cdrom_iso_path: Some(iso_path.clone()),
-            gpu_enabled: false,
+            gpus: vec!["addr".into()],
             port_forwarding: vec![(workload.metal_http_port, 80), (workload.metal_https_port, 443)],
             bios_path: Some("/bios".into()),
             initrd_path: Some("/initrd".into()),

--- a/nilcc-agent/src/tests.rs
+++ b/nilcc-agent/src/tests.rs
@@ -2,6 +2,7 @@ use crate::{
     agent_service::{AgentService, AgentServiceArgs},
     http_client::RestNilccApiClient,
     repositories::{sqlite::SqliteDb, workload::SqliteWorkloadRepository},
+    resources::SystemResources,
     services::vm::MockVmService,
 };
 use anyhow::Context;
@@ -51,7 +52,7 @@ async fn test_agent_registration_with_mock_server() -> anyhow::Result<()> {
         sync_interval: Duration::from_secs(1),
         start_port_range: 10000,
         end_port_range: 20000,
-        metal_details: Default::default(),
+        system_resources: SystemResources::gather(Default::default()).await.expect("failed to find system resources"),
     };
     let agent_service = AgentService::new(args);
 


### PR DESCRIPTION
This allows assigning GPUs to workloads. Similar to how we keep track of used memory/cpus, now we keep track of GPUs too and assign them during insert to the sqlite db.

Closes #80