### PR TITLE
feat: add nilcc-agent cli

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 
 !/nilcc-attester
 !/nilcc-agent
+!/nilcc-agent-cli
 !/nilcc-verifier
 !/cvm-agent
 !/crates

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2155,7 +2155,6 @@ dependencies = [
  "axum-valid",
  "chrono",
  "clap",
- "convert_case",
  "cvm-agent-models",
  "hex",
  "humantime",
@@ -2163,9 +2162,9 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "mockall",
+ "nilcc-agent-models",
  "once_cell",
  "qapi",
- "regex",
  "reqwest",
  "rstest",
  "rustls-acme",
@@ -2186,6 +2185,31 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-test",
+ "uuid",
+ "validator",
+]
+
+[[package]]
+name = "nilcc-agent-cli"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "nilcc-agent-models",
+ "reqwest",
+ "serde",
+ "thiserror 2.0.12",
+ "uuid",
+]
+
+[[package]]
+name = "nilcc-agent-models"
+version = "0.1.0"
+dependencies = [
+ "convert_case",
+ "regex",
+ "serde",
+ "serde_with",
  "uuid",
  "validator",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,10 @@ resolver = "2"
 
 members = [
   "crates/cvm-agent-models",
+  "crates/nilcc-agent-models", 
   "cvm-agent",
   "nilcc-attester",
   "nilcc-agent",
-  "nilcc-verifier", 
+  "nilcc-agent-cli", 
+  "nilcc-verifier",
 ]

--- a/crates/nilcc-agent-models/Cargo.toml
+++ b/crates/nilcc-agent-models/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "nilcc-agent-models"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+convert_case = "0.8"
+serde = { version = "1.0", features = ["derive"] }
+regex = "1.11"
+serde_with = { version = "3.14", features = ["base64"] }
+uuid = { version = "1.17", features = ["serde"] }
+validator = { version = "0.20", features = ["derive"] }

--- a/crates/nilcc-agent-models/src/lib.rs
+++ b/crates/nilcc-agent-models/src/lib.rs
@@ -1,0 +1,123 @@
+use convert_case::{Case, Casing};
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use serde_with::base64::Base64;
+use serde_with::serde_as;
+use std::collections::HashMap;
+use std::sync::LazyLock;
+use uuid::Uuid;
+use validator::{Validate, ValidationError};
+
+pub mod workloads {
+    use super::*;
+
+    pub mod create {
+        use super::*;
+
+        static FILENAME_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^[\w/._-]+$").unwrap());
+
+        fn validate_files(files: &HashMap<String, Vec<u8>>) -> Result<(), ValidationError> {
+            for key in files.keys() {
+                if !FILENAME_REGEX.is_match(key) {
+                    return Err(ValidationError::new("invalid filename"));
+                }
+            }
+            Ok(())
+        }
+
+        #[serde_as]
+        #[derive(Clone, Debug, Serialize, Deserialize, Validate)]
+        pub struct CreateWorkloadRequest {
+            pub id: Uuid,
+
+            pub docker_compose: String,
+
+            #[serde(default)]
+            pub env_vars: HashMap<String, String>,
+
+            #[serde_as(deserialize_as = "HashMap<_, Base64>")]
+            #[serde(default)]
+            #[validate(custom(function = "validate_files"))]
+            pub files: HashMap<String, Vec<u8>>,
+
+            pub public_container_name: String,
+
+            pub public_container_port: u16,
+
+            #[validate(range(min = 512))]
+            pub memory_mb: u32,
+
+            #[validate(range(min = 1))]
+            pub cpus: u32,
+
+            pub gpus: u16,
+
+            #[validate(range(min = 2))]
+            pub disk_space_gb: u32,
+
+            pub domain: String,
+        }
+
+        #[derive(Clone, Debug, Serialize, Deserialize)]
+        pub struct CreateWorkloadResponse {
+            pub id: Uuid,
+        }
+    }
+
+    pub mod delete {
+        use super::*;
+
+        #[derive(Clone, Debug, Serialize, Deserialize)]
+        pub struct DeleteWorkloadRequest {
+            pub id: Uuid,
+        }
+    }
+
+    pub mod start {
+        use super::*;
+
+        #[derive(Clone, Debug, Serialize, Deserialize)]
+        pub struct StartWorkloadRequest {
+            pub id: Uuid,
+        }
+    }
+
+    pub mod stop {
+        use super::*;
+
+        #[derive(Clone, Debug, Serialize, Deserialize)]
+        pub struct StopWorkloadRequest {
+            pub id: Uuid,
+        }
+    }
+
+    pub mod restart {
+        use super::*;
+
+        #[derive(Clone, Debug, Serialize, Deserialize)]
+        pub struct RestartWorkloadRequest {
+            pub id: Uuid,
+        }
+    }
+}
+
+pub mod errors {
+    use super::*;
+
+    /// An error when handling a request.
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct RequestHandlerError {
+        /// A descriptive message about the error that was encountered.
+        pub message: String,
+
+        /// The error code.
+        pub error_code: String,
+    }
+
+    impl RequestHandlerError {
+        pub fn new(message: impl Into<String>, error_code: impl AsRef<str>) -> Self {
+            let error_code = error_code.as_ref().to_case(Case::UpperSnake);
+            Self { message: message.into(), error_code }
+        }
+    }
+}

--- a/nilcc-agent-cli/Cargo.toml
+++ b/nilcc-agent-cli/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "nilcc-agent-cli"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anyhow = "1"
+clap = { version = "4.5", features = ["derive", "env"] }
+serde = "1.0"
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "json"] }
+thiserror = "2.0"
+uuid = { version = "1.17", features = ["v4"] }
+
+nilcc-agent-models = { path = "../crates/nilcc-agent-models" }

