### PR TITLE
chore: return nicer errors in cvm-agent

### DIFF
--- a/nilcc-agent/src/resources.rs
+++ b/nilcc-agent/src/resources.rs
@@ -170,6 +170,11 @@ impl IsPublic for Ipv4Addr {
         // TODO: use `Ipv4Addr::is_global` when stabilized
         let octets = self.octets();
 
+        // 127.0.0.0/8
+        if octets[0] == 127 {
+            return false;
+        }
+
         // 10.0.0.0/8
         if octets[0] == 10 {
             return false;
@@ -187,6 +192,11 @@ impl IsPublic for Ipv4Addr {
 
         // 172.16.0.0/12
         if octets[0] == 172 && octets[1] >= 16 && octets[1] <= 31 {
+            return false;
+        }
+
+        // 100.64.0.0/10
+        if octets[0] == 100 && (octets[1] & 0xc0) == 64 {
             return false;
         }
 

--- a/nilcc-agent/src/routes/workloads/containers/mod.rs
+++ b/nilcc-agent/src/routes/workloads/containers/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod logs;
 pub(crate) enum CvmAgentHandlerError {
     Internal(String),
     WorkloadNotFound,
+    ContainerNotFound,
 }
 
 impl From<WorkloadLookupError> for CvmAgentHandlerError {
@@ -33,6 +34,7 @@ impl IntoResponse for CvmAgentHandlerError {
                 (StatusCode::INTERNAL_SERVER_ERROR, "internal error".to_string())
             }
             Self::WorkloadNotFound => (StatusCode::NOT_FOUND, "workload not found".into()),
+            Self::ContainerNotFound => (StatusCode::NOT_FOUND, "container not found".into()),
         };
         let response = RequestHandlerError::new(message, format!("{discriminant:?}"));
         (code, Json(response)).into_response()


### PR DESCRIPTION
This improves errors when nilcc-agent talks to cvm-agent. Specifically, when fetching container logs it first checks that the container exists and otherwise returns 404, which is handled by nilcc-agent to return a nicer error.