### PR TITLE
feat: open 443 udp port to enable browser QUIC connections

### DIFF
--- a/cvm-agent/services/Caddyfile
+++ b/cvm-agent/services/Caddyfile
@@ -1,3 +1,9 @@
+{
+    servers {
+        protocols h1 h2
+    }
+}
+
 (ssl_config) {
     tls {
         protocols tls1.2 tls1.3

--- a/cvm-agent/src/resources.rs
+++ b/cvm-agent/src/resources.rs
@@ -42,7 +42,13 @@ mod tests {
             api: ContainerMetadata { container: "api".into(), port: 1337 },
         };
         let caddyfile = Resources::render(&metadata).caddyfile;
-        let expected = "(ssl_config) {
+        let expected = "{
+    servers {
+        protocols h1 h2
+    }
+}
+
+(ssl_config) {
     tls {
         protocols tls1.2 tls1.3
     }


### PR DESCRIPTION
For nilAI webpages to work, some browsers used QUICK to connect to Caddy through port 443 UDP. This PR opens that port for the cvm-agent so that they are reachable from the browser