### PR TITLE
feat: add nilcc-agent-cli support for container requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2195,9 +2195,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "cvm-agent-models",
  "nilcc-agent-models",
  "reqwest",
  "serde",
+ "serde_json",
  "thiserror 2.0.12",
  "uuid",
 ]

--- a/nilcc-agent-cli/Cargo.toml
+++ b/nilcc-agent-cli/Cargo.toml
@@ -7,8 +7,10 @@ edition = "2024"
 anyhow = "1"
 clap = { version = "4.5", features = ["derive", "env"] }
 serde = "1.0"
+serde_json = "1.0"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json"] }
 thiserror = "2.0"
 uuid = { version = "1.17", features = ["v4"] }
 
 nilcc-agent-models = { path = "../crates/nilcc-agent-models" }
+cvm-agent-models = { path = "../crates/cvm-agent-models" }


### PR DESCRIPTION
This adds nilcc-agent-cli support for the containers list and logs endpoints.

```
ubuntu@nilcc-cpu-dev:~/matias$ ./nilcc-agent-cli containers list 3bcfb227-d95c-48f1-b203-8090d888a905
[
  {
    "names": [
      "cvm-nilcc-attester-1"
    ],
    "image": "ghcr.io/nillionnetwork/nilcc-attester:latest",
    "imageId": "sha256:320e2cbb4aec16596556baf697e1221084c7992f534dfa02ec77dbc09767cf19",
    "state": "running"
  },
  {
    "names": [
      "cvm-nilcc-proxy-1"
    ],
    "image": "caddy:2",
    "imageId": "sha256:6ddf74dfb6187e856dab57d2bf87ab6ae10f093dd7ced7ec1f6d485eff7e7649",
    "state": "running"
  },
  {
    "names": [
      "cvm-greeter-1"
    ],
    "image": "ubuntu:latest",
    "imageId": "sha256:65ae7a6f3544bd2d2b6d19b13bfc64752d776bc92c510f874188bfd404d205a3",
    "state": "exited"
  }
]
ubuntu@nilcc-cpu-dev:~/matias$ ./nilcc-agent-cli containers logs 3bcfb227-d95c-48f1-b203-8090d888a905 --container cvm-greeter-1
hi mom
ubuntu@nilcc-cpu-dev:~/matias$
```

Closes #154