### PR TITLE
feat: add `/health` endpoint to nilcc-api

### DIFF
--- a/nilcc-api/src/app.ts
+++ b/nilcc-api/src/app.ts
@@ -14,6 +14,7 @@ import {
 } from "./env";
 import { buildMetalInstanceRouter } from "./metal-instance/metal-instance.router";
 import { createOpenApiRouter } from "./openapi/openapi.router";
+import { buildSystemRouter } from "./system/system.router";
 import { buildWorkloadRouter } from "./workload/workload.router";
 
 export type App = Hono<AppEnv>;
@@ -39,6 +40,7 @@ export async function buildApp(
 
   buildWorkloadRouter({ app, bindings });
   buildMetalInstanceRouter({ app, bindings });
+  buildSystemRouter({ app, bindings });
 
   const { printMetrics, registerMetrics } = prometheus();
   app.use("*", registerMetrics);

--- a/nilcc-api/src/common/paths.ts
+++ b/nilcc-api/src/common/paths.ts
@@ -33,4 +33,7 @@ export const PathsV1 = {
     read: PathSchema.parse("/api/v1/metal-instances/:id"),
     list: PathSchema.parse("/api/v1/metal-instances"),
   },
+  system: {
+    health: PathSchema.parse("/health"),
+  },
 } as const;

--- a/nilcc-api/src/system/system.controllers.ts
+++ b/nilcc-api/src/system/system.controllers.ts
@@ -1,0 +1,29 @@
+import { describeRoute } from "hono-openapi";
+import { PathsV1 } from "#/common/paths";
+import type { ControllerOptions } from "#/common/types";
+
+export function health(options: ControllerOptions): void {
+  const { app } = options;
+
+  app.get(
+    PathsV1.system.health,
+    describeRoute({
+      tags: ["System"],
+      summary: "Health check",
+      responses: {
+        200: {
+          description: "OK",
+          content: {
+            "text/plain": {
+              schema: {
+                type: "string",
+                example: "OK",
+              },
+            },
+          },
+        },
+      },
+    }),
+    async (c) => c.text("OK"),
+  );
+}

--- a/nilcc-api/src/system/system.router.ts
+++ b/nilcc-api/src/system/system.router.ts
@@ -1,0 +1,6 @@
+import type { ControllerOptions } from "#/common/types";
+import * as SystemController from "./system.controllers";
+
+export function buildSystemRouter(options: ControllerOptions): void {
+  SystemController.health(options);
+}


### PR DESCRIPTION
This adds a health endpoint, which is required by the LB's health checks.