### PR TITLE
ci: build artifacts if cvm-agent changes

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -3,9 +3,11 @@ on:
   pull_request:
     paths:
       - 'artifacts/**'
+      - 'cvm-agent/**'
   push:
     paths:
       - 'artifacts/**'
+      - 'cvm-agent/**'
     branches:
       - main
 

--- a/cvm-agent/README.md
+++ b/cvm-agent/README.md
@@ -1,0 +1,3 @@
+# cvm-agent
+
+This is the agent that runs inside every CVM and runs docker compose as soon as the CVM boots.


### PR DESCRIPTION
This changes the artifacts build job to rebuild if the cvm-agent directory has changed. I also added a README to the cvm-agent to force a rebuild since a change made a couple of days ago isn't currently reflected in the latest build artifact.