### PR TITLE
feat: ignore idle agents when assigning workloads

### DIFF
--- a/nilcc-api/src/env.ts
+++ b/nilcc-api/src/env.ts
@@ -78,6 +78,7 @@ export const EnvVarsSchema = z.object({
   metalInstancesDnsZone: z.string(),
   metalInstancesEndpointScheme: z.enum(["http", "https"]).default("https"),
   metalInstancesEndpointPort: z.number().default(443),
+  metalInstancesIdleThresholdSeconds: z.number().default(120),
 });
 
 export type EnvVars = z.infer<typeof EnvVarsSchema>;
@@ -99,6 +100,7 @@ declare global {
       APP_METAL_INSTANCES_DNS_ZONE: string;
       APP_METAL_INSTANCES_ENDPOINT_SCHEME: string;
       APP_METAL_INSTANCES_ENDPOINT_PORT: number;
+      APP_METAL_INSTANCES_IDLE_THRESHOLD_SECONDS: number;
     }
   }
 }
@@ -176,6 +178,8 @@ export function parseConfigFromEnv(overrides: Partial<EnvVars>): EnvVars {
     metalInstancesEndpointPort: Number(
       process.env.APP_METAL_INSTANCES_ENDPOINT_PORT,
     ),
+    metalInstancesIdleThresholdSeconds:
+      process.env.APP_METAL_INSTANCES_IDLE_THRESHOLD_SECONDS,
   });
 
   return {

--- a/nilcc-api/src/metal-instance/metal-instance.service.ts
+++ b/nilcc-api/src/metal-instance/metal-instance.service.ts
@@ -96,6 +96,13 @@ export class MetalInstanceService {
     const repository = this.getRepository(bindings, tx);
     const queryBuilder = repository
       .createQueryBuilder("metalInstance")
+      .where(
+        "EXTRACT(EPOCH FROM (:now - metalInstance.lastSeenAt)) < :threshold",
+        {
+          now: new Date(),
+          threshold: bindings.config.metalInstancesIdleThresholdSeconds,
+        },
+      )
       .leftJoin("metalInstance.workloads", "workload")
       .groupBy("metalInstance.id")
       .having(


### PR DESCRIPTION
This causes idle agents to not be considered when assigning new workloads. By default we consider an agent to be idle if it hasn't sent us a heartbeat in 2 minutes.