--- a/nilcc-agent-cli/src/main.rs
+++ b/nilcc-agent-cli/src/main.rs
@@ -1,0 +1,230 @@
+use crate::api::ApiClient;
+use anyhow::Context;
+use clap::{Args, Parser, Subcommand};
+use nilcc_agent_models::workloads::{
+    create::{CreateWorkloadRequest, CreateWorkloadResponse},
+    delete::DeleteWorkloadRequest,
+};
+use std::{fs, path::PathBuf, process::exit, str::FromStr};
+use uuid::Uuid;
+
+mod api;
+
+#[derive(Parser)]
+struct Cli {
+    #[clap(long, env = "NILCC_AGENT_URL")]
+    url: String,
+
+    #[clap(long, env = "NILCC_AGENT_API_KEY")]
+    api_key: String,
+
+    #[clap(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Launch a workload.
+    Launch(LaunchArgs),
+
+    /// Delete a workload.
+    Delete(DeleteArgs),
+
+    /// Start a workload
+    Start(StartArgs),
+
+    /// Stop a workload.
+    Stop(StopArgs),
+
+    /// Restart a workload.
+    Restart(RestartArgs),
+}
+
+#[derive(Args)]
+struct LaunchArgs {
+    /// The id to use for the workload.
+    #[clap(long)]
+    id: Option<Uuid>,
+
+    /// The environment variables to be set, in the format `<name>=<value>`.
+    #[clap(short, long = "env-var")]
+    env_vars: Vec<KeyValue>,
+
+    /// The files to be included in the ISO image, in the format `<name>=<value>`.
+    #[clap(short, long = "file")]
+    files: Vec<KeyValue>,
+
+    /// The container entrypoint, in the format `<container-name>:<container-port>`
+    #[clap(long)]
+    entrypoint: Entrypoint,
+
+    /// The number of CPUs to use in the VM.
+    #[clap(long, default_value_t = 1)]
+    cpus: u32,
+
+    /// The number of GPUs to use in the VM.
+    #[clap(long, default_value_t = 0)]
+    gpus: u16,
+
+    /// The amount of RAM, in MBs.
+    #[clap(long, default_value_t = 2048)]
+    memory_mb: u32,
+
+    /// The amount of disk space, in GBs, to use for the VM's state disk.
+    #[clap(long = "disk-space", default_value_t = 10)]
+    disk_space_gb: u32,
+
+    /// The domain for the VM.
+    #[clap(long)]
+    domain: String,
+
+    /// The path to the docker compose file to be used.
+    #[clap(long = "docker-compose")]
+    docker_compose_path: PathBuf,
+}
+
+#[derive(Args)]
+struct DeleteArgs {
+    /// The identifier of the workload to be deleted.
+    id: Uuid,
+}
+
+#[derive(Args)]
+struct StopArgs {
+    /// The identifier of the workload to be stopped.
+    id: Uuid,
+}
+
+#[derive(Args)]
+struct StartArgs {
+    /// The identifier of the workload to be started.
+    id: Uuid,
+}
+
+#[derive(Args)]
+struct RestartArgs {
+    /// The identifier of the workload to be restarted.
+    id: Uuid,
+}
+
+#[derive(Clone)]
+struct KeyValue {
+    key: String,
+    value: String,
+}
+
+impl FromStr for KeyValue {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (key, value) = s.split_once('=').ok_or("missing '='")?;
+        let key = key.to_string();
+        let value = value.to_string();
+        Ok(Self { key, value })
+    }
+}
+
+#[derive(Clone)]
+struct Entrypoint {
+    container: String,
+    port: u16,
+}
+
+impl FromStr for Entrypoint {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (container, port) = s.split_once(':').ok_or("missing ':'")?;
+        let container = container.to_string();
+        let port = port.parse().map_err(|_| "invalid port")?;
+        Ok(Self { container, port })
+    }
+}
+
+fn launch(client: ApiClient, args: LaunchArgs) -> anyhow::Result<()> {
+    let LaunchArgs {
+        id,
+        env_vars,
+        files,
+        entrypoint,
+        cpus,
+        gpus,
+        memory_mb,
+        disk_space_gb,
+        domain,
+        docker_compose_path,
+    } = args;
+    let docker_compose = fs::read_to_string(docker_compose_path).context("Failed to read docker compose")?;
+    let env_vars = env_vars.into_iter().map(|kv| (kv.key, kv.value)).collect();
+    let files = files
+        .into_iter()
+        .map(|f| fs::read(&f.value).map(|contents| (f.key, contents)).context("Failed to read file"))
+        .collect::<Result<_, _>>()?;
+    let request = CreateWorkloadRequest {
+        id: id.unwrap_or_else(Uuid::new_v4),
+        docker_compose,
+        env_vars,
+        files,
+        public_container_name: entrypoint.container,
+        public_container_port: entrypoint.port,
+        memory_mb,
+        cpus,
+        gpus,
+        disk_space_gb,
+        domain,
+    };
+    let response: CreateWorkloadResponse = client.post("/api/v1/workloads/create", &request)?;
+    let CreateWorkloadResponse { id } = response;
+    println!("Workload id {id} launched");
+    Ok(())
+}
+
+fn delete(client: ApiClient, args: DeleteArgs) -> anyhow::Result<()> {
+    let DeleteArgs { id } = args;
+    let request = DeleteWorkloadRequest { id };
+    let _: () = client.post("/api/v1/workloads/delete", &request)?;
+    println!("Workload {id} deleted");
+    Ok(())
+}
+
+fn start(client: ApiClient, args: StartArgs) -> anyhow::Result<()> {
+    let StartArgs { id } = args;
+    let request = DeleteWorkloadRequest { id };
+    let _: () = client.post("/api/v1/workloads/start", &request)?;
+    println!("Workload {id} started");
+    Ok(())
+}
+
+fn stop(client: ApiClient, args: StopArgs) -> anyhow::Result<()> {
+    let StopArgs { id } = args;
+    let request = DeleteWorkloadRequest { id };
+    let _: () = client.post("/api/v1/workloads/stop", &request)?;
+    println!("Workload {id} stopped");
+    Ok(())
+}
+
+fn restart(client: ApiClient, args: RestartArgs) -> anyhow::Result<()> {
+    let RestartArgs { id } = args;
+    let request = DeleteWorkloadRequest { id };
+    let _: () = client.post("/api/v1/workloads/restart", &request)?;
+    println!("Workload {id} restarted");
+    Ok(())
+}
+
+fn main() {
+    let cli = Cli::parse();
+    let Cli { url, api_key, command } = cli;
+
+    let client = ApiClient::new(url, &api_key);
+    let result = match command {
+        Command::Launch(args) => launch(client, args),
+        Command::Delete(args) => delete(client, args),
+        Command::Start(args) => start(client, args),
+        Command::Stop(args) => stop(client, args),
+        Command::Restart(args) => restart(client, args),
+    };
+    if let Err(e) = result {
+        eprintln!("Failed to run command: {e:#}");
+        exit(1);
+    }
+}

