### PR TITLE
feat: add scheduler/worker to start and manage VMs

### DIFF
--- a/nilcc-agent/src/config.rs
+++ b/nilcc-agent/src/config.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 use std::{net::SocketAddr, path::PathBuf, time::Duration};
 use uuid::Uuid;
 
-#[derive(Deserialize, Debug)]
+#[derive(Debug, Deserialize)]
 pub struct AgentConfig {
     /// Directory where VM folders live
     pub vm_store: PathBuf,
@@ -36,7 +36,7 @@ pub struct AgentConfig {
     pub resources: ResourcesConfig,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct CvmConfig {
     /// The path to the initrd file.
     pub initrd: PathBuf,
@@ -51,7 +51,7 @@ pub struct CvmConfig {
     pub gpu: CvmFiles,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct CvmFiles {
     /// The path to the kernel file.
     pub kernel: PathBuf,
@@ -67,7 +67,7 @@ pub struct CvmFiles {
     pub verity_root_hash: String,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct QemuConfig {
     /// Path to the qemu-system binary
     pub system_bin: PathBuf,
@@ -76,7 +76,7 @@ pub struct QemuConfig {
     pub img_bin: PathBuf,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct ControllerConfig {
     /// nilcc API endpoint to connect to.
     pub endpoint: String,
@@ -89,19 +89,19 @@ pub struct ControllerConfig {
     pub sync_interval: Duration,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct ApiConfig {
     /// The endpoint to bind to.
     pub bind_endpoint: SocketAddr,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct DbConfig {
     /// The database URL.
     pub url: String,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct SniProxyConfig {
     /// The DNS subdomain where workloads will be accessible.
     pub dns_subdomain: String,
@@ -125,7 +125,7 @@ pub struct SniProxyConfig {
     pub max_connections: u64,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SniProxyConfigTimeouts {
     /// Timeout for connection establishment in ms.
     pub connect: u64,
@@ -137,21 +137,21 @@ pub struct SniProxyConfigTimeouts {
     pub client: u64,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct MetricsConfig {
     /// The endpoint where metrics are exposed.
     pub bind_endpoint: SocketAddr,
 }
 
 /// The resources configuration.
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct ResourcesConfig {
     /// The reserved resources.
     pub reserved: ReservedResourcesConfig,
 }
 
 /// The reserved resources configuration.
-#[derive(Deserialize, Debug, Default)]
+#[derive(Clone, Debug, Default, Deserialize)]
 pub struct ReservedResourcesConfig {
     /// The number of reserved CPUs.
     pub cpus: u32,

--- a/nilcc-agent/src/lib.rs
+++ b/nilcc-agent/src/lib.rs
@@ -8,3 +8,4 @@ pub mod resources;
 pub mod routes;
 pub mod services;
 pub mod version;
+pub mod workers;

--- a/nilcc-agent/src/services/vm.rs
+++ b/nilcc-agent/src/services/vm.rs
@@ -1,18 +1,12 @@
-use crate::config::CvmFiles;
 use crate::{
-    clients::qemu::{HardDiskFormat, HardDiskSpec, QemuClientError, VmClient, VmSpec},
-    config::CvmConfig,
-    iso::{ApplicationMetadata, ContainerMetadata, EnvironmentVariable, IsoSpec},
-    repositories::workload::{WorkloadModel, WorkloadModelStatus, WorkloadRepository},
-    services::{
-        disk::{DiskService, DockerComposeHash},
-        sni_proxy::SniProxyService,
-    },
+    clients::qemu::VmClient,
+    repositories::workload::{WorkloadModel, WorkloadRepository},
+    services::sni_proxy::SniProxyService,
 };
 use anyhow::Context;
 use async_trait::async_trait;
 use metrics::{counter, gauge};
-use std::{fmt, path::PathBuf, sync::Arc, time::Duration};
+use std::{path::PathBuf, sync::Arc, time::Duration};
 use tokio::{
     fs, select,
     sync::mpsc::{channel, Receiver, Sender},
@@ -37,9 +31,7 @@ pub trait VmService: Send + Sync {
 pub struct VmServiceArgs {
     pub state_path: PathBuf,
     pub vm_client: Box<dyn VmClient>,
-    pub disk_service: Box<dyn DiskService>,
     pub workload_repository: Arc<dyn WorkloadRepository>,
-    pub cvm_config: CvmConfig,
     pub sni_proxy_service: Box<dyn SniProxyService>,
 }
 
@@ -76,28 +68,17 @@ impl VmService for DefaultVmService {
 struct Worker {
     state_path: PathBuf,
     vm_client: Box<dyn VmClient>,
-    disk_service: Box<dyn DiskService>,
     workload_repository: Arc<dyn WorkloadRepository>,
     sni_proxy_service: Box<dyn SniProxyService>,
-    cvm_config: CvmConfig,
     receiver: Receiver<Command>,
 }
 
 impl Worker {
     fn start(args: VmServiceArgs) -> Sender<Command> {
         let (sender, receiver) = channel(WORKER_CHANNEL_SIZE);
-        let VmServiceArgs { state_path, vm_client, disk_service, workload_repository, cvm_config, sni_proxy_service } =
-            args;
+        let VmServiceArgs { state_path, vm_client, workload_repository, sni_proxy_service } = args;
         tokio::spawn(async move {
-            let worker = Worker {
-                state_path,
-                vm_client,
-                disk_service,
-                workload_repository,
-                sni_proxy_service,
-                cvm_config,
-                receiver,
-            };
+            let worker = Worker { state_path, vm_client, workload_repository, sni_proxy_service, receiver };
             worker.run().await;
             warn!("Worker loop exited");
         });
@@ -130,19 +111,7 @@ impl Worker {
         warn!("Worker loop ended");
     }
 
-    async fn handle_command(&mut self, command: Command) -> anyhow::Result<()> {
-        match command {
-            Command::SyncVm { workload } => {
-                info!("Need to sync vm {}", workload.id);
-                counter!("vm_commands_executed_total", "command" => "start").increment(1);
-                self.sync_vm(workload).await?;
-            }
-            Command::StopVm { id } => {
-                info!("Need to stop vm {id}");
-                counter!("vm_commands_executed_total", "command" => "stop").increment(1);
-                self.stop_vm(id).await?;
-            }
-        };
+    async fn handle_command(&mut self, _command: Command) -> anyhow::Result<()> {
         self.update_sni_proxy_config().await
     }
 
@@ -179,113 +148,9 @@ impl Worker {
         Ok(())
     }
 
-    async fn sync_vm(&mut self, mut workload: WorkloadModel) -> anyhow::Result<()> {
-        let id = workload.id;
-        let socket_path = self.socket_path(id);
-        info!("Trying to stop VM {id} before syncing");
-        match self.vm_client.stop_vm(&socket_path, true).await {
-            Ok(()) => (),
-            Err(QemuClientError::VmNotRunning) => {
-                info!("VM was not running");
-            }
-            Err(e) => Err(e).context("Failed to stop running VM")?,
-        };
-
-        info!("Starting VM {id}");
-        let (iso_path, docker_compose_hash) = self.create_application_iso(&workload).await?;
-        let state_disk = self.create_state_disk(&workload).await?;
-        let vm_spec = self.create_vm_spec(&workload, iso_path, state_disk, docker_compose_hash)?;
-        self.vm_client.start_vm(vm_spec, &socket_path).await.context("Failed to start VM")?;
-
-        // Mark it as running and update it
-        workload.status = WorkloadModelStatus::Running;
-        self.workload_repository.upsert(workload).await.context("Failed to upsert workload")?;
-        Ok(())
-    }
-
-    async fn stop_vm(&mut self, id: Uuid) -> anyhow::Result<()> {
-        let socket_path = self.socket_path(id);
-        info!("Stopping VM {id}");
-        match self.vm_client.stop_vm(&socket_path, true).await {
-            Ok(()) => (),
-            Err(QemuClientError::VmNotRunning) => {
-                info!("VM was not running");
-            }
-            Err(e) => return Err(e).context("Failed to stop running VM")?,
-        };
-        self.workload_repository.delete(id).await.context("Failed to delete workload")?;
-        Ok(())
-    }
-
     fn socket_path(&self, vm_id: Uuid) -> PathBuf {
         let file_name = format!("{vm_id}.sock");
         self.state_path.join(file_name)
-    }
-
-    async fn create_state_disk(&self, workload: &WorkloadModel) -> anyhow::Result<PathBuf> {
-        let disk_name = format!("{}.raw", workload.id);
-        let disk_path = self.state_path.join(disk_name);
-        self.disk_service
-            .create_disk(&disk_path, HardDiskFormat::Raw, workload.disk_gb.into())
-            .await
-            .context("Failed to create state disk")?;
-        Ok(disk_path)
-    }
-
-    async fn create_application_iso(&self, workload: &WorkloadModel) -> anyhow::Result<(PathBuf, DockerComposeHash)> {
-        let iso_name = format!("{}.iso", workload.id);
-        let iso_path = self.state_path.join(iso_name);
-        let environment_variables =
-            workload.environment_variables.iter().map(|(name, value)| EnvironmentVariable::new(name, value)).collect();
-        let spec = IsoSpec {
-            docker_compose_yaml: workload.docker_compose.clone(),
-            metadata: ApplicationMetadata {
-                hostname: "UNKNOWN".into(),
-                api: ContainerMetadata {
-                    container: workload.public_container_name.clone(),
-                    port: workload.public_container_port,
-                },
-            },
-            environment_variables,
-        };
-        let docker_compose_hash = self
-            .disk_service
-            .create_application_iso(&iso_path, spec)
-            .await
-            .context("Failed to create application ISO")?;
-        Ok((iso_path, docker_compose_hash))
-    }
-
-    fn create_vm_spec(
-        &self,
-        workload: &WorkloadModel,
-        iso_path: PathBuf,
-        state_disk_path: PathBuf,
-        docker_compose_hash: DockerComposeHash,
-    ) -> anyhow::Result<VmSpec> {
-        let CvmFiles { base_disk, kernel, verity_root_hash, verity_disk } =
-            if workload.gpus.is_empty() { &self.cvm_config.cpu } else { &self.cvm_config.gpu };
-        let kernel_args =
-            KernelArgs { filesystem_root_hash: verity_root_hash, docker_compose_hash: &docker_compose_hash.0 };
-        let spec = VmSpec {
-            cpu: workload.cpus.into(),
-            ram_mib: workload.memory_mb,
-            hard_disks: vec![
-                HardDiskSpec { path: base_disk.clone(), format: HardDiskFormat::Qcow2 },
-                HardDiskSpec { path: verity_disk.clone(), format: HardDiskFormat::Raw },
-                HardDiskSpec { path: state_disk_path, format: HardDiskFormat::Raw },
-            ],
-            cdrom_iso_path: Some(iso_path),
-            gpus: workload.gpus.clone(),
-            port_forwarding: vec![(workload.metal_http_port, 80), (workload.metal_https_port, 443)],
-            bios_path: Some(self.cvm_config.bios.clone()),
-            initrd_path: Some(self.cvm_config.initrd.clone()),
-            kernel_path: Some(kernel.clone()),
-            kernel_args: Some(kernel_args.to_string()),
-            display_gtk: false,
-            enable_cvm: true,
-        };
-        Ok(spec)
     }
 
     async fn update_sni_proxy_config(&self) -> anyhow::Result<()> {
@@ -295,30 +160,18 @@ impl Worker {
     }
 }
 
+#[allow(dead_code)]
 enum Command {
     SyncVm { workload: WorkloadModel },
     StopVm { id: Uuid },
-}
-
-struct KernelArgs<'a> {
-    docker_compose_hash: &'a str,
-    filesystem_root_hash: &'a str,
-}
-
-impl fmt::Display for KernelArgs<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let Self { docker_compose_hash, filesystem_root_hash } = self;
-        write!(f, "panic=-1 root=/dev/sda2 verity_disk=/dev/sdb verity_roothash={filesystem_root_hash} state_disk=/dev/sdc docker_compose_disk=/dev/sr0 docker_compose_hash={docker_compose_hash}")
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::{
-        clients::qemu::MockVmClient,
-        repositories::workload::MockWorkloadRepository,
-        services::{disk::MockDiskService, sni_proxy::MockSniProxyService},
+        clients::qemu::MockVmClient, repositories::workload::MockWorkloadRepository,
+        services::sni_proxy::MockSniProxyService,
     };
     use mockall::predicate::eq;
     use tempfile::TempDir;
@@ -349,23 +202,19 @@ mod tests {
     struct WorkerBuilder {
         state_path: TempDir,
         vm_client: MockVmClient,
-        disk_service: MockDiskService,
         workload_repository: MockWorkloadRepository,
         sni_proxy_service: MockSniProxyService,
-        cvm_config: CvmConfig,
     }
 
     impl WorkerBuilder {
         fn build(self) -> WorkerCtx {
-            let Self { state_path, vm_client, disk_service, workload_repository, sni_proxy_service, cvm_config } = self;
+            let Self { state_path, vm_client, workload_repository, sni_proxy_service } = self;
             WorkerCtx {
                 worker: Worker {
                     state_path: state_path.path().into(),
                     vm_client: Box::new(vm_client),
-                    disk_service: Box::new(disk_service),
                     workload_repository: Arc::new(workload_repository),
                     sni_proxy_service: Box::new(sni_proxy_service),
-                    cvm_config,
                     receiver: channel(1).1,
                 },
                 state_path,
@@ -378,105 +227,10 @@ mod tests {
             Self {
                 state_path: tempfile::tempdir().expect("failed to create temp dir"),
                 vm_client: Default::default(),
-                disk_service: Default::default(),
                 workload_repository: Default::default(),
                 sni_proxy_service: Default::default(),
-                cvm_config: CvmConfig {
-                    initrd: "/initrd".into(),
-                    bios: "/bios".into(),
-                    cpu: CvmFiles {
-                        base_disk: "/base_disk".into(),
-                        kernel: "/kernel".into(),
-                        verity_disk: "/verity_disk".into(),
-                        verity_root_hash: "root-hash".into(),
-                    },
-                    gpu: CvmFiles {
-                        base_disk: "/base_disk_gpu".into(),
-                        kernel: "/kernel_gpu".into(),
-                        verity_disk: "/verity_disk_gpu".into(),
-                        verity_root_hash: "root-hash-gpu".into(),
-                    },
-                },
             }
         }
-    }
-
-    #[tokio::test]
-    async fn application_iso() {
-        let mut builder = WorkerBuilder::default();
-        let id = Uuid::new_v4();
-        let expected_iso_path = builder.state_path.path().join(format!("{id}.iso"));
-        let workload = WorkloadModel {
-            id,
-            docker_compose: "some_yaml".into(),
-            public_container_name: "foo".into(),
-            public_container_port: 80,
-            environment_variables: [("var".into(), "value".into())].into(),
-            ..make_workload()
-        };
-        let spec = IsoSpec {
-            docker_compose_yaml: workload.docker_compose.clone(),
-            metadata: ApplicationMetadata {
-                hostname: "UNKNOWN".into(),
-                api: ContainerMetadata {
-                    container: workload.public_container_name.clone(),
-                    port: workload.public_container_port,
-                },
-            },
-            environment_variables: vec![EnvironmentVariable::new("var", "value")],
-        };
-
-        builder
-            .disk_service
-            .expect_create_application_iso()
-            .with(eq(expected_iso_path.clone()), eq(spec))
-            .return_once(move |_, _| Ok(DockerComposeHash("hash".into())));
-
-        let ctx = builder.build();
-        let (iso_path, _) = ctx.worker.create_application_iso(&workload).await.expect("failed to generate ISO");
-        assert_eq!(iso_path, expected_iso_path);
-    }
-
-    #[test]
-    fn vm_spec() {
-        let builder = WorkerBuilder::default();
-        let docker_compose_hash = "deadbeef";
-        let workload = WorkloadModel {
-            memory_mb: 1024,
-            cpus: 2.try_into().unwrap(),
-            gpus: vec!["addr".into()],
-            ..make_workload()
-        };
-        let iso_path = PathBuf::from("/tmp/vm.iso");
-        let filesystem_root_hash = &builder.cvm_config.gpu.verity_root_hash;
-        let kernel_args = KernelArgs { docker_compose_hash, filesystem_root_hash }.to_string();
-        let state_disk_path = PathBuf::from("/tmp/vm.raw");
-
-        let expected_spec = VmSpec {
-            cpu: 2,
-            ram_mib: 1024,
-            hard_disks: vec![
-                HardDiskSpec { path: "/base_disk_gpu".into(), format: HardDiskFormat::Qcow2 },
-                HardDiskSpec { path: "/verity_disk_gpu".into(), format: HardDiskFormat::Raw },
-                HardDiskSpec { path: state_disk_path.clone(), format: HardDiskFormat::Raw },
-            ],
-            cdrom_iso_path: Some(iso_path.clone()),
-            gpus: vec!["addr".into()],
-            port_forwarding: vec![(workload.metal_http_port, 80), (workload.metal_https_port, 443)],
-            bios_path: Some("/bios".into()),
-            initrd_path: Some("/initrd".into()),
-            kernel_path: Some("/kernel_gpu".into()),
-            kernel_args: Some(kernel_args),
-            display_gtk: false,
-            enable_cvm: true,
-        };
-        let ctx = builder.build();
-        let spec = ctx
-            .worker
-            .create_vm_spec(&workload, iso_path, state_disk_path, DockerComposeHash(docker_compose_hash.to_string()))
-            .expect("failed to create vm spec");
-
-        assert_eq!(spec, expected_spec);
     }
 
     #[tokio::test]
@@ -506,7 +260,6 @@ mod tests {
     async fn stop_vm_command() {
         let id = Uuid::new_v4();
         let mut builder = WorkerBuilder::default();
-        let path = builder.state_path.path().join(format!("{id}.sock"));
         let workloads = vec![make_workload(), make_workload()];
         builder
             .sni_proxy_service
@@ -515,8 +268,6 @@ mod tests {
             .once()
             .return_once(move |_| Ok(()));
         builder.workload_repository.expect_list().return_once(move || Ok(workloads));
-        builder.vm_client.expect_stop_vm().with(eq(path), eq(true)).once().return_once(move |_, _| Ok(()));
-        builder.workload_repository.expect_delete().with(eq(id)).once().return_once(move |_| Ok(()));
 
         let mut ctx = builder.build();
         ctx.worker.handle_command(Command::StopVm { id }).await.expect("failed to handle command");

--- a/nilcc-agent/src/workers/mod.rs
+++ b/nilcc-agent/src/workers/mod.rs
@@ -1,0 +1,2 @@
+pub mod scheduler;
+pub(crate) mod vm;

--- a/nilcc-agent/src/workers/scheduler.rs
+++ b/nilcc-agent/src/workers/scheduler.rs
@@ -1,0 +1,90 @@
+use crate::{
+    clients::qemu::{VmClient, VmSpec},
+    workers::vm::{VmWorker, VmWorkerHandle},
+};
+use anyhow::bail;
+use async_trait::async_trait;
+use std::{collections::HashMap, path::PathBuf, sync::Arc};
+use strum::EnumDiscriminants;
+use tokio::sync::mpsc::{channel, Receiver, Sender};
+use tracing::{error, info, warn};
+use uuid::Uuid;
+
+const CHANNEL_SIZE: usize = 1024;
+
+pub struct VmScheduler {
+    receiver: Receiver<SchedulerCommand>,
+    vm_client: Arc<dyn VmClient>,
+    workers: HashMap<Uuid, VmWorkerHandle>,
+}
+
+impl VmScheduler {
+    pub fn spawn(qemu_client: Arc<dyn VmClient>) -> Box<dyn VmSchedulerHandle> {
+        let (sender, receiver) = channel(CHANNEL_SIZE);
+        tokio::spawn(async move {
+            let this = VmScheduler { receiver, vm_client: qemu_client, workers: Default::default() };
+            this.run().await
+        });
+        Box::new(DefaultVmSchedulerHandle { sender })
+    }
+
+    async fn run(mut self) {
+        info!("Starting run loop");
+        while let Some(command) = self.receiver.recv().await {
+            let discriminant = SchedulerCommandDiscriminants::from(&command);
+            info!("Received {discriminant:?} command");
+            if let Err(e) = self.handle_command(command).await {
+                error!("Failed to process {discriminant:?} command: {e}");
+            }
+        }
+        warn!("Sender dropped, exiting");
+    }
+
+    async fn handle_command(&mut self, command: SchedulerCommand) -> anyhow::Result<()> {
+        match command {
+            SchedulerCommand::StartVm { id, spec, socket_path } => self.start_vm(id, spec, socket_path).await,
+        }
+    }
+
+    async fn start_vm(&mut self, id: Uuid, spec: VmSpec, socket_path: PathBuf) -> anyhow::Result<()> {
+        match self.workers.get(&id) {
+            Some(_) => bail!("VM {id} is already being ran"),
+            None => {
+                let worker = VmWorker::spawn(self.vm_client.clone(), spec, socket_path);
+                self.workers.insert(id, worker);
+                Ok(())
+            }
+        }
+    }
+}
+
+#[cfg_attr(test, mockall::automock)]
+#[async_trait]
+pub trait VmSchedulerHandle: Send + Sync {
+    async fn start_vm(&self, id: Uuid, spec: VmSpec, socket_path: PathBuf);
+}
+
+pub(crate) struct DefaultVmSchedulerHandle {
+    sender: Sender<SchedulerCommand>,
+}
+
+impl DefaultVmSchedulerHandle {
+    async fn send_command(&self, command: SchedulerCommand) {
+        if self.sender.send(command).await.is_err() {
+            error!("Failed to send command: receiver dropped");
+        }
+    }
+}
+
+#[async_trait]
+impl VmSchedulerHandle for DefaultVmSchedulerHandle {
+    async fn start_vm(&self, id: Uuid, spec: VmSpec, socket_path: PathBuf) {
+        let command = SchedulerCommand::StartVm { id, spec, socket_path };
+        self.send_command(command).await;
+    }
+}
+
+#[derive(Debug, EnumDiscriminants)]
+pub(crate) enum SchedulerCommand {
+    StartVm { id: Uuid, spec: VmSpec, socket_path: PathBuf },
+}

--- a/nilcc-agent/src/workers/vm.rs
+++ b/nilcc-agent/src/workers/vm.rs
@@ -1,0 +1,28 @@
+use crate::clients::qemu::{VmClient, VmSpec};
+use std::{path::PathBuf, sync::Arc};
+use tracing::error;
+
+pub(crate) struct VmWorker {
+    vm_client: Arc<dyn VmClient>,
+    spec: VmSpec,
+    socket_path: PathBuf,
+}
+
+impl VmWorker {
+    pub(crate) fn spawn(vm_client: Arc<dyn VmClient>, spec: VmSpec, socket_path: PathBuf) -> VmWorkerHandle {
+        tokio::spawn(async move {
+            let worker = VmWorker { vm_client, spec, socket_path };
+            worker.run().await;
+        });
+        VmWorkerHandle {}
+    }
+
+    async fn run(self) {
+        // TODO: do something
+        if let Err(e) = self.vm_client.start_vm(self.spec.clone(), &self.socket_path).await {
+            error!("Failed to start VM: {e}")
+        }
+    }
+}
+
+pub(crate) struct VmWorkerHandle {}


### PR DESCRIPTION
This moves the existing logic to start a VM into 2 new stateful workers. Now when a request to create a VM comes in we forward the request to these workers which will do the real work. For now the worker that manages the VM is very dumb but in the next PR it will start monitoring the VM to make sure it's up and report errors if it's not.