### PR TITLE
fix: use correct workloads domain when calling nilcc-agent

### DIFF
--- a/nilcc-api/src/workload/workload.controllers.ts
+++ b/nilcc-api/src/workload/workload.controllers.ts
@@ -67,7 +67,12 @@ export function create(options: ControllerOptions): void {
           payload,
           c.get("txQueryRunner"),
         );
-        return c.json(workloadMapper.entityToResponse(workload));
+        return c.json(
+          workloadMapper.entityToResponse(
+            workload,
+            bindings.config.workloadsDnsDomain,
+          ),
+        );
       } catch (e: unknown) {
         if (
           e instanceof CreateEntityError &&
@@ -109,7 +114,14 @@ export function list(options: ControllerOptions): void {
     responseValidator(bindings, CreateWorkloadResponse.array()),
     async (c) => {
       const workloads = await bindings.services.workload.list(bindings);
-      return c.json(workloads.map(workloadMapper.entityToResponse));
+      return c.json(
+        workloads.map((w) =>
+          workloadMapper.entityToResponse(
+            w,
+            bindings.config.workloadsDnsDomain,
+          ),
+        ),
+      );
     },
   );
 }
@@ -147,7 +159,12 @@ export function read(options: ControllerOptions): void {
       if (!workload) {
         return c.notFound();
       }
-      return c.json(workloadMapper.entityToResponse(workload));
+      return c.json(
+        workloadMapper.entityToResponse(
+          workload,
+          bindings.config.workloadsDnsDomain,
+        ),
+      );
     },
   );
 }

--- a/nilcc-api/src/workload/workload.dto.ts
+++ b/nilcc-api/src/workload/workload.dto.ts
@@ -38,6 +38,7 @@ export const CreateWorkloadResponse = CreateWorkloadRequest.extend({
   status: z.enum(["scheduled", "starting", "running", "stopped", "error"]),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
+  domain: z.string(),
 }).openapi({ ref: "CreateWorkloadResponse" });
 export type CreateWorkloadResponse = z.infer<typeof CreateWorkloadResponse>;
 

--- a/nilcc-api/src/workload/workload.mapper.ts
+++ b/nilcc-api/src/workload/workload.mapper.ts
@@ -2,7 +2,10 @@ import type { CreateWorkloadResponse } from "#/workload/workload.dto";
 import type { WorkloadEntity } from "#/workload/workload.entity";
 
 export const workloadMapper = {
-  entityToResponse(workload: WorkloadEntity): CreateWorkloadResponse {
+  entityToResponse(
+    workload: WorkloadEntity,
+    workloadsDomain: string,
+  ): CreateWorkloadResponse {
     return {
       id: workload.id,
       name: workload.name,
@@ -17,6 +20,7 @@ export const workloadMapper = {
       gpus: workload.gpus,
       disk: workload.disk,
       status: workload.status,
+      domain: `${workload.id}.${workloadsDomain}`,
       createdAt: workload.createdAt.toISOString(),
       updatedAt: workload.updatedAt.toISOString(),
     };

--- a/nilcc-api/src/workload/workload.service.ts
+++ b/nilcc-api/src/workload/workload.service.ts
@@ -274,7 +274,7 @@ export class WorkloadService {
       metalInstanceDomain,
       "CNAME",
     );
-    return metalInstanceDomain;
+    return `${workloadId}.${bindings.config.workloadsDnsDomain}`;
   }
 
   async removeCnameForWorkload(

--- a/nilcc-api/tests/workload.test.ts
+++ b/nilcc-api/tests/workload.test.ts
@@ -81,6 +81,9 @@ services:
     );
     myWorkload = await myWorkloadResponse.parse_body();
     expect(myWorkload.name).equals(createWorkloadRequest.name);
+    expect(myWorkload.domain).equals(
+      `${myWorkload.id}.workloads.public.localhost`,
+    );
   });
 
   it("should fail to create a workload if it doesn't fit in the metal instance", async ({


### PR DESCRIPTION
The domain being passed along to nilcc-agent was ".agents" rather than ".workloads" which caused it to not work.