### PR TITLE
feat: persist and expose workload events

### DIFF
--- a/nilcc-api/package.json
+++ b/nilcc-api/package.json
@@ -47,6 +47,7 @@
     "temporal-polyfill": "^0.3.0",
     "tsx": "^4.19.4",
     "typeorm": "^0.3.24",
+    "uuid": "^11.1.0",
     "yaml": "^2.8.0",
     "zod": "^3.25.13",
     "zod-openapi": "^4.2.4",

--- a/nilcc-api/pnpm-lock.yaml
+++ b/nilcc-api/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       typeorm:
         specifier: ^0.3.24
         version: 0.3.24(pg@8.16.0)(reflect-metadata@0.2.2)
+      uuid:
+        specifier: ^11.1.0
+        version: 11.1.0
       yaml:
         specifier: ^2.8.0
         version: 2.8.0

--- a/nilcc-api/src/common/errors.ts
+++ b/nilcc-api/src/common/errors.ts
@@ -150,6 +150,18 @@ export class SubmitEventError extends AppError {
   tag = "SubmitEventError";
 }
 
+export class ListWorkloadEventsError extends AppError {
+  tag = "ListWorkloadEventsError";
+}
+
+export class ListContainersError extends AppError {
+  tag = "ListContainersError";
+}
+
+export class ContainerLogsError extends AppError {
+  tag = "ContainerLogsError";
+}
+
 export class HttpError extends AppError {
   tag = "HttpError";
   statusCode: ContentfulStatusCode;

--- a/nilcc-api/src/common/paths.ts
+++ b/nilcc-api/src/common/paths.ts
@@ -20,6 +20,7 @@ export const PathsV1 = {
     remove: PathSchema.parse("/api/v1/workloads/:id"),
     events: {
       submit: PathSchema.parse("/api/v1/workloads/~/events/submit"),
+      list: PathSchema.parse("/api/v1/workloads/~/events/list"),
     },
     containers: {
       list: PathSchema.parse("/api/v1/workloads/~/containers/list"),

--- a/nilcc-api/src/data-source.ts
+++ b/nilcc-api/src/data-source.ts
@@ -4,7 +4,10 @@ import type { Logger } from "pino";
 import { DataSource } from "typeorm";
 import { type EnvVars, FeatureFlag, hasFeatureFlag } from "#/env";
 import { MetalInstanceEntity } from "#/metal-instance/metal-instance.entity";
-import { WorkloadEntity } from "#/workload/workload.entity";
+import {
+  WorkloadEntity,
+  WorkloadEventEntity,
+} from "#/workload/workload.entity";
 
 export async function buildDataSource(
   config: EnvVars,
@@ -18,7 +21,7 @@ export async function buildDataSource(
   const dataSource = new DataSource({
     type: "postgres",
     url: config.dbUri,
-    entities: [WorkloadEntity, MetalInstanceEntity],
+    entities: [WorkloadEntity, MetalInstanceEntity, WorkloadEventEntity],
     synchronize,
     logging: false,
   });

--- a/nilcc-api/src/metal-instance/metal-instance.dto.ts
+++ b/nilcc-api/src/metal-instance/metal-instance.dto.ts
@@ -59,19 +59,20 @@ export type ListMetalInstancesResponse = z.infer<
   typeof ListMetalInstancesResponse
 >;
 
-export const WorkloadEvent = z.discriminatedUnion("kind", [
+export const WorkloadEventKind = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("created") }),
   z.object({ kind: z.literal("starting") }),
   z.object({ kind: z.literal("stopped") }),
   z.object({ kind: z.literal("running") }),
   z.object({ kind: z.literal("failedToStart"), error: z.string() }),
 ]);
-export type WorkloadEvent = z.infer<typeof WorkloadEvent>;
+export type WorkloadEventKind = z.infer<typeof WorkloadEventKind>;
 
 export const SubmitEventRequest = z
   .object({
     agentId: Uuid,
     workloadId: Uuid,
-    event: WorkloadEvent,
+    event: WorkloadEventKind,
   })
   .openapi({ ref: "SubmitEventRequest" });
 export type SubmitEventRequest = z.infer<typeof SubmitEventRequest>;

--- a/nilcc-api/src/workload/workload.dto.ts
+++ b/nilcc-api/src/workload/workload.dto.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { Container, ContainerLogsRequest } from "#/clients/nilcc-agent.client";
 import { Uuid } from "#/common/types";
+import { WorkloadEventKind } from "#/metal-instance/metal-instance.dto";
 
 const FILENAME_REGEX = /^[\w/._-]+$/;
 
@@ -72,4 +73,31 @@ export const WorkloadContainerLogsResponse = z
   .openapi({ ref: "WorkloadContainerLogsResponse" });
 export type WorkloadContainerLogsResponse = z.infer<
   typeof WorkloadContainerLogsResponse
+>;
+
+export const WorkloadEvent = z
+  .object({
+    id: Uuid,
+    details: WorkloadEventKind,
+    timestamp: z.string().datetime(),
+  })
+  .openapi({ ref: "WorkloadEvent" });
+export type WorkloadEvent = z.infer<typeof WorkloadEvent>;
+
+export const ListWorkloadEventsRequest = z
+  .object({
+    workloadId: Uuid,
+  })
+  .openapi({ ref: "ListWorkloadEventsRequest" });
+export type ListWorkloadEventsRequest = z.infer<
+  typeof ListWorkloadEventsRequest
+>;
+
+export const ListWorkloadEventsResponse = z
+  .object({
+    events: WorkloadEvent.array(),
+  })
+  .openapi({ ref: "ListWorkloadEventsResponse" });
+export type ListWorkloadEventsResponse = z.infer<
+  typeof ListWorkloadEventsResponse
 >;

--- a/nilcc-api/src/workload/workload.entity.ts
+++ b/nilcc-api/src/workload/workload.entity.ts
@@ -1,4 +1,10 @@
-import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
+import {
+  Column,
+  Entity,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+} from "typeorm";
 import { z } from "zod";
 import { MetalInstanceEntity } from "#/metal-instance/metal-instance.entity";
 
@@ -65,11 +71,7 @@ export class WorkloadEntity {
   @Column({ type: "int" })
   disk: number;
 
-  @Column({
-    type: "enum",
-    enum: ["scheduled", "starting", "running", "stopped", "error"],
-    default: "scheduled",
-  })
+  @Column({ type: "varchar", default: "scheduled" })
   status: "scheduled" | "starting" | "running" | "stopped" | "error";
 
   @ManyToOne(
@@ -78,9 +80,37 @@ export class WorkloadEntity {
   )
   metalInstance: MetalInstanceEntity;
 
+  @OneToMany(
+    () => WorkloadEventEntity,
+    (events) => events.workload,
+  )
+  events: WorkloadEventEntity[];
+
   @Column({ type: "timestamp" })
   createdAt: Date;
 
   @Column({ type: "timestamp" })
   updatedAt: Date;
+}
+
+@Entity()
+export class WorkloadEventEntity {
+  @PrimaryGeneratedColumn("uuid")
+  id: string;
+
+  @ManyToOne(
+    () => WorkloadEntity,
+    (workload) => workload.events,
+    { onDelete: "CASCADE" },
+  )
+  workload: WorkloadEntity;
+
+  @Column({ type: "varchar" })
+  event: "created" | "starting" | "running" | "stopped" | "failedToStart";
+
+  @Column({ type: "varchar", nullable: true })
+  details?: string;
+
+  @Column({ type: "timestamp" })
+  timestamp: Date;
 }

--- a/nilcc-api/src/workload/workload.router.ts
+++ b/nilcc-api/src/workload/workload.router.ts
@@ -7,4 +7,5 @@ export function buildWorkloadRouter(options: ControllerOptions): void {
   WorkloadController.read(options);
   WorkloadController.remove(options);
   WorkloadController.submitEvent(options);
+  WorkloadController.listEvents(options);
 }

--- a/nilcc-api/tests/fixture/test-client.ts
+++ b/nilcc-api/tests/fixture/test-client.ts
@@ -12,6 +12,8 @@ import {
   type CreateWorkloadRequest,
   CreateWorkloadResponse,
   GetWorkloadResponse,
+  type ListWorkloadEventsRequest,
+  ListWorkloadEventsResponse,
   ListWorkloadsResponse,
 } from "#/workload/workload.dto";
 
@@ -112,20 +114,14 @@ export class UserClient extends TestClient {
         method: "GET",
       },
     );
-    return new ParseableResponse<GetWorkloadResponse>(
-      response,
-      GetWorkloadResponse,
-    );
+    return new ParseableResponse(response, GetWorkloadResponse);
   }
 
   async listWorkloads(): Promise<ParseableResponse<ListWorkloadsResponse>> {
     const response = await this.request(PathsV1.workload.list, {
       method: "GET",
     });
-    return new ParseableResponse<ListWorkloadsResponse>(
-      response,
-      ListWorkloadsResponse,
-    );
+    return new ParseableResponse(response, ListWorkloadsResponse);
   }
 
   async deleteWorkload(params: { id: string }): Promise<Response> {
@@ -142,10 +138,7 @@ export class UserClient extends TestClient {
         method: "GET",
       },
     );
-    return new ParseableResponse<GetMetalInstanceResponse>(
-      response,
-      GetMetalInstanceResponse,
-    );
+    return new ParseableResponse(response, GetMetalInstanceResponse);
   }
 
   async submitEvent(request: SubmitEventRequest) {
@@ -156,6 +149,16 @@ export class UserClient extends TestClient {
         "x-api-key": this.bindings.config.metalInstanceApiKey,
       },
     });
+  }
+
+  async getWorkloadEvents(
+    request: ListWorkloadEventsRequest,
+  ): Promise<ParseableResponse<ListWorkloadEventsResponse>> {
+    const response = await this.request(PathsV1.workload.events.list, {
+      method: "POST",
+      body: request,
+    });
+    return new ParseableResponse(response, ListWorkloadEventsResponse);
   }
 }
 

--- a/nilcc-api/tests/workload.test.ts
+++ b/nilcc-api/tests/workload.test.ts
@@ -148,5 +148,15 @@ services:
     });
     const updatedWorkload = await updatedWorkloadResponse.parse_body();
     expect(updatedWorkload.status).toBe("starting");
+
+    const eventsResponse = await userClient.getWorkloadEvents({
+      workloadId: myWorkload.id,
+    });
+    expect(eventsResponse.response.status).toBe(200);
+
+    const eventsBody = await eventsResponse.parse_body();
+    expect(eventsBody.events).toHaveLength(2);
+    const eventKinds = eventsBody.events.map((e) => e.details.kind);
+    expect(eventKinds).toEqual(["created", "starting"]);
   });
 });


### PR DESCRIPTION
This extends the events endpoint created in #126 to persist those events in postgres and expose them via a new endpoint.

Closes #151