### PR TITLE
feat: add cvm-agent endpoint to list containers and fetch their logs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@
 !/nilcc-attester
 !/nilcc-agent
 !/nilcc-verifier
+!/cvm-agent
 !/Cargo.toml
 !/Cargo.lock
 !/artifacts/initramfs/build/kernel/kernel.deb

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,6 +526,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "bollard"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899ca34eb6924d6ec2a77c6f7f5c7339e60fd68235eaf91edd5a15f12958bb06"
+dependencies = [
+ "base64",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-named-pipe",
+ "hyper-util",
+ "hyperlocal",
+ "log",
+ "pin-project-lite",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "serde_urlencoded",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.48.3-rc.28.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ea257e555d16a2c01e5593f40b73865cdf12efbceda33c6d14a2d8d1490368"
+dependencies = [
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "serde_with",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -806,10 +851,17 @@ dependencies = [
 name = "cvm-agent"
 version = "0.1.0"
 dependencies = [
+ "axum",
+ "bollard",
  "clap",
+ "futures",
  "serde",
  "serde_json",
  "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "validator",
 ]
 
 [[package]]
@@ -1491,6 +1543,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-named-pipe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+dependencies = [
+ "hex",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+ "winapi",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.27.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1543,6 +1610,21 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -3420,6 +3502,17 @@ checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
 dependencies = [
  "itoa",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/artifacts/autoinstall_ubuntu/user-data-guest-cpu.yaml
+++ b/artifacts/autoinstall_ubuntu/user-data-guest-cpu.yaml
@@ -24,7 +24,7 @@ autoinstall:
   late-commands:
     - curtin in-target -- dpkg -i /cdrom/packages/*.deb
     - curtin in-target -- apt update
-    - curtin in-target -- apt install -y docker-compose-v2 jq
+    - curtin in-target -- apt install -y docker-compose-v2
     - curtin in-target -- apt purge -y linux-image-6.8* linux-headers-6.8* linux-tools-6.8*
     # Copy over cvm-agent.
     - curtin in-target -- mkdir /opt/nillion

--- a/artifacts/autoinstall_ubuntu/user-data-guest-gpu.yaml
+++ b/artifacts/autoinstall_ubuntu/user-data-guest-gpu.yaml
@@ -24,7 +24,7 @@ autoinstall:
   late-commands:
     - curtin in-target -- dpkg -i /cdrom/packages/*.deb
     - curtin in-target -- apt-get update
-    - curtin in-target -- apt-get -y install nvidia-driver-550-server-open docker-compose-v2 jq
+    - curtin in-target -- apt-get -y install nvidia-driver-550-server-open docker-compose-v2
     - curtin in-target -- bash -c 'echo "install nvidia /sbin/modprobe ecdsa_generic ecdh; /sbin/modprobe --ignore-install nvidia" > /etc/modprobe.d/nvidia-lkca.conf'
     - curtin in-target -- sed -i "/^ExecStart=/d" /usr/lib/systemd/system/nvidia-persistenced.service
     - curtin in-target -- bash -c 'echo "ExecStart=/usr/bin/nvidia-persistenced --user nvidia-persistenced --uvm-persistence-mode --verbose" >> /usr/lib/systemd/system/nvidia-persistenced.service'

--- a/cvm-agent/Cargo.toml
+++ b/cvm-agent/Cargo.toml
@@ -4,7 +4,14 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+axum = { version = "0.8", features = ["json"] }
+bollard = "0.19"
 clap = { version = "4.5", features = ["derive", "string"] }
+futures = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tempfile = "3.20"
+tokio = { version =  "1.46", features = ["macros", "process", "rt", "signal"] }
+tracing = "0.1"
+tracing-subscriber = "0.3"
+validator = { version = "0.20", features = ["derive"] }

--- a/cvm-agent/services/docker-compose.yaml
+++ b/cvm-agent/services/docker-compose.yaml
@@ -11,6 +11,7 @@ services:
       APP__SERVER__BIND_ENDPOINT: "0.0.0.0:80"
       APP__NILCC_VERSION: ${NILCC_VERSION}
       APP__VM_TYPE: ${NILCC_VM_TYPE}
+      NO_COLOR: 1
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost/health"]
 

--- a/cvm-agent/src/main.rs
+++ b/cvm-agent/src/main.rs
@@ -1,12 +1,27 @@
-use crate::resources::{ApplicationMetadata, Resources};
+use crate::{
+    resources::{ApplicationMetadata, Resources},
+    routes::create_router,
+};
+use bollard::Docker;
 use clap::{error::ErrorKind, CommandFactory, Parser};
 use std::{
     fs,
+    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
     path::{Path, PathBuf},
-    process::Command,
+    sync::Arc,
 };
-use tempfile::tempdir;
+use tempfile::{tempdir, TempDir};
+use tokio::{
+    net::TcpListener,
+    process::{Child, Command},
+    signal::{self, unix::SignalKind},
+};
+use tracing::{error, info};
+
+const COMPOSE_PROJECT_NAME: &str = "cvm";
+
 mod resources;
+mod routes;
 
 #[derive(Parser)]
 struct Cli {
@@ -17,6 +32,9 @@ struct Cli {
 
     #[clap(long, default_value = default_vm_type_path().into_os_string())]
     vm_type_path: PathBuf,
+
+    #[clap(long, default_value_t = default_bind_endpoint())]
+    bind_endpoint: SocketAddr,
 }
 
 fn default_version_path() -> PathBuf {
@@ -27,28 +45,31 @@ fn default_vm_type_path() -> PathBuf {
     "/opt/nillion/nilcc-vm-type".into()
 }
 
+fn default_bind_endpoint() -> SocketAddr {
+    SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 59666).into()
+}
+
 fn load_metadata(path: &Path) -> Result<ApplicationMetadata, Box<dyn std::error::Error>> {
     let metadata = fs::read_to_string(path)?;
     let metadata = serde_json::from_str(&metadata)?;
     Ok(metadata)
 }
 
-fn main() {
-    let cli = Cli::parse();
+fn launch_docker_compose(cli: &Cli) -> (TempDir, Child) {
     let metadata = match load_metadata(&cli.iso_mount_path.join("metadata.json")) {
         Ok(metadata) => metadata,
         Err(e) => {
             Cli::command().error(ErrorKind::InvalidValue, format!("could not load metadata: {e}")).exit();
         }
     };
-    let version = fs::read_to_string(cli.version_path).expect("failed to read version").trim().to_string();
-    let vm_type = fs::read_to_string(cli.vm_type_path).expect("failed to read version").trim().to_string();
-    let state_path = tempdir().expect("failed to create tempdir");
-    println!("Writing state files to {}", state_path.path().display());
+    let version = fs::read_to_string(&cli.version_path).expect("failed to read version").trim().to_string();
+    let vm_type = fs::read_to_string(&cli.vm_type_path).expect("failed to read version").trim().to_string();
+    let state_dir = tempdir().expect("failed to create tempdir");
+    println!("Writing state files to {}", state_dir.path().display());
 
     let resources = Resources::render(&metadata);
-    let our_compose_path = state_path.path().join("docker-compose.yaml");
-    let our_caddy_path = state_path.path().join("Caddyfile");
+    let our_compose_path = state_dir.path().join("docker-compose.yaml");
+    let our_caddy_path = state_dir.path().join("Caddyfile");
     fs::write(&our_compose_path, resources.docker_compose).expect("failed to write docker-compose.yaml");
     fs::write(&our_caddy_path, resources.caddyfile).expect("failed to write Caddyfile");
 
@@ -57,16 +78,59 @@ fn main() {
     let mut command = Command::new("docker");
     let command = command
         .current_dir(&cli.iso_mount_path)
+        // pass in `FILES` which points to `<iso>/files`
         .env("FILES", external_files_path.into_os_string())
+        // pass in other env vars that are needed by our compose file
         .env("CADDY_INPUT_FILE", our_caddy_path.into_os_string())
         .env("NILCC_VERSION", version)
         .env("NILCC_VM_TYPE", vm_type)
         .arg("compose")
+        // set a well defined project name, this is used as a prefix for container names
+        .arg("-p")
+        .arg(COMPOSE_PROJECT_NAME)
+        // point to the user provided compose file first
         .arg("-f")
         .arg(iso_compose_path)
+        // the outs
         .arg("-f")
         .arg(our_compose_path)
         .arg("up");
-    let mut handle = command.spawn().expect("failed to spawn docker");
-    handle.wait().expect("error while waiting for docker");
+    let child = command.spawn().expect("failed to spawn docker");
+    (state_dir, child)
+}
+
+async fn shutdown_signal(mut docker_compose: Child) {
+    let ctrl_c = async {
+        signal::ctrl_c().await.expect("failed to install ctrl-c handler");
+    };
+
+    let terminate = async {
+        signal::unix::signal(SignalKind::terminate()).expect("failed to install signal handler").recv().await;
+    };
+
+    tokio::select! {
+        _ = ctrl_c => {
+            info!("Received ctrl-c");
+        },
+        _ = terminate => {
+            info!("Received SIGTERM");
+        },
+        _ = docker_compose.wait() => {
+            info!("Docker compose child terminated")
+        }
+    }
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    tracing_subscriber::fmt().init();
+
+    let cli = Cli::parse();
+    let docker = Arc::new(Docker::connect_with_local_defaults().expect("failed to connect to docker daemon"));
+    let (_state_dir, compose_child) = launch_docker_compose(&cli);
+    let router = create_router(docker);
+    let listener = TcpListener::bind(cli.bind_endpoint).await.expect("failed to bind");
+    if let Err(e) = axum::serve(listener, router).with_graceful_shutdown(shutdown_signal(compose_child)).await {
+        error!("Failed to serve: {e}");
+    }
 }

--- a/cvm-agent/src/routes/containers/list.rs
+++ b/cvm-agent/src/routes/containers/list.rs
@@ -1,0 +1,33 @@
+use axum::{extract::State, http::StatusCode, Json};
+use bollard::{query_parameters::ListContainersOptionsBuilder, secret::ContainerSummaryStateEnum, Docker};
+use serde::Serialize;
+use std::sync::Arc;
+use tracing::error;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct Container {
+    names: Vec<String>,
+    image: String,
+    image_id: String,
+    state: String,
+}
+
+pub(crate) async fn handler(docker: State<Arc<Docker>>) -> Result<Json<Vec<Container>>, StatusCode> {
+    let options = ListContainersOptionsBuilder::new().all(true).build();
+    let containers = docker.list_containers(Some(options)).await.map_err(|e| {
+        error!("Failed to fetch logs: {e}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+    let containers = containers
+        .into_iter()
+        .map(|c| Container {
+            // get rid of the `/` at the beginning of container names
+            names: c.names.unwrap_or_default().into_iter().map(|n| n.trim_start_matches('/').to_string()).collect(),
+            image: c.image.unwrap_or_default(),
+            image_id: c.image_id.unwrap_or_default(),
+            state: c.state.unwrap_or(ContainerSummaryStateEnum::EMPTY).to_string(),
+        })
+        .collect();
+    Ok(Json(containers))
+}

--- a/cvm-agent/src/routes/containers/logs.rs
+++ b/cvm-agent/src/routes/containers/logs.rs
@@ -1,0 +1,56 @@
+use axum::{
+    extract::{Query, State},
+    http::StatusCode,
+    Json,
+};
+use bollard::{query_parameters::LogsOptionsBuilder, Docker};
+use futures::StreamExt;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use validator::Validate;
+
+#[derive(Deserialize, Validate)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ContainersLogsRequest {
+    container: String,
+    #[serde(default)]
+    tail: bool,
+    stream: OutputStream,
+    #[validate(range(max = 1000))]
+    max_lines: usize,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+enum OutputStream {
+    Stdout,
+    Stderr,
+}
+
+#[derive(Serialize)]
+pub(crate) struct ContainersLogsResponse {
+    lines: Vec<String>,
+}
+
+pub(crate) async fn handler(
+    docker: State<Arc<Docker>>,
+    request: Query<ContainersLogsRequest>,
+) -> Result<Json<ContainersLogsResponse>, StatusCode> {
+    let ContainersLogsRequest { container, tail, stream, max_lines } = request.0;
+    let mut builder = LogsOptionsBuilder::new();
+    if tail {
+        builder = builder.tail(&max_lines.to_string());
+    }
+    let builder = match stream {
+        OutputStream::Stdout => builder.stdout(true),
+        OutputStream::Stderr => builder.stderr(true),
+    };
+
+    let mut lines = Vec::new();
+    let mut stream = docker.logs(&container, Some(builder.build())).take(max_lines);
+    while let Some(output) = stream.next().await {
+        let output = output.map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        lines.push(String::from_utf8_lossy(&output.into_bytes()).trim().to_string());
+    }
+    Ok(Json(ContainersLogsResponse { lines }))
+}

--- a/cvm-agent/src/routes/containers/mod.rs
+++ b/cvm-agent/src/routes/containers/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod list;
+pub(crate) mod logs;

--- a/cvm-agent/src/routes/mod.rs
+++ b/cvm-agent/src/routes/mod.rs
@@ -1,0 +1,15 @@
+use axum::{routing::get, Router};
+use bollard::Docker;
+use std::sync::Arc;
+
+pub(crate) mod containers;
+
+pub fn create_router(docker: Arc<Docker>) -> Router {
+    Router::new().nest(
+        "/api/v1",
+        Router::new()
+            .route("/containers/logs", get(containers::logs::handler))
+            .route("/containers/list", get(containers::list::handler))
+            .with_state(docker),
+    )
+}


### PR DESCRIPTION
This adds 2 endpoints to `cvm-agent`:

* `/api/v1/containers/list` which lists the running containers. This is needed because `docker compose` mangles the container names a little (e.g. names look like `{project}-{container}-{replica}`). This is also probably something we want to expose anyway, since as a user I probably want to know at least if my containers are running. If we feel like transforming these names somewhere so we remove the `{project}` and `{replica}` portions I think that's good but should happen elsewhere since it's a presentation problem.
* `/api/v1/containers/log` which lets you get the logs for a container, capping log lines to a max of 1000 and allowing you to use `tail=true|false` to pull the last set of logs or the first one.

These endpoints will be exposed via nilcc-agent and nilcc-api in the next PR, since those are just (authenticated) proxies to the ones in cvm-agent.

Note that because we don't port forward this port (yet) it's unaccessible from the outside. In the next PR this will be forwarded as a local port so only nilcc-agent can hit it.