### PR TITLE
feat: add first endpoint to create a workload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,6 +464,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "convert_case"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1600,8 +1609,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "axum",
  "chrono",
  "clap",
+ "convert_case",
  "hex",
  "humantime",
  "humantime-serde",
@@ -3692,6 +3703,12 @@ name = "unicode-properties"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/nilcc-agent/Cargo.toml
+++ b/nilcc-agent/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
+axum = { version = "0.8.4", features = ["json"] }
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.5", features = ["derive", "env"] }
 hex = { version = "0.4", features = ["serde"] }
@@ -27,6 +28,7 @@ tempfile = "3.19.1"
 tera = { version = "1", default-features = false }
 thiserror = "2"
 tokio = { version = "1.44", features = ["rt-multi-thread", "macros", "net", "process", "time", "fs", "signal"] }
+convert_case = "0.8.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
 uuid = { version = "1.17.0", features = ["serde", "v4"] }

--- a/nilcc-agent/nilcc-agent-config.sample.yaml
+++ b/nilcc-agent/nilcc-agent-config.sample.yaml
@@ -6,6 +6,9 @@ qemu:
   img_bin: qemu-img
 
 api:
+  bind_endpoint: "127.0.0.1:50055"
+
+controller:
   endpoint: "http://127.0.0.1:50051"
   key: test
   sync_interval: 10s

