### PR TITLE
fix: don't use `null` for attributes serialized as JSON

### DIFF
--- a/nilcc-api/src/workload/workload.entity.ts
+++ b/nilcc-api/src/workload/workload.entity.ts
@@ -27,7 +27,7 @@ export class WorkloadEntity {
         value
           ? z.record(z.string(), z.string()).parse(value) &&
             JSON.stringify(value)
-          : null,
+          : undefined,
       from: (value?: string) => (value ? JSON.parse(value) : {}),
     },
   })
@@ -41,7 +41,7 @@ export class WorkloadEntity {
         value
           ? z.record(z.string(), z.string()).parse(value) &&
             JSON.stringify(value)
-          : null,
+          : undefined,
       from: (value?: string) => (value ? JSON.parse(value) : {}),
     },
   })


### PR DESCRIPTION
> This bug would not happen in rust.
> \- Napoleon Bonaparte