### PR TITLE
fix: use transactions in all workload controllers

### DIFF
--- a/nilcc-api/src/metal-instance/metal-instance.service.ts
+++ b/nilcc-api/src/metal-instance/metal-instance.service.ts
@@ -57,7 +57,7 @@ export class MetalInstanceService {
   async createOrUpdate(
     bindings: AppBindings,
     request: RegisterMetalInstanceRequest,
-    tx?: QueryRunner,
+    tx: QueryRunner,
   ) {
     const maybeMetalInstance = await this.read(bindings, request.id, tx);
     if (maybeMetalInstance) {
@@ -69,7 +69,7 @@ export class MetalInstanceService {
   async heartbeat(
     bindings: AppBindings,
     request: HeartbeatRequest,
-    tx?: QueryRunner,
+    tx: QueryRunner,
   ) {
     const metalInstance = await this.read(bindings, request.id, tx);
     if (metalInstance === null) {
@@ -130,7 +130,7 @@ export class MetalInstanceService {
     bindings: AppBindings,
     metalInstance: RegisterMetalInstanceRequest,
     currentMetalInstance: MetalInstanceEntity,
-    tx?: QueryRunner,
+    tx: QueryRunner,
   ) {
     const repository = this.getRepository(bindings, tx);
     currentMetalInstance.agentVersion = metalInstance.agentVersion;
@@ -156,7 +156,7 @@ export class MetalInstanceService {
   async create(
     bindings: AppBindings,
     request: RegisterMetalInstanceRequest,
-    tx?: QueryRunner,
+    tx: QueryRunner,
   ) {
     const repository = this.getRepository(bindings, tx);
     const now = new Date();

--- a/nilcc-api/src/workload/workload.controllers.ts
+++ b/nilcc-api/src/workload/workload.controllers.ts
@@ -112,8 +112,12 @@ export function list(options: ControllerOptions): void {
     }),
     apiKey(bindings.config.userApiKey),
     responseValidator(bindings, CreateWorkloadResponse.array()),
+    transactionMiddleware(bindings.dataSource),
     async (c) => {
-      const workloads = await bindings.services.workload.list(bindings);
+      const workloads = await bindings.services.workload.list(
+        bindings,
+        c.get("txQueryRunner"),
+      );
       return c.json(
         workloads.map((w) =>
           workloadMapper.entityToResponse(
@@ -149,12 +153,14 @@ export function read(options: ControllerOptions): void {
     }),
     apiKey(bindings.config.userApiKey),
     paramsValidator(idParamSchema),
+    transactionMiddleware(bindings.dataSource),
     responseValidator(bindings, GetWorkloadResponse),
     async (c) => {
       const params = c.req.valid("param");
       const workload = await bindings.services.workload.read(
         bindings,
         params.id,
+        c.get("txQueryRunner"),
       );
       if (!workload) {
         return c.notFound();
@@ -185,11 +191,13 @@ export function remove(options: ControllerOptions): void {
     }),
     apiKey(bindings.config.userApiKey),
     paramsValidator(idParamSchema),
+    transactionMiddleware(bindings.dataSource),
     async (c) => {
       const workloadId = c.req.valid("param").id;
       const deleted = await bindings.services.workload.remove(
         bindings,
         workloadId,
+        c.get("txQueryRunner"),
       );
       if (!deleted) {
         return c.notFound();
@@ -250,12 +258,14 @@ export function listEvents(options: ControllerOptions) {
     }),
     apiKey(bindings.config.userApiKey),
     zValidator("json", ListWorkloadEventsRequest),
+    transactionMiddleware(bindings.dataSource),
     responseValidator(bindings, ListWorkloadEventsResponse),
     async (c) => {
       const payload = c.req.valid("json");
       const events = await bindings.services.workload.listEvents(
         bindings,
         payload,
+        c.get("txQueryRunner"),
       );
       return c.json({ events });
     },
@@ -283,12 +293,14 @@ export function listContainers(options: ControllerOptions) {
     }),
     apiKey(bindings.config.metalInstanceApiKey),
     zValidator("json", ListContainersRequest),
+    transactionMiddleware(bindings.dataSource),
     responseValidator(bindings, ListContainersResponse),
     async (c) => {
       const payload = c.req.valid("json");
       const containers = await bindings.services.workload.listContainers(
         bindings,
         payload,
+        c.get("txQueryRunner"),
       );
       return c.json(containers);
     },
@@ -316,12 +328,14 @@ export function containerLogs(options: ControllerOptions) {
     }),
     apiKey(bindings.config.metalInstanceApiKey),
     zValidator("json", WorkloadContainerLogsRequest),
+    transactionMiddleware(bindings.dataSource),
     responseValidator(bindings, WorkloadContainerLogsResponse),
     async (c) => {
       const payload = c.req.valid("json");
       const logs = await bindings.services.workload.containerLogs(
         bindings,
         payload,
+        c.get("txQueryRunner"),
       );
       return c.json(logs);
     },

--- a/nilcc-api/src/workload/workload.service.ts
+++ b/nilcc-api/src/workload/workload.service.ts
@@ -32,7 +32,7 @@ export class WorkloadService {
   @mapError((e) => new GetRepositoryError(e))
   getRepository(
     bindings: AppBindings,
-    tx?: QueryRunner,
+    tx: QueryRunner,
   ): Repository<WorkloadEntity> {
     if (tx) {
       return tx.manager.getRepository(WorkloadEntity);
@@ -103,8 +103,11 @@ export class WorkloadService {
   }
 
   @mapError((e) => new FindEntityError(WorkloadEntity, e))
-  async list(bindings: AppBindings): Promise<WorkloadEntity[]> {
-    const repository = this.getRepository(bindings);
+  async list(
+    bindings: AppBindings,
+    tx: QueryRunner,
+  ): Promise<WorkloadEntity[]> {
+    const repository = this.getRepository(bindings, tx);
     return await repository.find();
   }
 
@@ -112,14 +115,19 @@ export class WorkloadService {
   async read(
     bindings: AppBindings,
     workloadId: string,
+    tx: QueryRunner,
   ): Promise<WorkloadEntity | null> {
-    const repository = this.getRepository(bindings);
+    const repository = this.getRepository(bindings, tx);
     return await repository.findOneBy({ id: workloadId });
   }
 
   @mapError((e) => new RemoveEntityError(WorkloadEntity, e))
-  async remove(bindings: AppBindings, workloadId: string): Promise<boolean> {
-    const workloadRepository = this.getRepository(bindings);
+  async remove(
+    bindings: AppBindings,
+    workloadId: string,
+    tx: QueryRunner,
+  ): Promise<boolean> {
+    const workloadRepository = this.getRepository(bindings, tx);
     const workloads = await workloadRepository.find({
       where: { id: workloadId },
       relations: ["metalInstance"],
@@ -184,8 +192,9 @@ export class WorkloadService {
   async listEvents(
     bindings: AppBindings,
     request: ListWorkloadEventsRequest,
+    tx: QueryRunner,
   ): Promise<Array<WorkloadEvent>> {
-    const repository = this.getRepository(bindings);
+    const repository = this.getRepository(bindings, tx);
     const workloads = await repository.find({
       where: { id: request.workloadId },
       relations: ["events"],
@@ -224,7 +233,7 @@ export class WorkloadService {
   async listContainers(
     bindings: AppBindings,
     request: ListContainersRequest,
-    tx?: QueryRunner,
+    tx: QueryRunner,
   ): Promise<Array<Container>> {
     const workloadRepository = this.getRepository(bindings, tx);
     const workloads = await workloadRepository.find({
@@ -245,7 +254,7 @@ export class WorkloadService {
   async containerLogs(
     bindings: AppBindings,
     request: WorkloadContainerLogsRequest,
-    tx?: QueryRunner,
+    tx: QueryRunner,
   ): Promise<Array<string>> {
     const workloadRepository = this.getRepository(bindings, tx);
     const workloads = await workloadRepository.find({


### PR DESCRIPTION
This passes the query runner to every workload service function since most of them do more than one thing and we want transactions.