### PR TITLE
chore: clean up schemas

### DIFF
--- a/nilcc-agent/migrations/20250606204408_add_workloads_table.sql
+++ b/nilcc-agent/migrations/20250606204408_add_workloads_table.sql
@@ -3,16 +3,15 @@
 CREATE TABLE workloads (
   id VARCHAR(36) PRIMARY KEY,
   docker_compose TEXT NOT NULL,
-  environment_variables TEXT NOT NULL,
+  env_vars TEXT NOT NULL,
   public_container_name VARCHAR(100) NOT NULL,
   public_container_port INT NOT NULL,
   memory_mb INT NOT NULL,
   cpus INT NOT NULL,
   gpus TEXT NOT NULL,
-  disk_gb INT NOT NULL,
-  metal_http_port INT NOT NULL,
-  metal_https_port INT NOT NULL,
-  status VARCHAR(64) NOT NULL, 
+  disk_space_gb INT NOT NULL,
+  proxy_http_port INT NOT NULL,
+  proxy_https_port INT NOT NULL,
   created_at DATETIME WITH TIMEZONE NOT NULL,
   updated_at DATETIME WITH TIMEZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
 );

--- a/nilcc-agent/nilcc-agent-config.sample.yaml
+++ b/nilcc-agent/nilcc-agent-config.sample.yaml
@@ -47,4 +47,4 @@ metrics:
 resources:
   reserved:
     cpus: 1
-    memory_gb: 2
+    memory_mb: 1024

--- a/nilcc-agent/src/clients/nilcc_api.rs
+++ b/nilcc-agent/src/clients/nilcc_api.rs
@@ -87,12 +87,9 @@ impl NilccApiClient for HttpNilccApiClient {
             id: self.agent_id,
             agent_version: agent_version().to_string(),
             hostname: resources.hostname.clone(),
-            memory_gb: resources.memory_gb,
-            os_reserved_memory_gb: resources.reserved_memory_gb,
-            disk_space_gb: resources.disk_space_gb,
-            os_reserved_disk_space_gb: resources.reserved_disk_space_gb,
-            cpus: resources.cpus,
-            os_reserved_cpus: resources.reserved_cpus,
+            memory_mb: Resource { reserved: resources.reserved_memory_mb, total: resources.memory_mb },
+            disk_space_gb: Resource { reserved: resources.reserved_disk_space_gb, total: resources.disk_space_gb },
+            cpus: Resource { reserved: resources.reserved_cpus, total: resources.cpus },
             gpus: resources.gpus.as_ref().map(|g| g.addresses.len() as u32),
             gpu_model: resources.gpus.as_ref().map(|g| g.model.clone()),
         };
