### PR TITLE
chore: make API errors consistent

### DIFF
--- a/nilcc-api/src/common/errors.ts
+++ b/nilcc-api/src/common/errors.ts
@@ -1,186 +1,33 @@
 import type { ContentfulStatusCode } from "hono/dist/types/utils/http-status";
-import { ZodError } from "zod";
-import { fromZodError } from "zod-validation-error";
-
-type Constructor<T> = new (...args: unknown[]) => T;
-
-function isError(error: unknown): error is Error {
-  return error instanceof Error;
-}
-
-function handleError<T extends AppError>(
-  error: unknown,
-  map: (error: Error) => T,
-) {
-  // If the error is an Error we can map it to a specific AppError
-  if (isError(error)) {
-    throw map(error);
-  }
-  // If the error is not an Error we create an error with the message using the error and hope it to be printable
-  throw map(new Error(`Unexpected error: ${error}`));
-}
-
-export function mapError<T extends AppError>(map: (error: Error) => T) {
-  return (
-    _target: unknown,
-    _propertyKey: string,
-    descriptor: PropertyDescriptor,
-  ) => {
-    const originalMethod = descriptor.value;
-    descriptor.value = function (...args: unknown[]) {
-      try {
-        const result = originalMethod.apply(this, args);
-
-        if (result instanceof Promise) {
-          return result.catch((error) => {
-            handleError(error, map);
-          });
-        }
-        return result;
-      } catch (error) {
-        handleError(error, map);
-      }
-    };
-    return descriptor;
-  };
-}
+import { StatusCodes } from "http-status-codes";
 
 export abstract class AppError extends Error {
-  abstract readonly tag: string;
+  abstract readonly kind: string;
+  readonly statusCode: ContentfulStatusCode = StatusCodes.INTERNAL_SERVER_ERROR;
+  readonly description: string | undefined;
+
   constructor(cause?: unknown) {
     super();
     this.cause = cause;
   }
 
   override get message(): string {
-    return `${this.tag}: ${this.cause instanceof Error ? this.cause.message : String(this.cause)}`;
+    return this.description || this.cause?.toString() || "Internal error";
   }
-
-  humanize(): string[] {
-    if (this.cause instanceof AppError) {
-      return [this.tag, ...this.cause.humanize()];
-    }
-    if (isError(this.cause)) {
-      return [this.tag, `Cause: ${this.cause.message}`];
-    }
-    return [this.tag, `Cause: ${this.cause}`];
-  }
-}
-
-export class DataValidationError extends AppError {
-  tag = "DataValidationError";
-  issues: (string | ZodError)[];
-
-  constructor({
-    cause,
-    issues,
-  }: { cause?: unknown; issues: (string | ZodError)[] }) {
-    super(cause);
-    this.issues = issues;
-  }
-
-  override humanize(): string[] {
-    const flattenedIssues = this.issues.flatMap((issue) => {
-      if (issue instanceof ZodError) {
-        const errorMessage = fromZodError(issue, {
-          prefix: null,
-          issueSeparator: ";",
-        }).message;
-        return errorMessage.split(";");
-      }
-      return issue;
-    });
-
-    return [this.tag, ...flattenedIssues];
-  }
-}
-
-export class GetRepositoryError extends AppError {
-  tag = "GetRepositoryError";
-}
-
-abstract class EntityError<T> extends AppError {
-  entity: Constructor<T>;
-
-  constructor(entity: Constructor<T>, cause?: unknown) {
-    super(cause);
-    this.entity = entity;
-  }
-
-  override humanize(): string[] {
-    const baseMessage = super.humanize();
-    delete baseMessage[0];
-    return [`${this.tag}<${this.entity.name}>`, ...baseMessage];
-  }
-}
-
-export class CreateEntityError<T> extends EntityError<T> {
-  tag = "CreateEntityError";
-}
-
-export class CreateOrUpdateEntityError<T> extends EntityError<T> {
-  tag = "CreateOrUpdateEntityError";
-}
-
-export class FindEntityError<T> extends EntityError<T> {
-  tag = "FindEntityError";
-}
-
-export class UpdateEntityError<T> extends EntityError<T> {
-  tag = "UpdateEntityError";
-}
-
-export class RemoveEntityError<T> extends EntityError<T> {
-  tag = "RemoveEntityError";
 }
 
 export class InstancesNotAvailable extends AppError {
-  tag = "InstancesNotAvailable";
+  kind = "NOT_ENOUGH_RESOURCES";
+  override statusCode: ContentfulStatusCode = StatusCodes.SERVICE_UNAVAILABLE;
+  override description =
+    "No metal instances are available to handle this workload";
 }
 
 export class InvalidDockerCompose extends AppError {
-  tag = "InvalidDockerCompose";
+  kind = "INVALID_DOCKER_COMPOSE";
+  override statusCode: ContentfulStatusCode = StatusCodes.BAD_REQUEST;
 }
 
 export class AgentRequestError extends AppError {
-  tag = "AgentRequestError";
-}
-
-export class SubmitEventError extends AppError {
-  tag = "SubmitEventError";
-}
-
-export class ListWorkloadEventsError extends AppError {
-  tag = "ListWorkloadEventsError";
-}
-
-export class ListContainersError extends AppError {
-  tag = "ListContainersError";
-}
-
-export class ContainerLogsError extends AppError {
-  tag = "ContainerLogsError";
-}
-
-export class HttpError extends AppError {
-  tag = "HttpError";
-  statusCode: ContentfulStatusCode;
-  humanizeMessage: string;
-  constructor({
-    message,
-    statusCode,
-    cause,
-  }: { message: string; statusCode: ContentfulStatusCode; cause?: unknown }) {
-    super(cause);
-    this.statusCode = statusCode;
-    this.humanizeMessage = message;
-  }
-
-  override get message(): string {
-    return `${this.tag} (${this.statusCode}): ${this.humanizeMessage}`;
-  }
-
-  override humanize(): string[] {
-    return [this.tag, this.humanizeMessage];
-  }
+  kind = "METAL_INSTANCE_COMMUNICATION";
 }

