### PR TITLE
feat: send periodic heartbeats from agents to api

### DIFF
--- a/nilcc-agent/src/main.rs
+++ b/nilcc-agent/src/main.rs
@@ -24,6 +24,7 @@ use nilcc_agent::{
         workload::{DefaultWorkloadService, WorkloadServiceArgs},
     },
     version,
+    workers::heartbeat::HeartbeatWorker,
 };
 use rustls_acme::{caches::DirCache, AcmeConfig};
 use std::{fs, path::PathBuf, str::FromStr, sync::Arc, time::Duration};
@@ -189,6 +190,9 @@ async fn run_daemon(config: AgentConfig) -> Result<()> {
 
     info!("Registering with API");
     nilcc_api_client.register(&config.api, &system_resources, public_ip).await.context("Failed to register")?;
+
+    info!("Starting heartbeat worker");
+    HeartbeatWorker::spawn(nilcc_api_client.clone());
 
     let vm_client = Arc::new(QemuClient::new(config.qemu.system_bin));
     let vm_service = DefaultVmService::new(VmServiceArgs {

--- a/nilcc-agent/src/workers/heartbeat.rs
+++ b/nilcc-agent/src/workers/heartbeat.rs
@@ -1,0 +1,30 @@
+use crate::clients::nilcc_api::NilccApiClient;
+use std::{sync::Arc, time::Duration};
+use tokio::time::sleep;
+use tracing::{debug, warn};
+
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
+
+pub struct HeartbeatWorker {
+    client: Arc<dyn NilccApiClient>,
+}
+
+impl HeartbeatWorker {
+    pub fn spawn(client: Arc<dyn NilccApiClient>) {
+        tokio::spawn(async move {
+            let worker = Self { client };
+            worker.run().await
+        });
+    }
+
+    async fn run(self) {
+        loop {
+            debug!("Sending heartbeat");
+            if let Err(e) = self.client.heartbeat().await {
+                warn!("Could not submit heartbeat: {e}");
+            }
+            debug!("Sleeping for {HEARTBEAT_INTERVAL:?}");
+            sleep(HEARTBEAT_INTERVAL).await;
+        }
+    }
+}

--- a/nilcc-agent/src/workers/mod.rs
+++ b/nilcc-agent/src/workers/mod.rs
@@ -1,1 +1,2 @@
+pub mod heartbeat;
 pub(crate) mod vm;

--- a/nilcc-api/src/common/paths.ts
+++ b/nilcc-api/src/common/paths.ts
@@ -24,6 +24,7 @@ export const PathsV1 = {
   },
   metalInstance: {
     register: PathSchema.parse("/api/v1/metal-instances/~/register"),
+    heartbeat: PathSchema.parse("/api/v1/metal-instances/~/heartbeat"),
     read: PathSchema.parse("/api/v1/metal-instances/:id"),
     list: PathSchema.parse("/api/v1/metal-instances"),
   },

--- a/nilcc-api/src/metal-instance/metal-instance.dto.ts
+++ b/nilcc-api/src/metal-instance/metal-instance.dto.ts
@@ -25,6 +25,13 @@ export type RegisterMetalInstanceRequest = z.infer<
   typeof RegisterMetalInstanceRequest
 >;
 
+export const HeartbeatRequest = z
+  .object({
+    id: Uuid,
+  })
+  .openapi({ ref: "HeartbeatRequest" });
+export type HeartbeatRequest = z.infer<typeof HeartbeatRequest>;
+
 export const GetMetalInstanceResponse = z
   .object({
     id: Uuid,
@@ -38,6 +45,7 @@ export const GetMetalInstanceResponse = z
     gpuModel: z.string().optional(),
     createdAt: z.string().datetime(),
     updatedAt: z.string().datetime(),
+    lastSeenAt: z.string().datetime(),
   })
   .openapi({
     ref: "GetMetalInstanceResponse",

--- a/nilcc-api/src/metal-instance/metal-instance.entity.ts
+++ b/nilcc-api/src/metal-instance/metal-instance.entity.ts
@@ -53,4 +53,7 @@ export class MetalInstanceEntity {
 
   @Column({ type: "timestamp" })
   updatedAt: Date;
+
+  @Column({ type: "timestamp" })
+  lastSeenAt: Date;
 }

--- a/nilcc-api/src/metal-instance/metal-instance.mapper.ts
+++ b/nilcc-api/src/metal-instance/metal-instance.mapper.ts
@@ -26,6 +26,7 @@ export const metalInstanceMapper = {
       gpuModel: metalInstance.gpuModel ?? undefined,
       createdAt: metalInstance.createdAt.toISOString(),
       updatedAt: metalInstance.updatedAt.toISOString(),
+      lastSeenAt: metalInstance.lastSeenAt.toISOString(),
     };
   },
 };

--- a/nilcc-api/src/metal-instance/metal-instance.router.ts
+++ b/nilcc-api/src/metal-instance/metal-instance.router.ts
@@ -2,6 +2,8 @@ import type { ControllerOptions } from "#/common/types";
 import * as MetalInstanceController from "./metal-instance.controller";
 
 export function buildMetalInstanceRouter(options: ControllerOptions): void {
-  MetalInstanceController.register(options);
+  MetalInstanceController.heartbeat(options);
+  MetalInstanceController.list(options);
   MetalInstanceController.read(options);
+  MetalInstanceController.register(options);
 }

--- a/nilcc-api/tests/fixture/test-client.ts
+++ b/nilcc-api/tests/fixture/test-client.ts
@@ -4,6 +4,7 @@ import { PathsV1 } from "#/common/paths";
 import type { AppBindings } from "#/env";
 import {
   GetMetalInstanceResponse,
+  type HeartbeatRequest,
   type RegisterMetalInstanceRequest,
   type SubmitEventRequest,
 } from "#/metal-instance/metal-instance.dto";
@@ -167,6 +168,13 @@ export class MetalInstanceClient extends TestClient {
 
   async register(body: RegisterMetalInstanceRequest): Promise<Response> {
     return await this.request(PathsV1.metalInstance.register, {
+      method: "POST",
+      body,
+    });
+  }
+
+  async heartbeat(body: HeartbeatRequest): Promise<Response> {
+    return await this.request(PathsV1.metalInstance.heartbeat, {
       method: "POST",
       body,
     });


### PR DESCRIPTION
This adds a periodic hearbeat from all agents to the API. This will allow the API to not schedule workflows on agents that are down, and maybe react to an agent being reported as down.