--- a/nilcc-agent/Cargo.toml
+++ b/nilcc-agent/Cargo.toml
@@ -18,7 +18,6 @@ metrics = "0.24"
 metrics-exporter-prometheus = { version = "0.17", default-features = false, features = ["http-listener"] }
 once_cell = "1.20"
 qapi = { version = "0.15", features = ["qmp", "async-tokio-all"] }
-regex = "1.11"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
 rustls-acme = { version = "0.14", features = ["axum"] }
 serde = { version = "1.0", features = ["derive"] }
@@ -34,13 +33,13 @@ tera = { version = "1", default-features = false }
 thiserror = "2"
 tokio = { version = "1.44", features = ["rt-multi-thread", "macros", "net", "process", "time", "fs", "signal"] }
 tower = "0.5"
-convert_case = "0.8"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
 uuid = { version = "1.17", features = ["serde", "v4"] }
 validator = { version = "0.20", features = ["derive"] }
 
 cvm-agent-models = { path = "../crates/cvm-agent-models" }
+nilcc-agent-models = { path = "../crates/nilcc-agent-models" }
 
 [dev-dependencies]
 mockall = "0.13"

--- a/nilcc-agent/src/auth.rs
+++ b/nilcc-agent/src/auth.rs
@@ -1,9 +1,10 @@
-use crate::routes::{Json, RequestHandlerError};
+use crate::routes::Json;
 use axum::body::Body;
 use axum::http::header::AUTHORIZATION;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::{extract::Request, response::Response};
