### PR TITLE
feat: add submit event endpoint in API

### DIFF
--- a/nilcc-agent/src/clients/nilcc_api.rs
+++ b/nilcc-agent/src/clients/nilcc_api.rs
@@ -100,7 +100,7 @@ impl NilccApiClient for HttpNilccApiClient {
     }
 
     async fn report_vm_event(&self, workload_id: Uuid, event: VmEvent) -> anyhow::Result<()> {
-        let url = self.make_url("/api/v1/metal-instances/~/events/submit");
+        let url = self.make_url("/api/v1/workloads/~/events/submit");
         let payload = VmEventRequest { agent_id: self.agent_id, workload_id, event };
         self.send_request(Method::POST, url, &payload).await.context("Failed to submit event")
     }

--- a/nilcc-api/src/common/errors.ts
+++ b/nilcc-api/src/common/errors.ts
@@ -146,6 +146,10 @@ export class AgentRequestError extends AppError {
   tag = "AgentRequestError";
 }
 
+export class SubmitEventError extends AppError {
+  tag = "SubmitEventError";
+}
+
 export class HttpError extends AppError {
   tag = "HttpError";
   statusCode: ContentfulStatusCode;

--- a/nilcc-api/src/common/paths.ts
+++ b/nilcc-api/src/common/paths.ts
@@ -18,6 +18,9 @@ export const PathsV1 = {
     read: PathSchema.parse("/api/v1/workloads/:id"),
     update: PathSchema.parse("/api/v1/workloads"),
     remove: PathSchema.parse("/api/v1/workloads/:id"),
+    events: {
+      submit: PathSchema.parse("/api/v1/workloads/~/events/submit"),
+    },
   },
   metalInstance: {
     register: PathSchema.parse("/api/v1/metal-instances/~/register"),

--- a/nilcc-api/src/metal-instance/metal-instance.controller.ts
+++ b/nilcc-api/src/metal-instance/metal-instance.controller.ts
@@ -23,12 +23,12 @@ export function register(options: ControllerOptions) {
     describeRoute({
       tags: ["Metal-Instance"],
       summary:
-        "Register a Metal Instance, will create it if it does not exist, or update it if it does",
+        "Register a metal instance, will create it if it does not exist, or update it if it does",
       description:
-        "Registers a Metal Instance by creating it if it does not exist, or updating it if it does",
+        "Registers a metal instance by creating it if it does not exist, or updating it if it does",
       responses: {
         200: {
-          description: "Metal Instance registered successfully",
+          description: "Metal instance registered successfully",
         },
         ...OpenApiSpecCommonErrorResponses,
       },
@@ -54,8 +54,8 @@ export function read(options: ControllerOptions) {
     PathsV1.metalInstance.read,
     describeRoute({
       tags: ["Metal-Instance"],
-      summary: "Get a Metal Instance by ID",
-      description: "Returns a Metal Instance by its ID",
+      summary: "Get a metal instance by ID",
+      description: "Returns a metal instance by its ID",
       responses: {
         200: {
           description: "Workload found",
@@ -88,11 +88,11 @@ export function list(options: ControllerOptions) {
     PathsV1.metalInstance.list,
     describeRoute({
       tags: ["Metal-Instance"],
-      summary: "List all Metal Instances",
-      description: "Returns a list of all Metal Instances",
+      summary: "List all metal instances",
+      description: "Returns a list of all metal instances",
       responses: {
         200: {
-          description: "List of Metal Instances",
+          description: "List of metal instances",
           content: {
             "application/json": {
               schema: resolver(ListMetalInstancesResponse),

--- a/nilcc-api/src/metal-instance/metal-instance.dto.ts
+++ b/nilcc-api/src/metal-instance/metal-instance.dto.ts
@@ -50,3 +50,19 @@ export const ListMetalInstancesResponse = z
 export type ListMetalInstancesResponse = z.infer<
   typeof ListMetalInstancesResponse
 >;
+
+export const WorkloadEvent = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("started") }),
+  z.object({ kind: z.literal("stopped") }),
+  z.object({ kind: z.literal("failedToStart"), error: z.string() }),
+]);
+export type WorkloadEvent = z.infer<typeof WorkloadEvent>;
+
+export const SubmitEventRequest = z
+  .object({
+    agentId: Uuid,
+    workloadId: Uuid,
+    event: WorkloadEvent,
+  })
+  .openapi({ ref: "SubmitEventRequest" });
+export type SubmitEventRequest = z.infer<typeof SubmitEventRequest>;

--- a/nilcc-api/src/metal-instance/metal-instance.service.ts
+++ b/nilcc-api/src/metal-instance/metal-instance.service.ts
@@ -128,7 +128,7 @@ export class MetalInstanceService {
   async create(
     bindings: AppBindings,
     metalInstance: RegisterMetalInstanceRequest,
-    tx: QueryRunner | undefined,
+    tx?: QueryRunner,
   ) {
     const repository = this.getRepository(bindings, tx);
     const now = new Date();

--- a/nilcc-api/src/workload/workload.dto.ts
+++ b/nilcc-api/src/workload/workload.dto.ts
@@ -24,7 +24,7 @@ export type CreateWorkloadRequest = z.infer<typeof CreateWorkloadRequest>;
 
 export const CreateWorkloadResponse = CreateWorkloadRequest.extend({
   id: Uuid,
-  status: z.enum(["pending", "running", "stopped", "error"]),
+  status: z.enum(["scheduled", "running", "stopped", "error"]),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
 }).openapi({ ref: "CreateWorkloadResponse" });

--- a/nilcc-api/src/workload/workload.entity.ts
+++ b/nilcc-api/src/workload/workload.entity.ts
@@ -53,10 +53,10 @@ export class WorkloadEntity {
 
   @Column({
     type: "enum",
-    enum: ["pending", "running", "stopped", "error"],
-    default: "pending",
+    enum: ["scheduled", "running", "stopped", "error"],
+    default: "scheduled",
   })
-  status: "pending" | "running" | "stopped" | "error";
+  status: "scheduled" | "running" | "stopped" | "error";
 
   @ManyToOne(
     () => MetalInstanceEntity,

--- a/nilcc-api/src/workload/workload.router.ts
+++ b/nilcc-api/src/workload/workload.router.ts
@@ -6,4 +6,5 @@ export function buildWorkloadRouter(options: ControllerOptions): void {
   WorkloadController.list(options);
   WorkloadController.read(options);
   WorkloadController.remove(options);
+  WorkloadController.submitEvent(options);
 }

--- a/nilcc-api/tests/fixture/test-client.ts
+++ b/nilcc-api/tests/fixture/test-client.ts
@@ -5,6 +5,7 @@ import type { AppBindings } from "#/env";
 import {
   GetMetalInstanceResponse,
   type RegisterMetalInstanceRequest,
+  type SubmitEventRequest,
 } from "#/metal-instance/metal-instance.dto";
 import {
   type CreateWorkloadRequest,
@@ -35,19 +36,23 @@ class TestClient {
       method?: "GET" | "POST" | "PUT" | "DELETE";
       body?: T;
       params?: Record<string, string>;
+      headers?: Record<string, string>;
     } = {},
   ): Promise<Response> {
-    const { method = "GET", body } = options;
+    const { method = "GET", body, headers } = options;
 
-    const headers: Record<string, string> = this.extraHeaders();
+    const requestHeaders: Record<string, string> = {
+      ...this.extraHeaders(),
+      ...headers,
+    };
 
     if (body) {
-      headers["Content-Type"] = "application/json";
+      requestHeaders["Content-Type"] = "application/json";
     }
 
     return this.app.request(path, {
       method,
-      headers,
+      headers: requestHeaders,
       ...(body && { body: JSON.stringify(body) }),
     });
   }
@@ -140,6 +145,16 @@ export class UserClient extends TestClient {
       response,
       GetMetalInstanceResponse,
     );
+  }
+
+  async submitEvent(request: SubmitEventRequest) {
+    return this.request(PathsV1.workload.events.submit, {
+      method: "POST",
+      body: request,
+      headers: {
+        "x-api-key": this.bindings.config.metalInstanceApiKey,
+      },
+    });
   }
 }
 

--- a/nilcc-api/tests/workload.test.ts
+++ b/nilcc-api/tests/workload.test.ts
@@ -121,4 +121,29 @@ services:
     });
     expect(getResponse.response.status).equal(404);
   });
+
+  it("should update a workload's state", async ({
+    expect,
+    userClient,
+    metalInstanceClient,
+  }) => {
+    await metalInstanceClient.register(myMetalInstance);
+    const workloadResponse = await userClient.createWorkload(
+      createWorkloadRequest,
+    );
+    myWorkload = await workloadResponse.parse_body();
+
+    const response = await userClient.submitEvent({
+      agentId: myMetalInstance.id,
+      workloadId: myWorkload.id,
+      event: { kind: "started" },
+    });
+    expect(response.status).toBe(200);
+
+    const updatedWorkloadResponse = await userClient.getWorkload({
+      id: myWorkload.id,
+    });
+    const updatedWorkload = await updatedWorkloadResponse.parse_body();
+    expect(updatedWorkload.status).toBe("running");
+  });
 });


### PR DESCRIPTION
This adds the endpoint to report workload events in the API. For now this only updates the workload's status; eventually we should actually store the events but this will do for now.