### PR TITLE
feat: add list workloads endpoint and command in nilcc-agent-cli

### DIFF
--- a/crates/nilcc-agent-models/src/lib.rs
+++ b/crates/nilcc-agent-models/src/lib.rs
@@ -64,6 +64,22 @@ pub mod workloads {
         }
     }
 
+    pub mod list {
+        use super::*;
+
+        #[derive(Clone, Debug, Serialize, Deserialize)]
+        pub struct ListWorkloadsRequest {
+            pub id: Uuid,
+        }
+
+        #[derive(Clone, Debug, Serialize, Deserialize)]
+        pub struct WorkloadSummary {
+            pub id: Uuid,
+            pub enabled: bool,
+            pub domain: String,
+        }
+    }
+
     pub mod delete {
         use super::*;
 

--- a/nilcc-agent-cli/src/main.rs
+++ b/nilcc-agent-cli/src/main.rs
@@ -8,6 +8,7 @@ use cvm_agent_models::{
 use nilcc_agent_models::workloads::{
     create::{CreateWorkloadRequest, CreateWorkloadResponse},
     delete::DeleteWorkloadRequest,
+    list::WorkloadSummary,
 };
 use std::{fs, path::PathBuf, process::exit, str::FromStr};
 use uuid::Uuid;
@@ -30,6 +31,9 @@ struct Cli {
 enum Command {
     /// Launch a workload.
     Launch(LaunchArgs),
+
+    /// List workloads.
+    List,
 
     /// Delete a workload.
     Delete(DeleteArgs),
@@ -225,6 +229,13 @@ fn launch(client: ApiClient, args: LaunchArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
+fn list(client: ApiClient) -> anyhow::Result<()> {
+    let workloads: Vec<WorkloadSummary> = client.get("/api/v1/workloads/list")?;
+    let containers = serde_json::to_string_pretty(&workloads).expect("failed to serialize");
+    println!("{containers}");
+    Ok(())
+}
+
 fn delete(client: ApiClient, args: DeleteArgs) -> anyhow::Result<()> {
     let DeleteArgs { id } = args;
     let request = DeleteWorkloadRequest { id };
@@ -284,6 +295,7 @@ fn main() {
     let client = ApiClient::new(url, &api_key);
     let result = match command {
         Command::Launch(args) => launch(client, args),
+        Command::List => list(client),
         Command::Delete(args) => delete(client, args),
         Command::Start(args) => start(client, args),
         Command::Stop(args) => stop(client, args),

--- a/nilcc-agent/src/routes/mod.rs
+++ b/nilcc-agent/src/routes/mod.rs
@@ -44,6 +44,7 @@ pub fn build_router(state: AppState, token: String) -> Router {
             .route("/workloads/restart", post(workloads::restart::handler))
             .route("/workloads/stop", post(workloads::stop::handler))
             .route("/workloads/start", post(workloads::start::handler))
+            .route("/workloads/list", get(workloads::list::handler))
             .route("/workloads/{workload_id}/containers/list", get(workloads::containers::list::handler))
             .route("/workloads/{workload_id}/containers/logs", get(workloads::containers::logs::handler))
             .with_state(state)

--- a/nilcc-agent/src/routes/workloads/list.rs
+++ b/nilcc-agent/src/routes/workloads/list.rs
@@ -1,0 +1,10 @@
+use crate::{routes::AppState, services::workload::WorkloadLookupError};
+use axum::{extract::State, Json};
+use nilcc_agent_models::workloads::list::WorkloadSummary;
+
+pub(crate) async fn handler(state: State<AppState>) -> Result<Json<Vec<WorkloadSummary>>, WorkloadLookupError> {
+    let workloads = state.services.workload.list_workloads().await?;
+    let workloads =
+        workloads.into_iter().map(|w| WorkloadSummary { id: w.id, enabled: w.enabled, domain: w.domain }).collect();
+    Ok(Json(workloads))
+}

--- a/nilcc-agent/src/routes/workloads/mod.rs
+++ b/nilcc-agent/src/routes/workloads/mod.rs
@@ -7,6 +7,7 @@ use tracing::error;
 pub(crate) mod containers;
 pub(crate) mod create;
 pub(crate) mod delete;
+pub(crate) mod list;
 pub(crate) mod restart;
 pub(crate) mod start;
 pub(crate) mod stop;

--- a/nilcc-agent/src/services/workload.rs
+++ b/nilcc-agent/src/services/workload.rs
@@ -19,6 +19,7 @@ use uuid::Uuid;
 #[async_trait]
 pub trait WorkloadService: Send + Sync {
     async fn create_workload(&self, request: CreateWorkloadRequest) -> Result<(), CreateWorkloadError>;
+    async fn list_workloads(&self) -> Result<Vec<Workload>, WorkloadLookupError>;
     async fn delete_workload(&self, id: Uuid) -> Result<(), WorkloadLookupError>;
     async fn restart_workload(&self, id: Uuid) -> Result<(), WorkloadLookupError>;
     async fn stop_workload(&self, id: Uuid) -> Result<(), WorkloadLookupError>;
@@ -237,6 +238,10 @@ impl WorkloadService for DefaultWorkloadService {
         resources.memory_mb -= memory_mb;
         resources.disk_space_gb -= disk_space_gb;
         Ok(())
+    }
+
+    async fn list_workloads(&self) -> Result<Vec<Workload>, WorkloadLookupError> {
+        Ok(self.repository.list().await?)
     }
 
     async fn delete_workload(&self, id: Uuid) -> Result<(), WorkloadLookupError> {


### PR DESCRIPTION
This adds an endpoint in nilcc-agent to get a list of the running workloads and a corresponding subcommand in nilcc-agent-cli. This for now only returns the id, whether it's enabled, and the public domain. We can add more as needed but this is mostly to see what's running more than anything.

Relates to #154