### PR TITLE
fix: validate request models before handling them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,6 +416,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-valid"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3881b4b05ede123ff3c82f41c63e47425443556365b47b2ba4d05098a5bd2645"
+dependencies = [
+ "axum",
+ "validator",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -852,6 +862,7 @@ name = "cvm-agent"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "axum-valid",
  "bollard",
  "clap",
  "cvm-agent-models",
@@ -2141,6 +2152,7 @@ dependencies = [
  "async-trait",
  "axum",
  "axum-server",
+ "axum-valid",
  "chrono",
  "clap",
  "convert_case",

--- a/cvm-agent/Cargo.toml
+++ b/cvm-agent/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 axum = { version = "0.8", features = ["json"] }
+axum-valid = "0.24"
 bollard = "0.19"
 clap = { version = "4.5", features = ["derive", "string"] }
 futures = "0.3"

--- a/cvm-agent/src/routes/containers/logs.rs
+++ b/cvm-agent/src/routes/containers/logs.rs
@@ -3,6 +3,7 @@ use axum::{
     http::StatusCode,
     Json,
 };
+use axum_valid::Valid;
 use bollard::{query_parameters::LogsOptionsBuilder, Docker};
 use cvm_agent_models::logs::{ContainerLogsRequest, ContainerLogsResponse, OutputStream};
 use futures::StreamExt;
@@ -10,9 +11,9 @@ use std::sync::Arc;
 
 pub(crate) async fn handler(
     docker: State<Arc<Docker>>,
-    request: Query<ContainerLogsRequest>,
+    request: Valid<Query<ContainerLogsRequest>>,
 ) -> Result<Json<ContainerLogsResponse>, StatusCode> {
-    let ContainerLogsRequest { container, tail, stream, max_lines } = request.0;
+    let ContainerLogsRequest { container, tail, stream, max_lines } = request.0 .0;
     let mut builder = LogsOptionsBuilder::new();
     if tail {
         builder = builder.tail(&max_lines.to_string());

--- a/nilcc-agent/Cargo.toml
+++ b/nilcc-agent/Cargo.toml
@@ -8,6 +8,7 @@ anyhow = "1.0"
 async-trait = "0.1"
 axum = { version = "0.8", features = ["json"] }
 axum-server = "0.7"
+axum-valid = "0.24"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.5", features = ["derive", "env"] }
 hex = { version = "0.4", features = ["serde"] }

--- a/nilcc-agent/src/routes/mod.rs
+++ b/nilcc-agent/src/routes/mod.rs
@@ -8,11 +8,13 @@ use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::routing::{get, post};
 use axum::Router;
+use axum_valid::{HasValidate, HasValidateArgs};
 use convert_case::{Case, Casing};
 use serde::Serialize;
 use std::ops::Deref;
 use std::sync::Arc;
 use tower::ServiceBuilder;
+use validator::ValidateArgs;
 
 pub(crate) mod workloads;
 
@@ -102,5 +104,21 @@ where
 {
     fn into_response(self) -> axum::response::Response {
         axum::Json(self.0).into_response()
+    }
+}
+
+// `axum_valid` support for `Json`/`validator`
+
+impl<T> HasValidate for Json<T> {
+    type Validate = T;
+    fn get_validate(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<'v, T: ValidateArgs<'v>> HasValidateArgs<'v> for Json<T> {
+    type ValidateArgs = T;
+    fn get_validate_args(&self) -> &Self::ValidateArgs {
+        &self.0
     }
 }

--- a/nilcc-agent/src/routes/workloads/create.rs
+++ b/nilcc-agent/src/routes/workloads/create.rs
@@ -7,6 +7,7 @@ use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
 };
+use axum_valid::Valid;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_with::base64::Base64;
@@ -68,7 +69,7 @@ pub(crate) struct CreateWorkloadResponse {
 
 pub(crate) async fn handler(
     state: State<AppState>,
-    request: Json<CreateWorkloadRequest>,
+    request: Valid<Json<CreateWorkloadRequest>>,
 ) -> Result<Json<CreateWorkloadResponse>, HandlerError> {
     let limits = &state.resource_limits;
     let checks = [
@@ -83,7 +84,7 @@ pub(crate) async fn handler(
     }
 
     let id = request.id;
-    state.services.workload.create_workload(request.0).await?;
+    state.services.workload.create_workload(request.0 .0).await?;
     Ok(Json(CreateWorkloadResponse { id }))
 }
 


### PR DESCRIPTION
The `validator` crate doesn't automatically validate; this uses `axum_valid` to connect `axum` and `validator` so we validate the requests before we handle them.