+use nilcc_agent_models::errors::RequestHandlerError;
 use std::convert::Infallible;
 use std::{
     pin::Pin,

--- a/nilcc-agent/src/routes/mod.rs
+++ b/nilcc-agent/src/routes/mod.rs
@@ -9,7 +9,7 @@ use axum::response::IntoResponse;
 use axum::routing::{get, post};
 use axum::Router;
 use axum_valid::{HasValidate, HasValidateArgs};
-use convert_case::{Case, Casing};
+use nilcc_agent_models::errors::RequestHandlerError;
 use serde::Serialize;
 use std::ops::Deref;
 use std::sync::Arc;
@@ -49,23 +49,6 @@ pub fn build_router(state: AppState, token: String) -> Router {
             .with_state(state)
             .layer(ServiceBuilder::new().layer(AuthLayer::new(token))),
     )
-}
-
-/// An error when handling a request.
-#[derive(Debug, Serialize)]
-pub struct RequestHandlerError {
-    /// A descriptive message about the error that was encountered.
-    pub(crate) message: String,
-
-    /// The error code.
-    pub(crate) error_code: String,
-}
-
-impl RequestHandlerError {
-    pub(crate) fn new(message: impl Into<String>, error_code: impl AsRef<str>) -> Self {
-        let error_code = error_code.as_ref().to_case(Case::UpperSnake);
-        Self { message: message.into(), error_code }
-    }
 }
 
 /// A type that behaves like `axum::Json` but provides JSON structured errors when parsing fails.

