### PR TITLE
chore: don't use auto generated uuids

### DIFF
--- a/nilcc-api/src/metal-instance/metal-instance.entity.ts
+++ b/nilcc-api/src/metal-instance/metal-instance.entity.ts
@@ -1,9 +1,9 @@
-import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from "typeorm";
+import { Column, Entity, OneToMany, PrimaryColumn } from "typeorm";
 import { WorkloadEntity } from "#/workload/workload.entity";
 
 @Entity()
 export class MetalInstanceEntity {
-  @PrimaryGeneratedColumn("uuid")
+  @PrimaryColumn({ type: "uuid" })
   id: string;
 
   @Column({ type: "varchar" })

--- a/nilcc-api/src/workload/workload.entity.ts
+++ b/nilcc-api/src/workload/workload.entity.ts
@@ -1,16 +1,10 @@
-import {
-  Column,
-  Entity,
-  ManyToOne,
-  OneToMany,
-  PrimaryGeneratedColumn,
-} from "typeorm";
+import { Column, Entity, ManyToOne, OneToMany, PrimaryColumn } from "typeorm";
 import { z } from "zod";
 import { MetalInstanceEntity } from "#/metal-instance/metal-instance.entity";
 
 @Entity()
 export class WorkloadEntity {
-  @PrimaryGeneratedColumn("uuid")
+  @PrimaryColumn({ type: "uuid" })
   id: string;
 
   @Column({ type: "varchar" })
@@ -95,7 +89,7 @@ export class WorkloadEntity {
 
 @Entity()
 export class WorkloadEventEntity {
-  @PrimaryGeneratedColumn("uuid")
+  @PrimaryColumn({ type: "uuid" })
   id: string;
 
   @ManyToOne(

--- a/nilcc-api/src/workload/workload.service.ts
+++ b/nilcc-api/src/workload/workload.service.ts
@@ -74,6 +74,7 @@ export class WorkloadService {
     const now = new Date();
     const entity = repository.create({
       ...workload,
+      id: uuidv4(),
       metalInstance,
       createdAt: now,
       updatedAt: now,


### PR DESCRIPTION
This otherwise requires enabling an extension in postgres and the `devops` cycle takes a day.