### PR TITLE
fix(cd): nilcc-api image deployment role ARN

### DIFF
--- a/.github/workflows/nilcc-api-cd.yml
+++ b/.github/workflows/nilcc-api-cd.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: "arn:aws:iam::054037142884:role/nilcc-github"
+          role-to-assume: "arn:aws:iam::054037142884:role/nilcc-api-github"
           aws-region: "us-east-1"
 
       - uses: aws-actions/amazon-ecr-login@v2


### PR DESCRIPTION
Since the deployment role was overridden in NillionNetwork/devops#7c0d090, this changed the role ARN