### PR TITLE
feat: add health check in cvm-agent and report back "running" to API

### DIFF
--- a/cvm-agent/src/routes/health.rs
+++ b/cvm-agent/src/routes/health.rs
@@ -1,0 +1,6 @@
+use axum::Json;
+
+// TODO: eventually expose information about e.g. docker
+pub(crate) async fn handler() -> Json<()> {
+    Json(())
+}

--- a/cvm-agent/src/routes/mod.rs
+++ b/cvm-agent/src/routes/mod.rs
@@ -3,11 +3,13 @@ use bollard::Docker;
 use std::sync::Arc;
 
 pub(crate) mod containers;
+pub(crate) mod health;
 
 pub fn create_router(docker: Arc<Docker>) -> Router {
     Router::new().nest(
         "/api/v1",
         Router::new()
+            .route("/health", get(health::handler))
             .route("/containers/logs", get(containers::logs::handler))
             .route("/containers/list", get(containers::list::handler))
             .with_state(docker),

--- a/nilcc-agent/src/clients/cvm_agent.rs
+++ b/nilcc-agent/src/clients/cvm_agent.rs
@@ -14,6 +14,8 @@ pub trait CvmAgentClient: Send + Sync {
     async fn list_containers(&self, cvm_agent_port: u16) -> anyhow::Result<Vec<Container>>;
 
     async fn logs(&self, cvm_agent_port: u16, request: &ContainerLogsRequest) -> anyhow::Result<ContainerLogsResponse>;
+
+    async fn check_health(&self, cvm_agent_port: u16) -> anyhow::Result<()>;
 }
 
 pub struct DefaultCvmAgentClient {
@@ -54,5 +56,9 @@ impl CvmAgentClient for DefaultCvmAgentClient {
 
     async fn logs(&self, cvm_agent_port: u16, request: &ContainerLogsRequest) -> anyhow::Result<ContainerLogsResponse> {
         self.get(cvm_agent_port, "/api/v1/containers/logs", &request).await
+    }
+
+    async fn check_health(&self, cvm_agent_port: u16) -> anyhow::Result<()> {
+        self.get(cvm_agent_port, "/api/v1/health", &()).await
     }
 }

--- a/nilcc-agent/src/clients/nilcc_api.rs
+++ b/nilcc-agent/src/clients/nilcc_api.rs
@@ -30,7 +30,8 @@ pub trait NilccApiClient: Send + Sync {
 #[derive(Debug, Clone, Serialize, PartialEq)]
 #[serde(tag = "kind", rename_all = "camelCase")]
 pub enum VmEvent {
-    Started,
+    Starting,
+    Running,
     Stopped,
     FailedToStart { error: String },
 }

--- a/nilcc-agent/src/main.rs
+++ b/nilcc-agent/src/main.rs
@@ -200,6 +200,7 @@ async fn run_daemon(config: AgentConfig) -> Result<()> {
     let vm_service = DefaultVmService::new(VmServiceArgs {
         vm_client,
         nilcc_api_client,
+        cvm_agent_client: cvm_agent_client.clone(),
         state_path: config.vm_store,
         disk_service: Box::new(DefaultDiskService::new(config.qemu.img_bin)),
         cvm_config: config.cvm,

--- a/nilcc-api/src/metal-instance/metal-instance.dto.ts
+++ b/nilcc-api/src/metal-instance/metal-instance.dto.ts
@@ -60,8 +60,9 @@ export type ListMetalInstancesResponse = z.infer<
 >;
 
 export const WorkloadEvent = z.discriminatedUnion("kind", [
-  z.object({ kind: z.literal("started") }),
+  z.object({ kind: z.literal("starting") }),
   z.object({ kind: z.literal("stopped") }),
+  z.object({ kind: z.literal("running") }),
   z.object({ kind: z.literal("failedToStart"), error: z.string() }),
 ]);
 export type WorkloadEvent = z.infer<typeof WorkloadEvent>;

--- a/nilcc-api/src/workload/workload.dto.ts
+++ b/nilcc-api/src/workload/workload.dto.ts
@@ -34,7 +34,7 @@ export type CreateWorkloadRequest = z.infer<typeof CreateWorkloadRequest>;
 
 export const CreateWorkloadResponse = CreateWorkloadRequest.extend({
   id: Uuid,
-  status: z.enum(["scheduled", "running", "stopped", "error"]),
+  status: z.enum(["scheduled", "starting", "running", "stopped", "error"]),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
 }).openapi({ ref: "CreateWorkloadResponse" });

--- a/nilcc-api/src/workload/workload.entity.ts
+++ b/nilcc-api/src/workload/workload.entity.ts
@@ -67,10 +67,10 @@ export class WorkloadEntity {
 
   @Column({
     type: "enum",
-    enum: ["scheduled", "running", "stopped", "error"],
+    enum: ["scheduled", "starting", "running", "stopped", "error"],
     default: "scheduled",
   })
-  status: "scheduled" | "running" | "stopped" | "error";
+  status: "scheduled" | "starting" | "running" | "stopped" | "error";
 
   @ManyToOne(
     () => MetalInstanceEntity,

--- a/nilcc-api/src/workload/workload.service.ts
+++ b/nilcc-api/src/workload/workload.service.ts
@@ -131,7 +131,10 @@ export class WorkloadService {
       throw new Error("workload not found");
     }
     switch (request.event.kind) {
-      case "started":
+      case "starting":
+        workload.status = "starting";
+        break;
+      case "running":
         workload.status = "running";
         break;
       case "stopped":

--- a/nilcc-api/tests/workload.test.ts
+++ b/nilcc-api/tests/workload.test.ts
@@ -9,8 +9,8 @@ import { createTestFixtureExtension } from "./fixture/it";
 describe("workload CRUD", () => {
   const { it, beforeAll, afterAll } = createTestFixtureExtension();
 
-  beforeAll(async (_ctx) => {});
-  afterAll(async (_ctx) => {});
+  beforeAll(async (_ctx) => { });
+  afterAll(async (_ctx) => { });
   let myWorkload: null | CreateWorkloadResponse = null;
 
   const createWorkloadRequest: CreateWorkloadRequest = {
@@ -139,7 +139,7 @@ services:
     const response = await userClient.submitEvent({
       agentId: myMetalInstance.id,
       workloadId: myWorkload.id,
-      event: { kind: "started" },
+      event: { kind: "starting" },
     });
     expect(response.status).toBe(200);
 
@@ -147,6 +147,6 @@ services:
       id: myWorkload.id,
     });
     const updatedWorkload = await updatedWorkloadResponse.parse_body();
-    expect(updatedWorkload.status).toBe("running");
+    expect(updatedWorkload.status).toBe("starting");
   });
 });


### PR DESCRIPTION
This adds a new health endpoint in cvm-agent. This is checked periodically after the VM is started until we get a successful response. nilcc-agent now sends 2 events to nilcc-api after a VM is started: one when it starts (`started`) and one when cvm-agent reports as healthy (`running`).

This gives us better visibility since otherwise a VM was considered to be "running" even while it's still booting, which is particularly bad for GPU machines that can take a few minutes to start.