### PR TITLE
fix: rollback transactions for reals

### DIFF
--- a/nilcc-api/src/data-source.ts
+++ b/nilcc-api/src/data-source.ts
@@ -43,8 +43,12 @@ export function transactionMiddleware(dataSource: DataSource) {
       c.set("txQueryRunner", queryRunner);
 
       await next();
-
-      await queryRunner.commitTransaction();
+      const statusCode = c.res.status;
+      if (statusCode >= 200 && statusCode < 300) {
+        await queryRunner.commitTransaction();
+      } else {
+        await queryRunner.rollbackTransaction();
+      }
     } catch (error) {
       await queryRunner.rollbackTransaction();
       throw error;

--- a/nilcc-api/src/workload/workload.entity.ts
+++ b/nilcc-api/src/workload/workload.entity.ts
@@ -28,7 +28,7 @@ export class WorkloadEntity {
           ? z.record(z.string(), z.string()).parse(value) &&
             JSON.stringify(value)
           : undefined,
-      from: (value?: string) => (value ? JSON.parse(value) : {}),
+      from: (value?: string) => (value ? JSON.parse(value) : undefined),
     },
   })
   envVars?: Record<string, string>;
@@ -42,7 +42,7 @@ export class WorkloadEntity {
           ? z.record(z.string(), z.string()).parse(value) &&
             JSON.stringify(value)
           : undefined,
-      from: (value?: string) => (value ? JSON.parse(value) : {}),
+      from: (value?: string) => (value ? JSON.parse(value) : undefined),
     },
   })
   files?: Record<string, string>;


### PR DESCRIPTION
The error handler was transforming the response before the transaction middleware could rollback the transaction so in the end we were getting all transactions committed regardless of what happened.