### PR TITLE
feat: create GPU VFIO devices on nilcc-agent startup

### DIFF
--- a/nilcc-agent/src/main.rs
+++ b/nilcc-agent/src/main.rs
@@ -119,6 +119,8 @@ async fn run_daemon(config: AgentConfig) -> Result<()> {
 
     let system_resources =
         SystemResources::gather(config.resources.reserved).await.context("Failed to find resources")?;
+    system_resources.create_gpu_vfio_devices().await.context("Failed to create PCI VFIO GPU devices")?;
+
     let api_client = Box::new(RestNilccApiClient::new(endpoint, key)?);
     debug!("sqlite db url: {}", config.db.url);
     let db = SqliteDb::connect(&config.db.url).await.context("Failed to create database")?;

--- a/nilcc-agent/src/resources.rs
+++ b/nilcc-agent/src/resources.rs
@@ -1,12 +1,15 @@
 use crate::config::ReservedResourcesConfig;
-use anyhow::{bail, Context};
+use anyhow::{anyhow, bail, Context};
+use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use std::{fmt, io};
 use sysinfo::{Disks, System};
-use tokio::process::Command;
-use tracing::info;
+use tokio::{fs, process::Command};
+use tracing::{info, warn};
 
-const SUPPORTED_GPU_MODEL: &str = "H100";
+const H100_MODEL: &str = "H100";
 const NVIDIA_GPU_VENDOR_ID: &str = "10de";
+const NEW_VFIO_PCI_ID_PATH: &str = "/sys/bus/pci/drivers/vfio-pci/new_id";
 
 #[derive(Debug, Clone, Serialize)]
 pub struct SystemResources {
@@ -64,39 +67,84 @@ impl SystemResources {
         })
     }
 
