### PR TITLE
fix: correctly handle > 100 hosted zones when querying route53

### DIFF
--- a/nilcc-api/src/env.ts
+++ b/nilcc-api/src/env.ts
@@ -135,11 +135,13 @@ async function buildServices(
       config.workloadsDnsZone,
       config.workloadsDnsDomain,
       config,
+      log,
     ),
     metalInstances: await createDnsService(
       config.metalInstancesDnsZone,
       config.metalInstancesDnsDomain,
       config,
+      log,
     ),
   };
   log.debug("Using DNS service: %s", dns.workloads.constructor.name);
@@ -192,6 +194,7 @@ async function createDnsService(
   zone: string,
   subdomain: string,
   config: EnvVars,
+  log: Logger,
 ): Promise<DnsService> {
   const localstackEnabled = hasFeatureFlag(
     config.enabledFeatures,
@@ -199,5 +202,5 @@ async function createDnsService(
   );
   return localstackEnabled
     ? await LocalStackDnsService.create(zone, subdomain)
-    : await Route53DnsService.create(zone, subdomain);
+    : await Route53DnsService.create(zone, subdomain, log);
 }

--- a/nilcc-api/tests/workload.test.ts
+++ b/nilcc-api/tests/workload.test.ts
@@ -9,8 +9,8 @@ import { createTestFixtureExtension } from "./fixture/it";
 describe("workload CRUD", () => {
   const { it, beforeAll, afterAll } = createTestFixtureExtension();
 
-  beforeAll(async (_ctx) => { });
-  afterAll(async (_ctx) => { });
+  beforeAll(async (_ctx) => {});
+  afterAll(async (_ctx) => {});
   let myWorkload: null | CreateWorkloadResponse = null;
 
   const createWorkloadRequest: CreateWorkloadRequest = {


### PR DESCRIPTION
The code that was querying route53 hosted zones was not handling the fact that this API returns up to 100 and you need to use the `NextMarker` attribute to fetch the next chunk.