### PR TITLE
fix: Alpine Qemu Build Dependencies

### DIFF
--- a/artifacts/qemu/build.sh
+++ b/artifacts/qemu/build.sh
@@ -28,7 +28,7 @@ fi
 
 cd ../..
 
-docker run --rm -v "$SCRIPT_PATH:/qemu" alpine sh -c "apk add bash; bash /qemu/docker_build.sh"
+docker run --rm -v "$SCRIPT_PATH:/qemu" alpine:3.22.0 sh -c "apk add bash; bash /qemu/docker_build.sh"
 docker run --rm -v "$SCRIPT_PATH:/qemu" ubuntu:24.04 sh -c "bash /qemu/docker_build_ovmf.sh"
 sudo chown -R $(whoami) $SCRIPT_PATH/build/
 

--- a/artifacts/qemu/docker_build.sh
+++ b/artifacts/qemu/docker_build.sh
@@ -7,7 +7,7 @@ apk update
 apk add gcc autoconf automake libtool sqlite ninja vim bash git python3 musl-dev build-base glib-dev gettext-dev shadow sudo meson iasl \
  glib-static gettext-static zlib-static util-linux-static bzip2-static ncurses-static libslirp-dev zlib-dev zlib-static libxkbcommon-static \
  libxkbcommon-dev libx11-static zstd-static zstd-dev zstd-libs libpng libpng-dev libpng-static libselinux libselinux-dev libselinux-static \
- libudev-zero libudev-zero-dev pixman pixman-dev pixman-static nasm perl
+ libudev-zero libudev-zero-dev pixman pixman-dev pixman-static nasm perl pcre2-static
 
 # install static libslirp
 git clone https://gitlab.freedesktop.org/slirp/libslirp.git /tmp/libslirp


### PR DESCRIPTION
This PR adds `pcre2-static` as a dependency for successfully building Qemu with the current stack. It also fixes the Alpine version in the Docker container to make sure the compatibility is kept and it is not broken because of new versions.