--- a/nilcc-agent/src/routes/workloads/create.rs
+++ b/nilcc-agent/src/routes/workloads/create.rs
@@ -8,64 +8,9 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use axum_valid::Valid;
-use regex::Regex;
-use serde::{Deserialize, Serialize};
-use serde_with::base64::Base64;
-use serde_with::serde_as;
-use std::{collections::HashMap, sync::LazyLock};
+use nilcc_agent_models::workloads::create::{CreateWorkloadRequest, CreateWorkloadResponse};
 use strum::EnumDiscriminants;
 use tracing::error;
-use uuid::Uuid;
-use validator::{Validate, ValidationError};
-
-static FILENAME_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^[\w/._-]+$").unwrap());
-
-fn beep(files: &HashMap<String, Vec<u8>>) -> Result<(), ValidationError> {
-    for key in files.keys() {
-        if !FILENAME_REGEX.is_match(key) {
-            return Err(ValidationError::new("invalid filename"));
-        }
-    }
-    Ok(())
-}
-
-#[serde_as]
-#[derive(Clone, Debug, Deserialize, Validate)]
-pub struct CreateWorkloadRequest {
-    pub(crate) id: Uuid,
-
-    pub(crate) docker_compose: String,
-
-    #[serde(default)]
-    pub(crate) env_vars: HashMap<String, String>,
-
-    #[serde_as(deserialize_as = "HashMap<_, Base64>")]
-    #[serde(default)]
-    #[validate(custom(function = "beep"))]
-    pub(crate) files: HashMap<String, Vec<u8>>,
-
-    pub(crate) public_container_name: String,
-
-    pub(crate) public_container_port: u16,
-
-    #[validate(range(min = 512))]
-    pub(crate) memory_mb: u32,
-
-    #[validate(range(min = 1))]
-    pub(crate) cpus: u32,
-
-    pub(crate) gpus: u16,
-
-    #[validate(range(min = 2))]
-    pub(crate) disk_space_gb: u32,
-
-    pub(crate) domain: String,
-}
-
-#[derive(Clone, Debug, Serialize)]
-pub(crate) struct CreateWorkloadResponse {
-    pub(crate) id: Uuid,
-}
 
 pub(crate) async fn handler(
     state: State<AppState>,

--- a/nilcc-agent/src/routes/workloads/delete.rs
+++ b/nilcc-agent/src/routes/workloads/delete.rs
@@ -3,13 +3,7 @@ use crate::{
     services::workload::WorkloadLookupError,
 };
 use axum::extract::State;
-use serde::Deserialize;
-use uuid::Uuid;
-
-#[derive(Clone, Debug, Deserialize)]
-pub(crate) struct DeleteWorkloadRequest {
-    pub(crate) id: Uuid,
-}
+use nilcc_agent_models::workloads::delete::DeleteWorkloadRequest;
 
 pub(crate) async fn handler(
     state: State<AppState>,

--- a/nilcc-agent/src/routes/workloads/restart.rs
+++ b/nilcc-agent/src/routes/workloads/restart.rs
@@ -3,13 +3,7 @@ use crate::{
     services::workload::WorkloadLookupError,
 };
 use axum::extract::State;
-use serde::Deserialize;
-use uuid::Uuid;
-
-#[derive(Clone, Debug, Deserialize)]
-pub(crate) struct RestartWorkloadRequest {
-    pub(crate) id: Uuid,
-}
+use nilcc_agent_models::workloads::restart::RestartWorkloadRequest;
 
 pub(crate) async fn handler(
     state: State<AppState>,

--- a/nilcc-agent/src/routes/workloads/start.rs
+++ b/nilcc-agent/src/routes/workloads/start.rs
@@ -3,13 +3,7 @@ use crate::{
     services::workload::WorkloadLookupError,
 };
 use axum::extract::State;
-use serde::Deserialize;
-use uuid::Uuid;
-
-#[derive(Clone, Debug, Deserialize)]
-pub(crate) struct StartWorkloadRequest {
-    pub(crate) id: Uuid,
-}
+use nilcc_agent_models::workloads::start::StartWorkloadRequest;
 
 pub(crate) async fn handler(
     state: State<AppState>,

--- a/nilcc-agent/src/routes/workloads/stop.rs
+++ b/nilcc-agent/src/routes/workloads/stop.rs
@@ -3,13 +3,7 @@ use crate::{
     services::workload::WorkloadLookupError,
 };
 use axum::extract::State;
-use serde::Deserialize;
-use uuid::Uuid;
-
-#[derive(Clone, Debug, Deserialize)]
-pub(crate) struct StopWorkloadRequest {
-    pub(crate) id: Uuid,
-}
+use nilcc_agent_models::workloads::stop::StopWorkloadRequest;
 
 pub(crate) async fn handler(
     state: State<AppState>,

--- a/nilcc-agent/src/services/workload.rs
+++ b/nilcc-agent/src/services/workload.rs
@@ -1,7 +1,6 @@
 use crate::{
     repositories::workload::{Workload, WorkloadRepository, WorkloadRepositoryError},
     resources::{GpuAddress, SystemResources},
-    routes::workloads::create::CreateWorkloadRequest,
     services::{
         proxy::{ProxiedVm, ProxyService},
         vm::{StartVmError, VmService},
@@ -9,6 +8,7 @@ use crate::{
     workers::vm::InitialVmState,
 };
 use async_trait::async_trait;
+use nilcc_agent_models::workloads::create::CreateWorkloadRequest;
 use std::{collections::BTreeSet, io, ops::Range};
 use strum::EnumDiscriminants;
 use tokio::sync::Mutex;


### PR DESCRIPTION
This adds an initial version of the nilcc-agent CLI. This for now allows launching, starting, stoping, restarting, and deleting workloads. This is intended to be a testing tool to run against a local nilcc-agent.

Example usage:

```bash
ubuntu@nilcc-cpu-dev:~/matias$ ./nilcc-agent-cli --api-key my_auth_token --url http://127.0.0.1:50055 launch --docker-compose tmp/docker-compose.yaml --domain foo.com --entrypoint greeter:80
Workload id 0cf0a468-58c1-41fe-a1e2-3500ca5dc071 launched
ubuntu@nilcc-cpu-dev:~/matias$ ./nilcc-agent-cli --api-key my_auth_token --url http://127.0.0.1:50055 stop 0cf0a468-58c1-41fe-a1e2-3500ca5dc071
Workload 0cf0a468-58c1-41fe-a1e2-3500ca5dc071 stopped
ubuntu@nilcc-cpu-dev:~/matias$ ./nilcc-agent-cli --api-key my_auth_token --url http://127.0.0.1:50055 start 0cf0a468-58c1-41fe-a1e2-3500ca5dc071
Workload 0cf0a468-58c1-41fe-a1e2-3500ca5dc071 started
ubuntu@nilcc-cpu-dev:~/matias$ ./nilcc-agent-cli --api-key my_auth_token --url http://127.0.0.1:50055 delete 0cf0a468-58c1-41fe-a1e2-3500ca5dc071
Workload 0cf0a468-58c1-41fe-a1e2-3500ca5dc071 deleted
ubuntu@nilcc-cpu-dev:~/matias$ ./nilcc-agent-cli --api-key my_auth_token --url http://127.0.0.1:50055 start 0cf0a468-58c1-41fe-a1e2-3500ca5dc071
Failed to run command: api error, code = WORKLOAD_NOT_FOUND, details = workload not found
ubuntu@nilcc-cpu-dev:~/matias$ ./nilcc-agent-cli --api-key my_auth_token --url http://127.0.0.1:50055 launch --docker-compose tmp/docker-compose.yaml --domain foo.com --entrypoint greeter:80 --gpus 2
Failed to run command: api error, code = INSUFFICIENT_RESOURCES, details = not enough GPUs avalable
ubuntu@nilcc-cpu-dev:~/matias$
```

Note that the url and API keys can be set via env vars.

Relates to #154