--- a/nilcc-agent/src/config.rs
+++ b/nilcc-agent/src/config.rs
@@ -17,7 +17,10 @@ pub struct AgentConfig {
     /// Unique agent ID, used to identify this agent in nilCC server
     pub agent_id: Uuid,
 
-    /// nilCC API configuration.
+    /// nilcc API configuration.
+    pub controller: ControllerConfig,
+
+    /// API configuration.
     pub api: ApiConfig,
 
     /// The database configuration.
@@ -74,16 +77,22 @@ pub struct QemuConfig {
 }
 
 #[derive(Deserialize, Debug)]
-pub struct ApiConfig {
-    /// nilCC API endpoint to connect to.
+pub struct ControllerConfig {
+    /// nilcc API endpoint to connect to.
     pub endpoint: String,
 
-    /// nilCC API key.
+    /// nilcc API key.
     pub key: String,
 
     /// Interval for periodic synchronization task.
     #[serde(with = "humantime_serde", default = "default_agent_sync_interval")]
     pub sync_interval: Duration,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct ApiConfig {
+    /// The endpoint to bind to.
+    pub bind_endpoint: SocketAddr,
 }
 
 #[derive(Deserialize, Debug)]

--- a/nilcc-agent/src/lib.rs
+++ b/nilcc-agent/src/lib.rs
@@ -5,5 +5,6 @@ pub mod iso;
 pub mod models;
 pub mod repositories;
 pub mod resources;
+pub mod routes;
 pub mod services;
 pub mod version;

--- a/nilcc-agent/src/routes/mod.rs
+++ b/nilcc-agent/src/routes/mod.rs
@@ -1,0 +1,89 @@
+use axum::extract::Request;
+use axum::extract::{rejection::JsonRejection, FromRequest};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::routing::post;
+use axum::Router;
+use convert_case::{Case, Casing};
+use serde::Serialize;
+use std::ops::Deref;
+use std::sync::Arc;
+
+use crate::services::workload::WorkloadService;
+
+pub(crate) mod workloads;
+
+#[derive(Clone)]
+pub struct Services {
+    pub workload: Arc<dyn WorkloadService>,
+}
+
+#[derive(Clone)]
+pub struct AppState {
+    pub services: Services,
+}
+
+pub fn build_router(state: AppState) -> Router {
+    Router::new()
+        .nest("/api/v1", Router::new().route("/workloads/create", post(workloads::create::handler)).with_state(state))
+}
+
+/// An error when handling a request.
+#[derive(Debug, Serialize)]
+pub struct RequestHandlerError {
+    /// A descriptive message about the error that was encountered.
+    pub(crate) message: String,
+
+    /// The error code.
+    pub(crate) error_code: String,
+}
+
+impl RequestHandlerError {
+    pub(crate) fn new(message: impl Into<String>, error_code: impl AsRef<str>) -> Self {
+        let error_code = error_code.as_ref().to_case(Case::UpperSnake);
+        Self { message: message.into(), error_code }
+    }
+}
+
+/// A type that behaves like `axum::Json` but provides JSON structured errors when parsing fails.
+#[derive(Debug)]
+pub struct Json<T>(pub T);
+
+impl<S, T> FromRequest<S> for Json<T>
+where
+    axum::Json<T>: FromRequest<S, Rejection = JsonRejection>,
+    S: Send + Sync,
+{
+    type Rejection = (StatusCode, axum::Json<RequestHandlerError>);
+
+    async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
+        let (parts, body) = req.into_parts();
+        let req = Request::from_parts(parts, body);
+
+        match axum::Json::<T>::from_request(req, state).await {
+            Ok(value) => Ok(Self(value.0)),
+            Err(rejection) => {
+                let payload = RequestHandlerError::new(rejection.body_text(), "MALFORMED_REQUEST");
+
+                Err((rejection.status(), axum::Json(payload)))
+            }
+        }
+    }
+}
+
+impl<T> Deref for Json<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> IntoResponse for Json<T>
+where
+    T: Serialize,
+{
+    fn into_response(self) -> axum::response::Response {
+        axum::Json(self.0).into_response()
+    }
+}

--- a/nilcc-agent/src/routes/workloads/create.rs
+++ b/nilcc-agent/src/routes/workloads/create.rs
@@ -1,0 +1,56 @@
+use crate::{
+    routes::{AppState, Json, RequestHandlerError},
+    services::workload::{CreateWorkloadError, CreateWorkloadErrorDiscriminants},
+};
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, num::NonZeroU16};
+use tracing::error;
+use uuid::Uuid;
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct CreateWorkloadRequest {
+    pub(crate) id: Uuid,
+    pub(crate) docker_compose: String,
+    pub(crate) env_vars: HashMap<String, String>,
+    pub(crate) public_container_name: String,
+    pub(crate) public_container_port: u16,
+    pub(crate) memory_gb: u32,
+    pub(crate) cpus: NonZeroU16,
+    pub(crate) gpus: u16,
+    pub(crate) disk_space_gb: NonZeroU16,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct CreateWorkloadResponse {
+    pub(crate) id: Uuid,
+}
+
+pub(crate) async fn handler(
+    state: State<AppState>,
+    request: Json<CreateWorkloadRequest>,
+) -> Result<Json<CreateWorkloadResponse>, CreateWorkloadError> {
+    let id = request.id;
+    state.services.workload.create_workload(request.0).await?;
+    Ok(Json(CreateWorkloadResponse { id }))
+}
+
+impl IntoResponse for CreateWorkloadError {
+    fn into_response(self) -> Response {
+        let discriminant = CreateWorkloadErrorDiscriminants::from(&self);
+        let (code, message) = match self {
+            Self::InsufficientResources(_) => (StatusCode::PRECONDITION_FAILED, self.to_string()),
+            Self::Internal(e) => {
+                error!("Failed to create workload: {e}");
+                (StatusCode::INTERNAL_SERVER_ERROR, "internal error".into())
+            }
+            Self::AlreadyExists => (StatusCode::BAD_REQUEST, "workload already exists".into()),
+        };
+        let response = RequestHandlerError::new(message, format!("{discriminant:?}"));
+        (code, Json(response)).into_response()
+    }
+}

--- a/nilcc-agent/src/routes/workloads/mod.rs
+++ b/nilcc-agent/src/routes/workloads/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod create;

--- a/nilcc-agent/src/services/mod.rs
+++ b/nilcc-agent/src/services/mod.rs
@@ -1,3 +1,4 @@
 pub mod disk;
 pub mod sni_proxy;
 pub mod vm;
+pub mod workload;

--- a/nilcc-tests/config/nilcc-agent-config.yaml
+++ b/nilcc-tests/config/nilcc-agent-config.yaml
@@ -6,6 +6,9 @@ qemu:
   img_bin: qemu-img
 
 api:
+  bind_endpoint: "127.0.0.1:50055"
+
+controller:
   endpoint: "http://127.0.0.1:8081"
   key: your-metal-instance-api-key
   sync_interval: 10s


### PR DESCRIPTION
This adds the first endpoint to create a workload. For now this only touches the database and performs validations; the corresponding VM will be started on the next PR.