@@ -110,33 +107,24 @@ impl NilccApiClient for HttpNilccApiClient {
 #[serde(rename_all = "camelCase")]
 pub struct RegisterRequest {
     id: Uuid,
-
     agent_version: String,
-
     hostname: String,
-
-    #[serde(rename = "totalMemory")]
-    memory_gb: u64,
-
-    #[serde(rename = "osReservedMemory")]
-    os_reserved_memory_gb: u64,
-
-    #[serde(rename = "totalDisk")]
-    disk_space_gb: u64,
-
-    #[serde(rename = "osReservedDisk")]
-    os_reserved_disk_space_gb: u64,
-
-    #[serde(rename = "totalCpus")]
-    cpus: u32,
-
-    os_reserved_cpus: u32,
+    memory_mb: Resource,
+    disk_space_gb: Resource,
+    cpus: Resource,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     gpus: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     gpu_model: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Resource {
+    reserved: u32,
+    total: u32,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/nilcc-agent/src/clients/qemu.rs
+++ b/nilcc-agent/src/clients/qemu.rs
@@ -60,7 +60,7 @@ impl fmt::Display for HardDiskFormat {
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct VmSpec {
     /// Number of vCPUs to allocate to the VM.
-    pub cpu: u16,
+    pub cpu: u32,
 
     /// Amount of RAM to allocate to the VM (in MiB).
     pub ram_mib: u32,

--- a/nilcc-agent/src/config.rs
+++ b/nilcc-agent/src/config.rs
@@ -153,10 +153,10 @@ pub struct ReservedResourcesConfig {
     pub cpus: u32,
 
     /// The reserved memory in GBs.
-    pub memory_gb: u64,
+    pub memory_mb: u32,
 
     /// The reserved disk space in GBs.
-    pub disk_space_gb: u64,
+    pub disk_space_gb: u32,
 }
 
 pub fn read_file_as_string<'de, D>(deserializer: D) -> Result<String, D::Error>

--- a/nilcc-agent/src/routes/workloads/create.rs
+++ b/nilcc-agent/src/routes/workloads/create.rs
@@ -8,7 +8,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, num::NonZeroU16};
+use std::collections::HashMap;
 use tracing::error;
 use uuid::Uuid;
 
@@ -19,10 +19,10 @@ pub struct CreateWorkloadRequest {
     pub(crate) env_vars: HashMap<String, String>,
     pub(crate) public_container_name: String,
     pub(crate) public_container_port: u16,
-    pub(crate) memory_gb: u32,
-    pub(crate) cpus: NonZeroU16,
+    pub(crate) memory_mb: u32,
+    pub(crate) cpus: u32,
     pub(crate) gpus: u16,
-    pub(crate) disk_space_gb: NonZeroU16,
+    pub(crate) disk_space_gb: u32,
 }
 
 #[derive(Clone, Debug, Serialize)]

--- a/nilcc-agent/src/services/disk.rs
+++ b/nilcc-agent/src/services/disk.rs
@@ -11,7 +11,7 @@ use tokio::process::Command;
 #[async_trait]
 pub trait DiskService: Send + Sync {
     /// Create a disk at the given path with the given format.
-    async fn create_disk(&self, path: &Path, format: HardDiskFormat, size_gib: u16) -> anyhow::Result<()>;
+    async fn create_disk(&self, path: &Path, format: HardDiskFormat, size_gib: u32) -> anyhow::Result<()>;
 
     /// Create the ISO for an application.
     async fn create_application_iso(&self, path: &Path, spec: IsoSpec) -> anyhow::Result<DockerComposeHash>;
@@ -29,7 +29,7 @@ impl DefaultDiskService {
 
 #[async_trait]
 impl DiskService for DefaultDiskService {
-    async fn create_disk(&self, path: &Path, format: HardDiskFormat, size_gib: u16) -> anyhow::Result<()> {
+    async fn create_disk(&self, path: &Path, format: HardDiskFormat, size_gib: u32) -> anyhow::Result<()> {
         let format = format.to_string();
         let args = ["create", "-f", &format, &path.to_string_lossy(), &format!("{size_gib}G")];
         let output = Command::new(&self.qemu_img_path)

--- a/nilcc-agent/src/services/proxy.rs
+++ b/nilcc-agent/src/services/proxy.rs
@@ -1,5 +1,5 @@
 use crate::config::SniProxyConfigTimeouts;
-use crate::repositories::workload::WorkloadModel;
+use crate::repositories::workload::Workload;
 use anyhow::{bail, Context as anyhowContext, Result};
 use async_trait::async_trait;
 use serde::Serialize;
@@ -18,9 +18,9 @@ pub struct ProxiedVm {
     pub(crate) https_port: u16,
 }
 
-impl From<&WorkloadModel> for ProxiedVm {
-    fn from(workload: &WorkloadModel) -> Self {
-        Self { id: workload.id, http_port: workload.metal_http_port, https_port: workload.metal_https_port }
+impl From<&Workload> for ProxiedVm {
+    fn from(workload: &Workload) -> Self {
+        Self { id: workload.id, http_port: workload.proxy_http_port, https_port: workload.proxy_https_port }
     }
 }
 

--- a/nilcc-api/src/metal-instance/metal-instance.controller.ts
+++ b/nilcc-api/src/metal-instance/metal-instance.controller.ts
@@ -11,8 +11,6 @@ import {
   GetMetalInstanceResponse,
   ListMetalInstancesResponse,
   RegisterMetalInstanceRequest,
-  SyncMetalInstanceRequest,
-  SyncMetalInstanceResponse,
 } from "#/metal-instance/metal-instance.dto";
 import { metalInstanceMapper } from "#/metal-instance/metal-instance.mapper";
 
@@ -46,39 +44,6 @@ export function register(options: ControllerOptions) {
         c.get("txQueryRunner"),
       );
       return c.body(null);
-    },
-  );
-}
-
-export function sync(options: ControllerOptions) {
-  const { app, bindings } = options;
-  app.post(
-    PathsV1.metalInstance.sync,
-    describeRoute({
-      tags: ["Metal-Instance"],
-      summary:
-        "Sync a Metal Instance State receiving current state and answering with desired state",
-      description:
-        "Sync a Metal Instance State receiving current state and answering with desired state",
-      responses: {
-        ...OpenApiSpecCommonErrorResponses,
-      },
-    }),
-    apiKey(bindings.config.metalInstanceApiKey),
-    zValidator("json", SyncMetalInstanceRequest),
-    responseValidator(bindings, SyncMetalInstanceResponse),
-    transactionMiddleware(bindings.dataSource),
-    async (c) => {
-      const payload = c.req.valid("json");
-      const result = await bindings.services.metalInstance.sync(
-        bindings,
-        payload,
-        c.get("txQueryRunner"),
-      );
-      if (!result) {
-        return c.notFound();
-      }
-      return c.json(metalInstanceMapper.syncEntityToResponse(result));
     },
   );
 }

--- a/nilcc-api/src/metal-instance/metal-instance.dto.ts
+++ b/nilcc-api/src/metal-instance/metal-instance.dto.ts
@@ -1,18 +1,17 @@
 import { z } from "zod";
 import { Uuid } from "#/common/types";
-import { GetWorkloadResponse } from "#/workload/workload.dto";
+
+export const Resource = z.object({ reserved: z.number(), total: z.number() });
+export type Resource = z.infer<typeof Resource>;
 
 export const RegisterMetalInstanceRequest = z
   .object({
     id: Uuid,
     agentVersion: z.string().min(1, "Agent version is required"),
     hostname: z.string().min(1, "hostname is required"),
-    totalMemory: z.number().int().positive(),
-    osReservedMemory: z.number().int().positive(),
-    totalCpus: z.number().int().positive(),
-    osReservedCpus: z.number().int().positive(),
-    totalDisk: z.number().int().positive(),
-    osReservedDisk: z.number().int().positive(),
+    memoryMb: Resource,
+    cpus: Resource,
+    diskSpaceGb: Resource,
     gpus: z.number().int().positive().optional(),
     gpuModel: z.string().optional(),
   })
@@ -34,26 +33,4 @@ export const ListMetalInstancesResponse = z
   .openapi({ ref: "ListMetalInstancesResponse" });
 export type ListMetalInstancesResponse = z.infer<
   typeof ListMetalInstancesResponse
->;
-
-export const SyncWorkload = z
-  .object({
-    id: Uuid,
-    status: z.enum(["pending", "running", "stopped", "error"]),
-  })
-  .array();
-
-export const SyncMetalInstanceRequest = z
-  .object({
-    id: Uuid,
-    workloads: SyncWorkload,
-  })
-  .openapi({ ref: "SyncMetalInstanceRequest" });
-export type SyncMetalInstanceRequest = z.infer<typeof SyncMetalInstanceRequest>;
-
-export const SyncMetalInstanceResponse = GetMetalInstanceResponse.extend({
-  workloads: GetWorkloadResponse.array(),
-}).openapi({ ref: "SyncMetalInstanceResponse" });
-export type SyncMetalInstanceResponse = z.infer<
-  typeof SyncMetalInstanceResponse
 >;

--- a/nilcc-api/src/metal-instance/metal-instance.mapper.ts
+++ b/nilcc-api/src/metal-instance/metal-instance.mapper.ts
@@ -1,9 +1,5 @@
-import type {
-  GetMetalInstanceResponse,
-  SyncMetalInstanceResponse,
-} from "#/metal-instance/metal-instance.dto";
+import type { GetMetalInstanceResponse } from "#/metal-instance/metal-instance.dto";
 import type { MetalInstanceEntity } from "#/metal-instance/metal-instance.entity";
-import { workloadMapper } from "#/workload/workload.mapper";
 
 export const metalInstanceMapper = {
   entityToResponse(
@@ -12,30 +8,23 @@ export const metalInstanceMapper = {
     return {
       agentVersion: metalInstance.agentVersion,
       hostname: metalInstance.hostname,
-      totalMemory: metalInstance.totalMemory,
-      osReservedMemory: metalInstance.osReservedMemory,
-      totalCpus: metalInstance.totalCpus,
-      osReservedCpus: metalInstance.osReservedCpus,
-      totalDisk: metalInstance.totalDisk,
-      osReservedDisk: metalInstance.osReservedDisk,
+      memoryMb: {
+        total: metalInstance.totalMemory,
+        reserved: metalInstance.osReservedMemory,
+      },
+      cpus: {
+        total: metalInstance.totalCpus,
+        reserved: metalInstance.osReservedCpus,
+      },
+      diskSpaceGb: {
+        total: metalInstance.totalDisk,
+        reserved: metalInstance.osReservedDisk,
+      },
       id: metalInstance.id,
       gpus: metalInstance.gpus ?? undefined,
       gpuModel: metalInstance.gpuModel ?? undefined,
       createdAt: metalInstance.createdAt.toISOString(),
       updatedAt: metalInstance.updatedAt.toISOString(),
-    };
-  },
-
-  syncEntityToResponse(
-    metalInstance: MetalInstanceEntity,
-  ): SyncMetalInstanceResponse {
-    const metalInstanceResponse = this.entityToResponse(metalInstance);
-    const workloads = metalInstance.workloads
-      ? metalInstance.workloads.map((w) => workloadMapper.entityToResponse(w))
-      : [];
-    return {
-      ...metalInstanceResponse,
-      workloads,
     };
   },
 };

--- a/nilcc-api/src/metal-instance/metal-instance.router.ts
+++ b/nilcc-api/src/metal-instance/metal-instance.router.ts
@@ -3,6 +3,5 @@ import * as MetalInstanceController from "./metal-instance.controller";
 
 export function buildMetalInstanceRouter(options: ControllerOptions): void {
   MetalInstanceController.register(options);
-  MetalInstanceController.sync(options);
   MetalInstanceController.read(options);
 }

--- a/nilcc-api/tests/fixture/fixture.ts
+++ b/nilcc-api/tests/fixture/fixture.ts
@@ -33,7 +33,7 @@ export async function buildFixture(): Promise<TestFixture> {
   const id = faker.string.alphanumeric({ length: 4, casing: "lower" });
   const log = createTestLogger(id);
 
-  log.info("Creating Binding");
+  log.info("Creating binding");
 
   const baseDBUri = process.env.APP_DB_URI;
   const thisDescribeDBUri = `${baseDBUri}-${id}`;
@@ -43,7 +43,7 @@ export async function buildFixture(): Promise<TestFixture> {
     dbUri: thisDescribeDBUri,
   })) as AppBindings;
 
-  log.info("Creating App");
+  log.info("Creating app");
   const { app } = await buildApp(bindings);
 
   const userClient = new UserClient({

--- a/nilcc-api/tests/fixture/test-client.ts
+++ b/nilcc-api/tests/fixture/test-client.ts
@@ -5,8 +5,6 @@ import type { AppBindings } from "#/env";
 import {
   GetMetalInstanceResponse,
   type RegisterMetalInstanceRequest,
-  type SyncMetalInstanceRequest,
-  SyncMetalInstanceResponse,
 } from "#/metal-instance/metal-instance.dto";
 import {
   type CreateWorkloadRequest,
@@ -158,17 +156,6 @@ export class MetalInstanceClient extends TestClient {
     return {
       "x-api-key": this.bindings.config.metalInstanceApiKey,
     };
-  }
-
-  async sync(body: SyncMetalInstanceRequest) {
-    const response = await this.request(PathsV1.metalInstance.sync, {
-      method: "POST",
-      body,
-    });
-    return new ParseableResponse<SyncMetalInstanceResponse>(
-      response,
-      SyncMetalInstanceResponse,
-    );
   }
 
   async register(body: RegisterMetalInstanceRequest): Promise<Response> {

--- a/nilcc-api/tests/workload.test.ts
+++ b/nilcc-api/tests/workload.test.ts
@@ -38,12 +38,18 @@ services:
     id: "c92c86e4-c7e5-4bb3-a5f5-45945b5593e4",
     agentVersion: "v0.1.0",
     hostname: "my-metal-instance",
-    totalMemory: 128,
-    osReservedMemory: 8,
-    totalCpus: 64,
-    osReservedCpus: 4,
-    totalDisk: 1024,
-    osReservedDisk: 100,
+    memoryMb: {
+      total: 8192,
+      reserved: 2048,
+    },
+    cpus: {
+      total: 8,
+      reserved: 2,
+    },
+    diskSpaceGb: {
+      total: 1024,
+      reserved: 128,
+    },
   };
 
   it("should fail to create a workload if there isn't a metal instance", async ({

--- a/nilcc-tests/config/nilcc-agent-config.yaml
+++ b/nilcc-tests/config/nilcc-agent-config.yaml
@@ -47,6 +47,6 @@ metrics:
 resources:
   reserved:
     cpus: 1
-    memory_gb: 2
+    memory_mb: 1024
     disk_space_gb: 10
 


### PR DESCRIPTION
This cleans up schemas so we **always** have memory as MBs all over the system. This was otherwise mixing units and it was annoying to convert between them. 