### PR TITLE
fix: disk management

### DIFF
--- a/nilcc-agent/src/services/vm.rs
+++ b/nilcc-agent/src/services/vm.rs
@@ -25,7 +25,7 @@ use uuid::Uuid;
 #[async_trait]
 pub trait VmService: Send + Sync {
     async fn start_vm(&self, workload: Workload) -> Result<(), StartVmError>;
-    async fn stop_vm(&self, id: Uuid);
+    async fn delete_vm(&self, id: Uuid);
 }
 
 pub struct VmServiceArgs {
@@ -174,11 +174,11 @@ impl VmService for DefaultVmService {
         }
     }
 
-    async fn stop_vm(&self, id: Uuid) {
+    async fn delete_vm(&self, id: Uuid) {
         let mut workers = self.workers.lock().await;
         match workers.remove(&id) {
             Some(worker) => {
-                worker.stop_vm().await;
+                worker.delete_vm().await;
             }
             None => {
                 error!("VM {id} is not being managed by any worker");

--- a/nilcc-agent/src/services/workload.rs
+++ b/nilcc-agent/src/services/workload.rs
@@ -236,7 +236,7 @@ impl WorkloadService for DefaultWorkloadService {
         info!("Deleting workload: {id}");
         self.repository.delete(id).await?;
         self.proxy_service.stop_vm_proxy(id).await;
-        self.vm_service.stop_vm(id).await;
+        self.vm_service.delete_vm(id).await;
         Ok(())
     }
 }


### PR DESCRIPTION
This fixes 2 issues around disk management:

* Copies over the base and verity disks to another directory before attaching them to a VM. This otherwise causes qemu to complain about the disk being locked.
* Deletes disks (copy of base disk, copy of verity disk, and ISO) when a VM is deleted. These were otherwise left lingering around, taking up disk space.