### PR TITLE
feat: send request to nilcc-agent to create workload

### DIFF
--- a/nilcc-agent/src/config.rs
+++ b/nilcc-agent/src/config.rs
@@ -98,6 +98,9 @@ pub struct ApiConfig {
     /// The endpoint to bind to.
     pub bind_endpoint: SocketAddr,
 
+    /// The public domain where this agent can be reached.
+    pub domain: String,
+
     /// The API key that needs to be presented when making requests to this instance.
     pub token: String,
 }

--- a/nilcc-agent/src/main.rs
+++ b/nilcc-agent/src/main.rs
@@ -128,7 +128,7 @@ async fn run_daemon(config: AgentConfig) -> Result<()> {
     system_resources.create_gpu_vfio_devices().await.context("Failed to create PCI VFIO GPU devices")?;
 
     info!("Registering with API");
-    nilcc_api_client.register(&system_resources).await.context("Failed to register")?;
+    nilcc_api_client.register(&config.api, &system_resources).await.context("Failed to register")?;
 
     let db = SqliteDb::connect(&config.db.url).await.context("Failed to create database")?;
     let workload_repository = Arc::new(SqliteWorkloadRepository::new(db.clone()));

--- a/nilcc-api/src/clients/nilcc-agent.service.ts
+++ b/nilcc-api/src/clients/nilcc-agent.service.ts
@@ -1,0 +1,84 @@
+import { AgentRequestError } from "#/common/errors";
+import type { MetalInstanceEntity } from "#/metal-instance/metal-instance.entity";
+import type { WorkloadEntity } from "#/workload/workload.entity";
+
+export interface NilccAgentClient {
+  createWorkload(
+    metalInstance: MetalInstanceEntity,
+    workload: WorkloadEntity,
+    domain: string,
+  ): Promise<void>;
+  deleteWorkload(
+    metalInstance: MetalInstanceEntity,
+    workloadId: string,
+  ): Promise<void>;
+}
+
+export class DefaultNilccAgentClient implements NilccAgentClient {
+  async createWorkload(
+    metalInstance: MetalInstanceEntity,
+    workload: WorkloadEntity,
+    domain: string,
+  ): Promise<void> {
+    const url = `${metalInstance.endpoint}/api/v1/workloads/create`;
+    const request: CreateWorkloadRequest = {
+      id: workload.id,
+      dockerCompose: workload.dockerCompose,
+      envVars: workload.envVars,
+      publicContainerName: workload.serviceToExpose,
+      publicContainerPort: workload.servicePortToExpose,
+      memoryMb: workload.memory,
+      cpus: workload.cpus,
+      gpus: workload.gpus,
+      diskSpaceGb: workload.disk,
+      domain,
+    };
+    await this.post(url, request, metalInstance);
+  }
+
+  async deleteWorkload(
+    metalInstance: MetalInstanceEntity,
+    workloadId: string,
+  ): Promise<void> {
+    const url = `${metalInstance.endpoint}/api/v1/workloads/delete`;
+    const request: DeleteWorkloadRequest = {
+      id: workloadId,
+    };
+    await this.post(url, request, metalInstance);
+  }
+
+  async post(
+    url: string,
+    request: unknown,
+    metalInstance: MetalInstanceEntity,
+  ): Promise<void> {
+    const response = await fetch(url, {
+      method: "POST",
+      body: JSON.stringify(request),
+      headers: {
+        Authorization: `Bearer ${metalInstance.token}`,
+      },
+    });
+    if (!response.ok) {
+      const body = await response.json();
+      throw new AgentRequestError(body);
+    }
+  }
+}
+
+type CreateWorkloadRequest = {
+  id: string;
+  dockerCompose: string;
+  envVars?: Record<string, string>;
+  publicContainerName: string;
+  publicContainerPort: number;
+  memoryMb: number;
+  cpus: number;
+  gpus: number;
+  diskSpaceGb: number;
+  domain: string;
+};
+
+type DeleteWorkloadRequest = {
+  id: string;
+};

--- a/nilcc-api/src/common/errors.ts
+++ b/nilcc-api/src/common/errors.ts
@@ -142,6 +142,10 @@ export class InvalidDockerCompose extends AppError {
   tag = "InvalidDockerCompose";
 }
 
+export class AgentRequestError extends AppError {
+  tag = "AgentRequestError";
+}
+
 export class HttpError extends AppError {
   tag = "HttpError";
   statusCode: ContentfulStatusCode;

--- a/nilcc-api/src/common/handler.ts
+++ b/nilcc-api/src/common/handler.ts
@@ -4,11 +4,13 @@ import { StatusCodes } from "http-status-codes";
 import { Temporal } from "temporal-polyfill";
 import { z } from "zod";
 import {
+  AgentRequestError,
   CreateEntityError,
   DataValidationError,
   FindEntityError,
   GetRepositoryError,
   HttpError,
+  InvalidDockerCompose,
   RemoveEntityError,
   UpdateEntityError,
 } from "#/common/errors";
@@ -50,7 +52,7 @@ export function errorHandler(e: unknown, c: Context) {
     return c.json(payload, statusCode);
   };
 
-  if (e instanceof DataValidationError) {
+  if (e instanceof DataValidationError || e instanceof InvalidDockerCompose) {
     return toResponse(e, e.humanize(), StatusCodes.BAD_REQUEST);
   }
 
@@ -63,7 +65,8 @@ export function errorHandler(e: unknown, c: Context) {
     e instanceof CreateEntityError ||
     e instanceof FindEntityError ||
     e instanceof UpdateEntityError ||
-    e instanceof RemoveEntityError
+    e instanceof RemoveEntityError ||
+    e instanceof AgentRequestError
   ) {
     return toResponse(e, e.humanize(), StatusCodes.INTERNAL_SERVER_ERROR);
   }

--- a/nilcc-api/src/common/paths.ts
+++ b/nilcc-api/src/common/paths.ts
@@ -21,7 +21,6 @@ export const PathsV1 = {
   },
   metalInstance: {
     register: PathSchema.parse("/api/v1/metal-instances/~/register"),
-    sync: PathSchema.parse("/api/v1/metal-instances/~/sync"),
     read: PathSchema.parse("/api/v1/metal-instances/:id"),
     list: PathSchema.parse("/api/v1/metal-instances"),
   },

--- a/nilcc-api/src/env.ts
+++ b/nilcc-api/src/env.ts
@@ -6,6 +6,10 @@ import { buildDataSource } from "#/data-source";
 import { MetalInstanceService } from "#/metal-instance/metal-instance.service";
 import { WorkloadService } from "#/workload/workload.service";
 import {
+  DefaultNilccAgentClient,
+  type NilccAgentClient,
+} from "./clients/nilcc-agent.service";
+import {
   type DnsService,
   LocalStackDnsService,
   Route53DnsService,
@@ -43,6 +47,7 @@ export type AppServices = {
   metalInstance: MetalInstanceService;
   workload: WorkloadService;
   dns: DnsService;
+  nilccAgentClient: NilccAgentClient;
 };
 
 export type AppBindings = {
@@ -121,11 +126,13 @@ async function buildServices(
 
   const metalInstanceService = new MetalInstanceService();
   const workloadService = new WorkloadService();
+  const nilccAgentClient = new DefaultNilccAgentClient();
 
   return {
     metalInstance: metalInstanceService,
     workload: workloadService,
     dns: dnsService,
+    nilccAgentClient,
   };
 }
 

--- a/nilcc-api/src/metal-instance/metal-instance.dto.ts
+++ b/nilcc-api/src/metal-instance/metal-instance.dto.ts
@@ -1,18 +1,23 @@
 import { z } from "zod";
 import { Uuid } from "#/common/types";
 
-export const Resource = z.object({ reserved: z.number(), total: z.number() });
+export const Resource = z.object({
+  reserved: z.number().nonnegative(),
+  total: z.number().nonnegative(),
+});
 export type Resource = z.infer<typeof Resource>;
 
 export const RegisterMetalInstanceRequest = z
   .object({
     id: Uuid,
     agentVersion: z.string().min(1, "Agent version is required"),
+    endpoint: z.string(),
+    token: z.string(),
     hostname: z.string().min(1, "hostname is required"),
     memoryMb: Resource,
     cpus: Resource,
     diskSpaceGb: Resource,
-    gpus: z.number().int().positive().optional(),
+    gpus: z.number().nonnegative(),
     gpuModel: z.string().optional(),
   })
   .openapi({ ref: "RegisterMetalInstanceRequest" });
@@ -20,12 +25,23 @@ export type RegisterMetalInstanceRequest = z.infer<
   typeof RegisterMetalInstanceRequest
 >;
 
-export const GetMetalInstanceResponse = RegisterMetalInstanceRequest.extend({
-  createdAt: z.string().datetime(),
-  updatedAt: z.string().datetime(),
-}).openapi({
-  ref: "GetMetalInstanceResponse",
-});
+export const GetMetalInstanceResponse = z
+  .object({
+    id: Uuid,
+    agentVersion: z.string(),
+    endpoint: z.string(),
+    hostname: z.string(),
+    memoryMb: Resource,
+    cpus: Resource,
+    diskSpaceGb: Resource,
+    gpus: z.number(),
+    gpuModel: z.string().optional(),
+    createdAt: z.string().datetime(),
+    updatedAt: z.string().datetime(),
+  })
+  .openapi({
+    ref: "GetMetalInstanceResponse",
+  });
 export type GetMetalInstanceResponse = z.infer<typeof GetMetalInstanceResponse>;
 
 export const ListMetalInstancesResponse = z

--- a/nilcc-api/src/metal-instance/metal-instance.entity.ts
+++ b/nilcc-api/src/metal-instance/metal-instance.entity.ts
@@ -10,6 +10,12 @@ export class MetalInstanceEntity {
   hostname: string;
 
   @Column({ type: "varchar" })
+  endpoint: string;
+
+  @Column({ type: "varchar" })
+  token: string;
+
+  @Column({ type: "varchar" })
   agentVersion: string;
 
   @Column({ type: "int" })
@@ -30,8 +36,8 @@ export class MetalInstanceEntity {
   @Column({ type: "int" })
   osReservedDisk: number;
 
-  @Column({ type: "int", nullable: true })
-  gpus?: number;
+  @Column({ type: "int" })
+  gpus: number;
 
   @Column({ type: "varchar", nullable: true })
   gpuModel?: string;

--- a/nilcc-api/src/metal-instance/metal-instance.mapper.ts
+++ b/nilcc-api/src/metal-instance/metal-instance.mapper.ts
@@ -8,6 +8,7 @@ export const metalInstanceMapper = {
     return {
       agentVersion: metalInstance.agentVersion,
       hostname: metalInstance.hostname,
+      endpoint: metalInstance.endpoint,
       memoryMb: {
         total: metalInstance.totalMemory,
         reserved: metalInstance.osReservedMemory,
@@ -21,7 +22,7 @@ export const metalInstanceMapper = {
         reserved: metalInstance.osReservedDisk,
       },
       id: metalInstance.id,
-      gpus: metalInstance.gpus ?? undefined,
+      gpus: metalInstance.gpus,
       gpuModel: metalInstance.gpuModel ?? undefined,
       createdAt: metalInstance.createdAt.toISOString(),
       updatedAt: metalInstance.updatedAt.toISOString(),

--- a/nilcc-api/src/workload/workload.controllers.ts
+++ b/nilcc-api/src/workload/workload.controllers.ts
@@ -22,7 +22,6 @@ import {
   CreateWorkloadResponse,
   GetWorkloadResponse,
   ListWorkloadsResponse,
-  UpdateWorkloadRequest,
 } from "./workload.dto";
 
 const idParamSchema = z.object({ id: z.string().uuid() });
@@ -142,36 +141,6 @@ export function read(options: ControllerOptions): void {
         return c.notFound();
       }
       return c.json(workloadMapper.entityToResponse(workload));
-    },
-  );
-}
-
-export function update(options: ControllerOptions): void {
-  const { app, bindings } = options;
-
-  app.put(
-    PathsV1.workload.update,
-    describeRoute({
-      tags: ["Workload"],
-      summary: "Update a Workload",
-      description: "Update a Workload",
-      responses: {
-        200: OpenApiSpecEmptySuccessResponses[200],
-        ...OpenApiSpecCommonErrorResponses,
-      },
-    }),
-    apiKey(bindings.config.userApiKey),
-    zValidator("json", UpdateWorkloadRequest),
-    async (c) => {
-      const payload = c.req.valid("json");
-      const updated = await bindings.services.workload.update(
-        bindings,
-        payload,
-      );
-      if (!updated) {
-        return c.notFound();
-      }
-      return c.body(null, 200);
     },
   );
 }

--- a/nilcc-api/src/workload/workload.dto.ts
+++ b/nilcc-api/src/workload/workload.dto.ts
@@ -17,7 +17,7 @@ export const CreateWorkloadRequest = z
       .int()
       .min(10, "Disk must be at least 10GB")
       .max(100, "Disk must be at most 100GB"),
-    gpu: z.number().int().positive().optional(),
+    gpus: z.number().int(),
   })
   .openapi({ ref: "CreateWorkloadRequest" });
 export type CreateWorkloadRequest = z.infer<typeof CreateWorkloadRequest>;
@@ -39,30 +39,3 @@ export const ListWorkloadsResponse = z
   .array(GetWorkloadResponse)
   .openapi({ ref: "ListWorkloadsResponse" });
 export type ListWorkloadsResponse = z.infer<typeof ListWorkloadsResponse>;
-
-export const UpdateWorkloadRequest = z
-  .object({
-    id: Uuid,
-    name: z.string().min(1, "Name is required").optional(),
-    description: z.string().optional(),
-    tags: z.array(z.string()).optional(),
-    dockerCompose: z.string().min(1, "Docker Compose is required").optional(),
-    envVars: z.record(z.string(), z.string()).optional(),
-    serviceToExpose: z
-      .string()
-      .min(1, "Service to expose is required")
-      .optional(),
-    servicePortToExpose: z
-      .number()
-      .int()
-      .min(1, "Service port to expose is required")
-      .optional(),
-    memory: z
-      .number()
-      .int()
-      .min(1, "Memory must be a positive integer")
-      .optional(),
-    cpus: z.number().int().min(1, "CPU must be a positive integer").optional(),
-  })
-  .openapi({ ref: "UpdateWorkloadRequest" });
-export type UpdateWorkloadRequest = z.infer<typeof UpdateWorkloadRequest>;

--- a/nilcc-api/src/workload/workload.entity.ts
+++ b/nilcc-api/src/workload/workload.entity.ts
@@ -46,6 +46,9 @@ export class WorkloadEntity {
   cpus: number;
 
   @Column({ type: "int" })
+  gpus: number;
+
+  @Column({ type: "int" })
   disk: number;
 
   @Column({

--- a/nilcc-api/src/workload/workload.mapper.ts
+++ b/nilcc-api/src/workload/workload.mapper.ts
@@ -14,6 +14,7 @@ export const workloadMapper = {
       servicePortToExpose: workload.servicePortToExpose,
       memory: workload.memory,
       cpus: workload.cpus,
+      gpus: workload.gpus,
       disk: workload.disk,
       status: workload.status,
       createdAt: workload.createdAt.toISOString(),

--- a/nilcc-api/src/workload/workload.router.ts
+++ b/nilcc-api/src/workload/workload.router.ts
@@ -5,6 +5,5 @@ export function buildWorkloadRouter(options: ControllerOptions): void {
   WorkloadController.create(options);
   WorkloadController.list(options);
   WorkloadController.read(options);
-  WorkloadController.update(options);
   WorkloadController.remove(options);
 }

--- a/nilcc-api/src/workload/workload.service.ts
+++ b/nilcc-api/src/workload/workload.service.ts
@@ -6,14 +6,10 @@ import {
   InstancesNotAvailable,
   mapError,
   RemoveEntityError,
-  UpdateEntityError,
 } from "#/common/errors";
 import { DockerComposeValidator } from "#/compose/validator";
 import type { AppBindings } from "#/env";
-import type {
-  CreateWorkloadRequest,
-  UpdateWorkloadRequest,
-} from "./workload.dto";
+import type { CreateWorkloadRequest } from "./workload.dto";
 import { WorkloadEntity } from "./workload.entity";
 
 export class WorkloadService {
@@ -43,7 +39,7 @@ export class WorkloadService {
           cpus: workload.cpus,
           memory: workload.memory,
           disk: workload.disk,
-          gpu: workload.gpu,
+          gpus: workload.gpus,
         },
         bindings,
         tx,
@@ -66,10 +62,15 @@ export class WorkloadService {
       updatedAt: now,
     });
     const createdWorkload = await repository.save(entity);
-    await this.createCnameForWorkload(
+    const domain = await this.createCnameForWorkload(
       bindings,
       createdWorkload.id,
       metalInstance.id,
+    );
+    await bindings.services.nilccAgentClient.createWorkload(
+      metalInstance,
+      entity,
+      domain,
     );
     return createdWorkload;
   }
@@ -89,49 +90,34 @@ export class WorkloadService {
     return await repository.findOneBy({ id: workloadId });
   }
 
-  @mapError((e) => new UpdateEntityError(WorkloadEntity, e))
-  async update(
-    bindings: AppBindings,
-    payload: UpdateWorkloadRequest,
-    tx?: QueryRunner,
-  ): Promise<boolean> {
-    const repository = this.getRepository(bindings, tx);
-    const updated = await repository.update(
-      { id: payload.id },
-      {
-        name: payload.name,
-        description: payload.description,
-        tags: payload.tags,
-        dockerCompose: payload.dockerCompose,
-        envVars: payload.envVars,
-        serviceToExpose: payload.serviceToExpose,
-        servicePortToExpose: payload.servicePortToExpose,
-        memory: payload.memory,
-        cpus: payload.cpus,
-        updatedAt: new Date(),
-      },
-    );
-    return updated.affected ? updated.affected > 0 : false;
-  }
-
   @mapError((e) => new RemoveEntityError(WorkloadEntity, e))
   async remove(bindings: AppBindings, workloadId: string): Promise<boolean> {
-    const repository = this.getRepository(bindings);
-    const result = await repository.delete({ id: workloadId });
+    const workloadRepository = this.getRepository(bindings);
+    const workloads = await workloadRepository.find({
+      where: { id: workloadId },
+      relations: ["metalInstance"],
+    });
+    if (workloads.length === 0) {
+      return false;
+    }
+    const workload = workloads[0];
+    await workloadRepository.delete({ id: workloadId });
     await this.removeCnameForWorkload(bindings, workloadId);
-    return result.affected ? result.affected > 0 : false;
+    await bindings.services.nilccAgentClient.deleteWorkload(
+      workload.metalInstance,
+      workloadId,
+    );
+    return true;
   }
 
   async createCnameForWorkload(
     bindings: AppBindings,
     workloadId: string,
     metalInstanceId: string,
-  ): Promise<void> {
+  ): Promise<string> {
     const metalInstanceDomain = `${metalInstanceId}.${bindings.config.metalInstanceDnsDomain}`;
-    return await bindings.services.dns.registerCname(
-      workloadId,
-      metalInstanceDomain,
-    );
+    await bindings.services.dns.registerCname(workloadId, metalInstanceDomain);
+    return metalInstanceDomain;
   }
 
   async removeCnameForWorkload(

--- a/nilcc-api/tests/docker/docker-compose.yml
+++ b/nilcc-api/tests/docker/docker-compose.yml
@@ -5,7 +5,15 @@ services:
       POSTGRES_PASSWORD: postgres
     ports:
       - "35432:5432"
+
   localstack:
     image: localstack/localstack
     ports:
       - "4566:4566"
+
+  agent:
+    image: caddy:2
+    ports:
+      - "35433:80"
+    command: |
+      caddy respond --listen :80 --body '{}' --header "Content-Type: application/json" 

--- a/nilcc-api/tests/fixture/global-setup.ts
+++ b/nilcc-api/tests/fixture/global-setup.ts
@@ -13,7 +13,7 @@ const composeOptions = {
 };
 
 export async function setup(_project: TestProject) {
-  console.log("🚀 Starting containers...");
+  console.log("Starting containers...");
   try {
     // Check if containers are already running
     const psResult = await dockerCompose.ps(composeOptions);
@@ -22,7 +22,7 @@ export async function setup(_project: TestProject) {
       psResult.data.services.every((service) => service.state?.includes("Up"));
 
     if (allServicesUp) {
-      console.log("✅ Containers already running, skipping startup.");
+      console.log("Containers already running, skipping startup.");
       return;
     }
 
@@ -38,14 +38,14 @@ export async function setup(_project: TestProject) {
       await new Promise((f) => setTimeout(f, 200));
     }
     if (retry >= MAX_RETRIES) {
-      console.error("❌ Error starting containers: timeout");
+      console.error("Error starting containers: timeout");
       process.exit(1);
     }
     // We need sleep 1 sec to be sure that the AboutResponse.started is at least 1 sec earlier than the tests start.
     await new Promise((f) => setTimeout(f, 2000));
-    console.log("✅ Containers started successfully.");
+    console.log("Containers started successfully.");
   } catch (error) {
-    console.error("❌ Error starting containers: ", error);
+    console.error("Error starting containers: ", error);
     process.exit(1);
   }
 }
@@ -53,16 +53,16 @@ export async function setup(_project: TestProject) {
 export async function teardown(_project: TestProject) {
   // Skip teardown if KEEP_INFRA environment variable is set
   if (process.env.KEEP_INFRA === "true") {
-    console.log("🔄 Keeping infrastructure running as KEEP_INFRA=true");
+    console.log("Keeping infrastructure running as KEEP_INFRA=true");
     return;
   }
 
-  console.log("🛑 Removing containers...");
+  console.log("Removing containers...");
   try {
     await dockerCompose.downAll(composeOptions);
-    console.log("✅ Containers removed successfully.");
+    console.log("Containers removed successfully.");
   } catch (error) {
-    console.error("❌ Error removing containers: ", error);
+    console.error("Error removing containers: ", error);
     process.exit(1);
   }
 }

--- a/nilcc-api/tests/fixture/test-client.ts
+++ b/nilcc-api/tests/fixture/test-client.ts
@@ -11,7 +11,6 @@ import {
   CreateWorkloadResponse,
   GetWorkloadResponse,
   ListWorkloadsResponse,
-  type UpdateWorkloadRequest,
 } from "#/workload/workload.dto";
 
 export type TestClientOptions = {
@@ -121,13 +120,6 @@ export class UserClient extends TestClient {
       response,
       ListWorkloadsResponse,
     );
-  }
-
-  async updateWorkload(body: UpdateWorkloadRequest): Promise<Response> {
-    return await this.request(PathsV1.workload.update, {
-      method: "PUT",
-      body,
-    });
   }
 
   async deleteWorkload(params: { id: string }): Promise<Response> {

--- a/nilcc-api/tests/metal-instance.test.ts
+++ b/nilcc-api/tests/metal-instance.test.ts
@@ -11,6 +11,8 @@ describe("Metal Instance", () => {
   const myMetalInstance: RegisterMetalInstanceRequest = {
     id: "c92c86e4-c7e5-4bb3-a5f5-45945b5593e4",
     agentVersion: "v0.1.0",
+    endpoint: "http://127.0.0.1:35433",
+    token: "my_token",
     hostname: "my-metal-instance",
     memoryMb: {
       total: 8192,
@@ -24,9 +26,10 @@ describe("Metal Instance", () => {
       total: 128,
       reserved: 16,
     },
+    gpus: 0,
   };
 
-  it("should register a metal instance that haven't been created", async ({
+  it("should register a metal instance that hasn't been created", async ({
     expect,
     metalInstanceClient,
     userClient,
@@ -44,7 +47,12 @@ describe("Metal Instance", () => {
 
     expect(getResponseAfter.response.status).equals(200);
     const body = await getResponseAfter.parse_body();
-    const cleanBody = { ...body, updatedAt: undefined, createdAt: undefined };
+    const cleanBody = {
+      ...body,
+      updatedAt: undefined,
+      createdAt: undefined,
+      token: myMetalInstance.token,
+    };
     expect(cleanBody).toEqual(myMetalInstance);
   });
 
@@ -71,7 +79,12 @@ describe("Metal Instance", () => {
     });
     expect(getResponse.response.status).equals(200);
     const body = await getResponse.parse_body();
-    const cleanBody = { ...body, updatedAt: undefined, createdAt: undefined };
+    const cleanBody = {
+      ...body,
+      updatedAt: undefined,
+      createdAt: undefined,
+      token: myMetalInstance.token,
+    };
     expect(cleanBody).toEqual(updatedMetalInstance);
   });
 });

--- a/nilcc-api/tests/workload.test.ts
+++ b/nilcc-api/tests/workload.test.ts
@@ -32,11 +32,14 @@ services:
     memory: 4,
     cpus: 2,
     disk: 40,
+    gpus: 0,
   };
 
   const myMetalInstance: RegisterMetalInstanceRequest = {
     id: "c92c86e4-c7e5-4bb3-a5f5-45945b5593e4",
     agentVersion: "v0.1.0",
+    endpoint: "http://127.0.0.1:35433",
+    token: "my_token",
     hostname: "my-metal-instance",
     memoryMb: {
       total: 8192,
@@ -50,6 +53,7 @@ services:
       total: 1024,
       reserved: 128,
     },
+    gpus: 0,
   };
 
   it("should fail to create a workload if there isn't a metal instance", async ({
@@ -103,15 +107,6 @@ services:
     const workloads = await workloadsResponse.parse_body();
     expect(workloads.length).greaterThan(0);
     expect(workloads[0].name).equals(myWorkload!.name);
-  });
-
-  it("should update a workload", async ({ expect, userClient }) => {
-    const updatedName = "my-cool-workload-updated";
-    const response = await userClient.updateWorkload({
-      id: myWorkload!.id,
-      name: updatedName,
-    });
-    expect(response.status).equals(200);
   });
 
   it("should delete a workload", async ({ expect, userClient }) => {

--- a/nilcc-tests/config/nilcc-agent-config.yaml
+++ b/nilcc-tests/config/nilcc-agent-config.yaml
@@ -8,6 +8,7 @@ qemu:
 api:
   bind_endpoint: "127.0.0.1:50055"
   token: my_token
+  domain: "127.0.0.1"
 
 controller:
   mode: remote

--- a/nilcc-tests/docker/docker-compose.yml
+++ b/nilcc-tests/docker/docker-compose.yml
@@ -9,3 +9,9 @@ services:
     image: localstack/localstack
     ports:
       - "4566:4566"
+  agent:
+    image: caddy:2
+    ports:
+      - "35433:80"
+    command: |
+      caddy respond --listen :80 --body '{}' --header "Content-Type: application/json" 

--- a/nilcc-tests/e2e-tests/fixture/global-setup.ts
+++ b/nilcc-tests/e2e-tests/fixture/global-setup.ts
@@ -62,11 +62,11 @@ async function waitForResource(
   maxRetries = 30,
   retryDelay = 1000,
 ): Promise<void> {
-  console.log(`⏳ Waiting for ${resourceName} to be ready...`);
+  console.log(`Waiting for ${resourceName} to be ready...`);
   for (let retry = 1; retry <= maxRetries; retry++) {
     try {
       await check();
-      console.log(`✅ ${resourceName} is ready.`);
+      console.log(`${resourceName} is ready.`);
       return;
     } catch (error) {
       if (retry < maxRetries) {
@@ -121,7 +121,7 @@ async function waitForApi(): Promise<void> {
 }
 
 async function startDockerContainers() {
-  console.log("🚀 Starting docker containers...");
+  console.log("Starting docker containers...");
   try {
     await dockerCompose.upAll({
       ...DOCKER_COMPOSE_OPTIONS,
@@ -130,20 +130,20 @@ async function startDockerContainers() {
 
     await waitForPostgres();
     await waitForLocalstack();
-    console.log("✅ Containers and services are ready.");
+    console.log("Containers and services are ready.");
   } catch (error) {
-    console.error("❌ Error starting containers: ", error);
+    console.error("Error starting containers: ", error);
     await process.exit(1);
   }
 }
 
 async function startApiServer() {
   const apiCwd = "../nilcc-api";
-  console.log(`🚀 Installing API dependencies in ${apiCwd}...`);
+  console.log(`Installing API dependencies in ${apiCwd}...`);
   await spawnAsync("pnpm", ["install"], { cwd: apiCwd });
-  console.log("✅ API dependencies installed.");
+  console.log("API dependencies installed.");
 
-  console.log("🚀 Starting API server...");
+  console.log("Starting API server...");
   apiProcess = spawn("pnpm", ["start"], {
     cwd: apiCwd,
     env: { ...process.env, ...API_CONFIG },
@@ -157,42 +157,42 @@ async function startApiServer() {
 }
 
 export async function setup() {
-  console.log("⚙️  Building rust agent...");
+  console.log("Building rust agent...");
   await spawnAsync(...NILCC_AGENT_BUILD_OPTIONS);
-  console.log("✅ Rust agent built successfully.");
+  console.log("Rust agent built successfully.");
 
   await startDockerContainers();
   await startApiServer();
 
-  console.log("✅ Setup complete. Ready for tests.");
+  console.log("Setup complete. Ready for tests.");
 }
 
 export async function teardown() {
   if (process.env.SKIP_TEARDOWN) {
-    console.log("🟡 Skipping teardown due to SKIP_TEARDOWN flag.");
+    console.log("Skipping teardown due to SKIP_TEARDOWN flag.");
     return;
   }
 
   if (apiProcess?.pid) {
-    console.log("🛑 Stopping API server...");
+    console.log("Stopping API server...");
     try {
       // Use process group killing to ensure child processes are also terminated
       process.kill(-apiProcess.pid, "SIGTERM");
-      console.log("✅ API server stopped.");
+      console.log("API server stopped.");
     } catch (error) {
-      console.error("❌ Error stopping API server: ", error);
+      console.error("Error stopping API server: ", error);
     }
   }
 
-  console.log("🛑 Removing containers...");
+  console.log("Removing containers...");
   try {
     await dockerCompose.downAll({
       ...DOCKER_COMPOSE_OPTIONS,
       commandOptions: ["--volumes"], // Also remove volumes to ensure a full clean up
     });
-    console.log("✅ Containers removed successfully.");
+    console.log("Containers removed successfully.");
   } catch (error) {
-    console.error("❌ Error removing containers: ", error);
+    console.error("Error removing containers: ", error);
     process.exit(1);
   }
 }


### PR DESCRIPTION
This adds logic in nilcc-api to make a request to nilcc-agent to create/delete workloads. The main things being added here is the agent now needs to know it's publicly reachable domain and will use that during registration. This allows the API to later on send requests to this agent.