### PR TITLE
fix: don't pass cvm-agent resources to ISO build

### DIFF
--- a/artifacts/autoinstall_ubuntu/build.sh
+++ b/artifacts/autoinstall_ubuntu/build.sh
@@ -33,7 +33,6 @@ cp $SCRIPT_PATH/../kernel/build/$TYPE/linux-*.deb "$BUILD_PATH/kernel/"
 
 # Copy cvm-agent script and dependencies.
 cp "$CVM_AGENT_PATH" "$BUILD_PATH/custom/"
-cp -r "$SCRIPT_PATH/../../cvm-agent/services/" "$BUILD_PATH/custom/"
 cp "$SCRIPT_PATH/cvm-agent.service" "$BUILD_PATH/custom/"
 
 # Store version and type so the VM can store this persistently.


### PR DESCRIPTION
These resources are already part of the cvm binary so they're not needed.