### PR TITLE
fix: various nilcc-agent fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2181,6 +2181,7 @@ dependencies = [
  "test-with",
  "thiserror 2.0.12",
  "tokio",
+ "tokio-stream",
  "tower",
  "tracing",
  "tracing-subscriber",

--- a/crates/nilcc-agent-models/src/lib.rs
+++ b/crates/nilcc-agent-models/src/lib.rs
@@ -27,6 +27,7 @@ pub mod workloads {
 
         #[serde_as]
         #[derive(Clone, Debug, Serialize, Deserialize, Validate)]
+        #[serde(rename_all = "camelCase")]
         pub struct CreateWorkloadRequest {
             pub id: Uuid,
 
@@ -59,6 +60,7 @@ pub mod workloads {
         }
 
         #[derive(Clone, Debug, Serialize, Deserialize)]
+        #[serde(rename_all = "camelCase")]
         pub struct CreateWorkloadResponse {
             pub id: Uuid,
         }
@@ -68,11 +70,13 @@ pub mod workloads {
         use super::*;
 
         #[derive(Clone, Debug, Serialize, Deserialize)]
+        #[serde(rename_all = "camelCase")]
         pub struct ListWorkloadsRequest {
             pub id: Uuid,
         }
 
         #[derive(Clone, Debug, Serialize, Deserialize)]
+        #[serde(rename_all = "camelCase")]
         pub struct WorkloadSummary {
             pub id: Uuid,
             pub enabled: bool,
@@ -84,6 +88,7 @@ pub mod workloads {
         use super::*;
 
         #[derive(Clone, Debug, Serialize, Deserialize)]
+        #[serde(rename_all = "camelCase")]
         pub struct DeleteWorkloadRequest {
             pub id: Uuid,
         }
@@ -93,6 +98,7 @@ pub mod workloads {
         use super::*;
 
         #[derive(Clone, Debug, Serialize, Deserialize)]
+        #[serde(rename_all = "camelCase")]
         pub struct StartWorkloadRequest {
             pub id: Uuid,
         }
@@ -102,6 +108,7 @@ pub mod workloads {
         use super::*;
 
         #[derive(Clone, Debug, Serialize, Deserialize)]
+        #[serde(rename_all = "camelCase")]
         pub struct StopWorkloadRequest {
             pub id: Uuid,
         }
@@ -111,6 +118,7 @@ pub mod workloads {
         use super::*;
 
         #[derive(Clone, Debug, Serialize, Deserialize)]
+        #[serde(rename_all = "camelCase")]
         pub struct RestartWorkloadRequest {
             pub id: Uuid,
         }
@@ -122,6 +130,7 @@ pub mod errors {
 
     /// An error when handling a request.
     #[derive(Debug, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
     pub struct RequestHandlerError {
         /// A descriptive message about the error that was encountered.
         pub message: String,

--- a/nilcc-agent-cli/Cargo.toml
+++ b/nilcc-agent-cli/Cargo.toml
@@ -8,7 +8,7 @@ anyhow = "1"
 clap = { version = "4.5", features = ["derive", "env"] }
 serde = "1.0"
 serde_json = "1.0"
-reqwest = { version = "0.12", default-features = false, features = ["blocking", "json"] }
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "default-tls", "json"] }
 thiserror = "2.0"
 uuid = { version = "1.17", features = ["v4"] }
 

--- a/nilcc-agent/Cargo.toml
+++ b/nilcc-agent/Cargo.toml
@@ -32,6 +32,7 @@ tempfile = "3.20"
 tera = { version = "1", default-features = false }
 thiserror = "2"
 tokio = { version = "1.44", features = ["rt-multi-thread", "macros", "net", "process", "time", "fs", "signal"] }
+tokio-stream = "0.1"
 tower = "0.5"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }

--- a/nilcc-agent/src/config.rs
+++ b/nilcc-agent/src/config.rs
@@ -127,7 +127,7 @@ pub struct SniProxyConfig {
     pub end_port_range: u16,
 
     /// The path to the HAProxy configuration file.
-    pub config_file_path: String,
+    pub config_file_path: PathBuf,
 
     /// The path to the HA proxy master socket.
     #[serde(default = "ha_proxy_master_socket_path")]

--- a/nilcc-agent/src/routes/mod.rs
+++ b/nilcc-agent/src/routes/mod.rs
@@ -36,7 +36,7 @@ pub struct AppState {
 }
 
 pub fn build_router(state: AppState, token: String) -> Router {
-    Router::new().nest(
+    Router::new().route("/health", get(health)).nest(
         "/api/v1",
         Router::new()
             .route("/workloads/create", post(workloads::create::handler))
@@ -50,6 +50,10 @@ pub fn build_router(state: AppState, token: String) -> Router {
             .with_state(state)
             .layer(ServiceBuilder::new().layer(AuthLayer::new(token))),
     )
+}
+
+async fn health() -> impl IntoResponse {
+    (StatusCode::OK, "OK")
 }
 
 /// A type that behaves like `axum::Json` but provides JSON structured errors when parsing fails.

--- a/nilcc-agent/src/templates/haproxy.cfg.j2
+++ b/nilcc-agent/src/templates/haproxy.cfg.j2
@@ -45,7 +45,7 @@ frontend https_frontend
 # nilcc-agent backend
 backend agent-backend 
     mode tcp
-    server nilcc-agent {{ agent_domain }} check
+    server nilcc-agent 127.0.0.1:{{ agent_port }} check
 
 {%- for backend in backends %}
 


### PR DESCRIPTION
This fixes various things in nilcc-agent to get it to work:

* Start a task to get the TLS certs actually generated.
* Use camel case in all request/response models to match nilcc-api expectations.
* Write the correct domains into the haproxy config file.
* Use `\n` in haproxy master socket command.