### PR TITLE
feat: add a token to the nilcc-agent API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1676,6 +1676,7 @@ dependencies = [
  "test-with",
  "thiserror",
  "tokio",
+ "tower",
  "tracing",
  "tracing-subscriber",
  "tracing-test",
@@ -3336,9 +3337,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
  "getrandom 0.3.2",

--- a/nilcc-agent/Cargo.toml
+++ b/nilcc-agent/Cargo.toml
@@ -6,12 +6,12 @@ edition = "2024"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-axum = { version = "0.8.4", features = ["json"] }
+axum = { version = "0.8", features = ["json"] }
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.5", features = ["derive", "env"] }
 hex = { version = "0.4", features = ["serde"] }
-humantime = { version = "2.2.0"}
-humantime-serde = "1.1.1"
+humantime = { version = "2.2"}
+humantime-serde = "1.1"
 metrics = "0.24"
 metrics-exporter-prometheus = { version = "0.17", default-features = false, features = ["http-listener"] }
 once_cell = "1.20"
@@ -24,15 +24,16 @@ sha2 = "0.10"
 sqlx = { version = "0.8", features = ["chrono", "migrate", "runtime-tokio", "sqlite", "uuid"] }
 strum = { version = "0.27", features = ["derive"] }
 sysinfo = { version = "0.35"}
-tempfile = "3.19.1"
+tempfile = "3.20"
 tera = { version = "1", default-features = false }
 thiserror = "2"
 tokio = { version = "1.44", features = ["rt-multi-thread", "macros", "net", "process", "time", "fs", "signal"] }
-convert_case = "0.8.0"
+tower = "0.5"
+convert_case = "0.8"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
-uuid = { version = "1.17.0", features = ["serde", "v4"] }
-validator = { version = "0.20.0", features = ["derive"] }
+uuid = { version = "1.17", features = ["serde", "v4"] }
+validator = { version = "0.20", features = ["derive"] }
 
 [dev-dependencies]
 mockall = "0.13"

--- a/nilcc-agent/nilcc-agent-config.sample.yaml
+++ b/nilcc-agent/nilcc-agent-config.sample.yaml
@@ -7,6 +7,7 @@ qemu:
 
 api:
   bind_endpoint: "127.0.0.1:50055"
+  token: abcdefg
 
 controller:
   mode: remote

--- a/nilcc-agent/src/auth.rs
+++ b/nilcc-agent/src/auth.rs
@@ -1,0 +1,72 @@
+use crate::routes::{Json, RequestHandlerError};
+use axum::body::Body;
+use axum::http::header::AUTHORIZATION;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::{extract::Request, response::Response};
+use std::convert::Infallible;
+use std::{
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+use tower::{Layer, Service};
+
+#[derive(Clone)]
+pub(crate) struct AuthLayer {
+    token: Arc<String>,
+}
+
+impl AuthLayer {
+    pub(crate) fn new(token: String) -> Self {
+        Self { token: Arc::new(token) }
+    }
+}
+
+impl<S> Layer<S> for AuthLayer {
+    type Service = AuthMiddleware<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        AuthMiddleware { inner, token: self.token.clone() }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct AuthMiddleware<S> {
+    inner: S,
+    token: Arc<String>,
+}
+
+impl<S> Service<Request<Body>> for AuthMiddleware<S>
+where
+    S: Service<Request<Body>, Response = Response, Error = Infallible> + Send + Sync + Clone + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request) -> Self::Future {
+        let mut inner = self.inner.clone();
+        let token = self.token.clone();
+        Box::pin(async move {
+            if let Some(header) = req.headers().get(AUTHORIZATION) {
+                if let Ok(value) = header.to_str() {
+                    if value.strip_prefix("Bearer ") == Some(&token) {
+                        return inner.call(req).await;
+                    }
+                }
+            }
+
+            let response = RequestHandlerError {
+                error_code: "UNAUTHORIZED".into(),
+                message: "invalid or missing bearer token".into(),
+            };
+            Ok((StatusCode::UNAUTHORIZED, Json(response)).into_response())
+        })
+    }
+}

--- a/nilcc-agent/src/config.rs
+++ b/nilcc-agent/src/config.rs
@@ -97,6 +97,9 @@ pub struct ControllerConfig {
 pub struct ApiConfig {
     /// The endpoint to bind to.
     pub bind_endpoint: SocketAddr,
+
+    /// The API key that needs to be presented when making requests to this instance.
+    pub token: String,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/nilcc-agent/src/lib.rs
+++ b/nilcc-agent/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod auth;
 pub mod clients;
 pub mod config;
 pub mod repositories;

--- a/nilcc-agent/src/main.rs
+++ b/nilcc-agent/src/main.rs
@@ -165,7 +165,7 @@ async fn run_daemon(config: AgentConfig) -> Result<()> {
         services: Services { workload: Arc::new(workload_service) },
         resource_limits: config.resources.limits,
     };
-    let router = build_router(state);
+    let router = build_router(state, config.api.token);
     let listener = TcpListener::bind(config.api.bind_endpoint).await.context("Failed to bind")?;
     let server = axum::serve(listener, router).with_graceful_shutdown(shutdown_signal());
     info!("Listening to requests on {}", config.api.bind_endpoint);

--- a/nilcc-tests/config/nilcc-agent-config.yaml
+++ b/nilcc-tests/config/nilcc-agent-config.yaml
@@ -7,6 +7,7 @@ qemu:
 
 api:
   bind_endpoint: "127.0.0.1:50055"
+  token: my_token
 
 controller:
   mode: remote


### PR DESCRIPTION
This adds a middleware that expects an `Authorization: Bearer` header that nilcc-api will add in all requests.