+    pub async fn create_gpu_vfio_devices(&self) -> anyhow::Result<()> {
+        let Some(gpus) = &self.gpus else {
+            return Ok(());
+        };
+        info!("Creating PCI VFIO devices for {} GPUs", gpus.addresses.len());
+        for address in &gpus.addresses {
+            info!("Finding device id for {address}");
+            let output = Command::new("lspci").arg("-n").arg("-s").arg(&address.0).invoke().await?;
+            let device_id = Self::parse_device_id(&output).context("Failed to parse device id")?;
+            info!("Creating PCI VFIO for device {device_id}");
+
+            let command = format!("{NVIDIA_GPU_VENDOR_ID} {device_id}");
+            match fs::write(NEW_VFIO_PCI_ID_PATH, &command).await {
+                Ok(()) => info!("PCI VFIO device {device_id} created"),
+                Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {
+                    warn!("PCI VFIO device {device_id} already exists, ignoring")
+                }
+                Err(e) => Err(e).context("Failed to create PCI VFIO device {device_id}")?,
+            }
+        }
+        Ok(())
+    }
+
     /// Finds supported NVIDIA GPUs
     pub(crate) async fn find_gpus() -> anyhow::Result<Option<Gpus>> {
-        let output = Command::new("bash").arg("-c").arg(format!("lspci -d {NVIDIA_GPU_VENDOR_ID}:")).output().await?;
+        let output = Command::new("lspci").arg("-d").arg(format!("{NVIDIA_GPU_VENDOR_ID}:")).invoke().await?;
+        Self::parse_gpus(&output).context("Failed to parse GPUs")
+    }
 
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            bail!("lspci command failed with status {}: {stderr}", output.status.code().unwrap_or_default());
-        }
-
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let lines: Vec<&str> = stdout.lines().filter(|&line| !line.trim().is_empty()).collect();
+    fn parse_gpus(lspci_output: &str) -> anyhow::Result<Option<Gpus>> {
+        let lines: Vec<&str> = lspci_output.lines().filter(|&line| !line.trim().is_empty()).collect();
         if lines.is_empty() {
             return Ok(None);
         }
 
         let mut addresses = Vec::new();
         for line in lines {
-            if line.contains("H100") {
-                if let Some(bdf) = line.split_whitespace().next() {
-                    addresses.push(GpuAddress(bdf.to_string()));
-                } else {
-                    bail!(format!("Failed to parse BDF address from line: {line}"));
-                }
+            if !line.contains("H100") {
+                bail!("Unsupported NVIDIA GPU found. All GPUs must be {H100_MODEL}. Detected: {line}");
+            }
+            if let Some(bdf) = line.split_whitespace().next() {
+                addresses.push(GpuAddress(bdf.to_string()));
             } else {
-                bail!(format!(
-                    "Unsupported NVIDIA GPU found. All GPUs must be {SUPPORTED_GPU_MODEL}. Detected: {line}"
-                ));
+                bail!("Failed to parse BDF address from line: {line}");
             }
         }
 
         addresses.sort();
 
-        Ok(Some(Gpus { model: SUPPORTED_GPU_MODEL.to_string(), addresses }))
+        Ok(Some(Gpus { model: H100_MODEL.to_string(), addresses }))
+    }
+
+    fn parse_device_id(lspci_output: &str) -> anyhow::Result<String> {
+        // 01:00.0 0302: 10de:2331 (rev a1)
+        let device = lspci_output
+            .split_whitespace()
+            .nth(2)
+            .ok_or_else(|| anyhow!("Not enough whitespaces in lspci output: {lspci_output}"))?;
+        let (_, device_id) =
+            device.split_once(':').ok_or_else(|| anyhow!("No colon in lspci output: {lspci_output}"))?;
+        Ok(device_id.to_string())
+    }
+}
+
+#[async_trait]
+trait CommandExt {
+    async fn invoke(&mut self) -> anyhow::Result<String>;
+}
+
+#[async_trait]
+impl CommandExt for Command {
+    async fn invoke(&mut self) -> anyhow::Result<String> {
+        let output = self.output().await?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            bail!("lspci command failed with status {}: {stderr}", output.status.code().unwrap_or_default());
+        }
+        Ok(String::from_utf8_lossy(&output.stdout).to_string())
     }
 }
 
@@ -107,6 +155,12 @@ pub struct GpuAddress(pub(crate) String);
 impl From<&'_ str> for GpuAddress {
     fn from(address: &str) -> Self {
         Self(address.to_string())
+    }
+}
+
+impl fmt::Display for GpuAddress {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 
@@ -143,5 +197,24 @@ mod tests {
     async fn gather_too_much_reserved_disk() {
         let reserved = ReservedResourcesConfig { cpus: 0, memory_gb: 0, disk_space_gb: 100_000 };
         SystemResources::gather(reserved).await.expect_err("gathering did not fail");
+    }
+
+    #[test]
+    fn parse_h100() {
+        let input = [
+            "01:00.1 3D controller: NVIDIA Corporation GH100 [H100 PCIe] (rev a1)",
+            "01:00.0 3D controller: NVIDIA Corporation GH100 [H100 PCIe] (rev a1)",
+        ]
+        .join("\n");
+        let gpus = SystemResources::parse_gpus(&input).expect("failed to parse").expect("no gpus detected");
+        assert_eq!(gpus.model, H100_MODEL);
+        assert_eq!(gpus.addresses, &["01:00.0".into(), "01:00.1".into()]);
+    }
+
+    #[test]
+    fn parse_device_id() {
+        let input = "01:00.0 0302: 10de:2331 (rev a1)";
+        let id = SystemResources::parse_device_id(input).expect("failed to parse");
+        assert_eq!(id, "2331");
     }
 }


### PR DESCRIPTION
This creates PCI VFIO devices for all GPUs on startup. For this we:

* Make a query via lspci to figure out what the device id is.
* Write into a specific `/sys` path to create the device. If the device already exists (e.g. nilcc-agent was restarted) we ignore it.