--- a/nilcc-api/src/dns/dns.errors.ts
+++ b/nilcc-api/src/dns/dns.errors.ts
@@ -1,9 +1,9 @@
 import { AppError } from "#/common/errors";
 
 export class CreateRecordError extends AppError {
-  tag = "CreateRecordError";
+  kind = "CreateRecordError";
 }
 
 export class DeleteRecordError extends AppError {
-  tag = "DeleteRecordError";
+  kind = "DeleteRecordError";
 }

--- a/nilcc-api/src/dns/dns.service.ts
+++ b/nilcc-api/src/dns/dns.service.ts
@@ -7,8 +7,6 @@ import {
   type RRType,
 } from "@aws-sdk/client-route-53";
 import type { Logger } from "pino";
-import { mapError } from "#/common/errors";
-import { CreateRecordError, DeleteRecordError } from "#/dns/dns.errors";
 
 export interface DnsService {
   createRecord(domain: string, to: string, recordType: RRType): Promise<void>;
@@ -47,7 +45,6 @@ export class Route53DnsService implements DnsService {
     return new Route53DnsService(zone, subdomain, zoneId, route53);
   }
 
-  @mapError((e) => new CreateRecordError(e))
   async createRecord(
     domain: string,
     to: string,
@@ -73,7 +70,6 @@ export class Route53DnsService implements DnsService {
     await this.route53.send(command);
   }
 
-  @mapError((e) => new DeleteRecordError(e))
   async deleteRecord(domain: string, recordType: RRType): Promise<void> {
     const fullDomain = `${domain}.${this.subdomain}`;
     const domainData = await this.findDomain(

--- a/nilcc-api/src/metal-instance/metal-instance.controller.ts
+++ b/nilcc-api/src/metal-instance/metal-instance.controller.ts
@@ -1,11 +1,15 @@
 import { describeRoute } from "hono-openapi";
-import { resolver, validator as zValidator } from "hono-openapi/zod";
+import { resolver } from "hono-openapi/zod";
 import z from "zod";
 import { apiKey } from "#/common/auth";
 import { OpenApiSpecCommonErrorResponses } from "#/common/openapi";
 import { PathsV1 } from "#/common/paths";
 import type { ControllerOptions } from "#/common/types";
-import { paramsValidator, responseValidator } from "#/common/zod-utils";
+import {
+  pathValidator,
+  payloadValidator,
+  responseValidator,
+} from "#/common/zod-utils";
 import { transactionMiddleware } from "#/data-source";
 import {
   GetMetalInstanceResponse,
@@ -34,7 +38,7 @@ export function register(options: ControllerOptions) {
       },
     }),
     apiKey(bindings.config.metalInstanceApiKey),
-    zValidator("json", RegisterMetalInstanceRequest),
+    payloadValidator(RegisterMetalInstanceRequest),
     transactionMiddleware(bindings.dataSource),
     async (c) => {
       const payload = c.req.valid("json");
@@ -65,7 +69,7 @@ export function heartbeat(options: ControllerOptions) {
       },
     }),
     apiKey(bindings.config.metalInstanceApiKey),
-    zValidator("json", HeartbeatRequest),
+    payloadValidator(HeartbeatRequest),
     transactionMiddleware(bindings.dataSource),
     async (c) => {
       const payload = c.req.valid("json");
@@ -99,7 +103,7 @@ export function read(options: ControllerOptions) {
       },
     }),
     apiKey(bindings.config.userApiKey),
-    paramsValidator(idParamSchema),
+    pathValidator(idParamSchema),
     responseValidator(bindings, GetMetalInstanceResponse),
     async (c) => {
       const id = c.req.param("id");

--- a/nilcc-api/src/metal-instance/metal-instance.service.ts
+++ b/nilcc-api/src/metal-instance/metal-instance.service.ts
@@ -1,13 +1,4 @@
 import type { QueryRunner, Repository } from "typeorm";
-import {
-  CreateEntityError,
-  CreateOrUpdateEntityError,
-  FindEntityError,
-  GetRepositoryError,
-  mapError,
-  RemoveEntityError,
-  UpdateEntityError,
-} from "#/common/errors";
 import type { AppBindings } from "#/env";
 import type {
   HeartbeatRequest,
@@ -16,7 +7,6 @@ import type {
 import { MetalInstanceEntity } from "./metal-instance.entity";
 
 export class MetalInstanceService {
-  @mapError((e) => new GetRepositoryError(e))
   getRepository(
     bindings: AppBindings,
     tx?: QueryRunner,
@@ -27,13 +17,11 @@ export class MetalInstanceService {
     return bindings.dataSource.getRepository(MetalInstanceEntity);
   }
 
-  @mapError((e) => new FindEntityError(MetalInstanceEntity, e))
   async list(bindings: AppBindings): Promise<MetalInstanceEntity[]> {
     const repository = this.getRepository(bindings);
     return await repository.find();
   }
 
-  @mapError((e) => new FindEntityError(MetalInstanceEntity, e))
   async read(
     bindings: AppBindings,
     metalInstanceId: string,
@@ -43,7 +31,6 @@ export class MetalInstanceService {
     return await repository.findOneBy({ id: metalInstanceId });
   }
 
-  @mapError((e) => new RemoveEntityError(MetalInstanceEntity, e))
   async remove(
     bindings: AppBindings,
     metalInstanceId: string,
@@ -53,7 +40,6 @@ export class MetalInstanceService {
     return result.affected ? result.affected > 0 : false;
   }
 
-  @mapError((e) => new CreateOrUpdateEntityError(MetalInstanceEntity, e))
   async createOrUpdate(
     bindings: AppBindings,
     request: RegisterMetalInstanceRequest,
@@ -73,10 +59,7 @@ export class MetalInstanceService {
   ) {
     const metalInstance = await this.read(bindings, request.id, tx);
     if (metalInstance === null) {
-      throw new FindEntityError(
-        MetalInstanceEntity,
-        "metal instance not found",
-      );
+      throw new Error("metal instance not found");
     }
     const repository = this.getRepository(bindings, tx);
     metalInstance.lastSeenAt = new Date();
@@ -125,7 +108,6 @@ export class MetalInstanceService {
     return await queryBuilder.getMany();
   }
 
-  @mapError((e) => new UpdateEntityError(MetalInstanceEntity, e))
   async update(
     bindings: AppBindings,
     metalInstance: RegisterMetalInstanceRequest,
@@ -152,7 +134,6 @@ export class MetalInstanceService {
     await repository.save(currentMetalInstance);
   }
 
-  @mapError((e) => new CreateEntityError(MetalInstanceEntity, e))
   async create(
     bindings: AppBindings,
     request: RegisterMetalInstanceRequest,

--- a/nilcc-api/src/workload-container/workload-container.controllers.ts
+++ b/nilcc-api/src/workload-container/workload-container.controllers.ts
@@ -1,11 +1,10 @@
-import { zValidator } from "@hono/zod-validator";
 import { describeRoute } from "hono-openapi";
 import { resolver } from "hono-openapi/zod";
 import { apiKey } from "#/common/auth";
 import { OpenApiSpecCommonErrorResponses } from "#/common/openapi";
 import { PathsV1 } from "#/common/paths";
 import type { ControllerOptions } from "#/common/types";
-import { responseValidator } from "#/common/zod-utils";
+import { payloadValidator, responseValidator } from "#/common/zod-utils";
 import { transactionMiddleware } from "#/data-source";
 import {
   ListContainersRequest,
@@ -36,7 +35,7 @@ export function listContainers(options: ControllerOptions) {
       },
     }),
     apiKey(bindings.config.metalInstanceApiKey),
-    zValidator("json", ListContainersRequest),
+    payloadValidator(ListContainersRequest),
     transactionMiddleware(bindings.dataSource),
     responseValidator(bindings, ListContainersResponse),
     async (c) => {
@@ -73,7 +72,7 @@ export function containerLogs(options: ControllerOptions) {
       },
     }),
     apiKey(bindings.config.metalInstanceApiKey),
-    zValidator("json", WorkloadContainerLogsRequest),
+    payloadValidator(WorkloadContainerLogsRequest),
     transactionMiddleware(bindings.dataSource),
     responseValidator(bindings, WorkloadContainerLogsResponse),
     async (c) => {

--- a/nilcc-api/src/workload-event/workload-event.controllers.ts
+++ b/nilcc-api/src/workload-event/workload-event.controllers.ts
@@ -1,11 +1,10 @@
-import { zValidator } from "@hono/zod-validator";
 import { describeRoute } from "hono-openapi";
 import { resolver } from "hono-openapi/zod";
 import { apiKey } from "#/common/auth";
 import { OpenApiSpecCommonErrorResponses } from "#/common/openapi";
 import { PathsV1 } from "#/common/paths";
 import type { ControllerOptions } from "#/common/types";
-import { responseValidator } from "#/common/zod-utils";
+import { payloadValidator, responseValidator } from "#/common/zod-utils";
 import { transactionMiddleware } from "#/data-source";
 import { SubmitEventRequest } from "#/metal-instance/metal-instance.dto";
 import {
@@ -30,7 +29,7 @@ export function submitEvent(options: ControllerOptions) {
       },
     }),
     apiKey(bindings.config.metalInstanceApiKey),
-    zValidator("json", SubmitEventRequest),
+    payloadValidator(SubmitEventRequest),
     transactionMiddleware(bindings.dataSource),
     async (c) => {
       const payload = c.req.valid("json");
@@ -64,7 +63,7 @@ export function listEvents(options: ControllerOptions) {
       },
     }),
     apiKey(bindings.config.userApiKey),
-    zValidator("json", ListWorkloadEventsRequest),
+    payloadValidator(ListWorkloadEventsRequest),
     transactionMiddleware(bindings.dataSource),
     responseValidator(bindings, ListWorkloadEventsResponse),
     async (c) => {

--- a/nilcc-api/src/workload/workload.service.ts
+++ b/nilcc-api/src/workload/workload.service.ts
@@ -1,18 +1,7 @@
 import type { QueryRunner, Repository } from "typeorm";
 import { v4 as uuidv4 } from "uuid";
 import type { Container } from "#/clients/nilcc-agent.client";
-import {
-  ContainerLogsError,
-  CreateEntityError,
-  FindEntityError,
-  GetRepositoryError,
-  InstancesNotAvailable,
-  ListContainersError,
-  ListWorkloadEventsError,
-  mapError,
-  RemoveEntityError,
-  SubmitEventError,
-} from "#/common/errors";
+import { InstancesNotAvailable } from "#/common/errors";
 import { DockerComposeValidator } from "#/compose/validator";
 import type { AppBindings } from "#/env";
 import type {
@@ -31,7 +20,6 @@ import type { CreateWorkloadRequest } from "./workload.dto";
 import { WorkloadEntity, WorkloadEventEntity } from "./workload.entity";
 
 export class WorkloadService {
-  @mapError((e) => new GetRepositoryError(e))
   getRepository(
     bindings: AppBindings,
     tx: QueryRunner,
@@ -42,7 +30,6 @@ export class WorkloadService {
     return bindings.dataSource.getRepository(WorkloadEntity);
   }
 
-  @mapError((e) => new CreateEntityError(WorkloadEntity, e))
   async create(
     bindings: AppBindings,
     request: CreateWorkloadRequest,
@@ -106,7 +93,6 @@ export class WorkloadService {
     return createdWorkload;
   }
 
-  @mapError((e) => new FindEntityError(WorkloadEntity, e))
   async list(
     bindings: AppBindings,
     tx: QueryRunner,
@@ -115,7 +101,6 @@ export class WorkloadService {
     return await repository.find();
   }
 
-  @mapError((e) => new FindEntityError(WorkloadEntity, e))
   async read(
     bindings: AppBindings,
     workloadId: string,
@@ -125,7 +110,6 @@ export class WorkloadService {
     return await repository.findOneBy({ id: workloadId });
   }
 
-  @mapError((e) => new RemoveEntityError(WorkloadEntity, e))
   async remove(
     bindings: AppBindings,
     workloadId: string,
@@ -149,7 +133,6 @@ export class WorkloadService {
     return true;
   }
 
-  @mapError((e) => new SubmitEventError(e))
   async submitEvent(
     bindings: AppBindings,
     request: SubmitEventRequest,
@@ -192,7 +175,6 @@ export class WorkloadService {
     await eventRepository.save(event);
   }
 
-  @mapError((e) => new ListWorkloadEventsError(e))
   async listEvents(
     bindings: AppBindings,
     request: ListWorkloadEventsRequest,
@@ -233,7 +215,6 @@ export class WorkloadService {
     });
   }
 
-  @mapError((e) => new ListContainersError(e))
   async listContainers(
     bindings: AppBindings,
     request: ListContainersRequest,
@@ -254,7 +235,6 @@ export class WorkloadService {
     );
   }
 
-  @mapError((e) => new ContainerLogsError(e))
   async containerLogs(
     bindings: AppBindings,
     request: WorkloadContainerLogsRequest,


### PR DESCRIPTION
This unifies all errors so we don't have a bunch of schemas for them. Now all errors return something like

```json
{
    "kind": "SOME_IDENTIFIER",
    "error": "some descriptive text or rich object",
    "ts": "<a timestamp>"
}
```