### PR TITLE
feat: only report workload as running when https endpoint is up

### DIFF
--- a/crates/cvm-agent-models/src/lib.rs
+++ b/crates/cvm-agent-models/src/lib.rs
@@ -35,6 +35,21 @@ pub mod container {
     }
 }
 
+pub mod health {
+    use super::*;
+
+    /// A response to a health request.
+    #[derive(Deserialize, Serialize, Validate)]
+    #[serde(rename_all = "camelCase")]
+    pub struct HealthResponse {
+        /// Whether HTTPS is configured and available.
+        pub https: bool,
+
+        /// Whether the CVM is bootstrapped
+        pub bootstrapped: bool,
+    }
+}
+
 pub mod logs {
     use super::*;
 

--- a/cvm-agent/src/routes/health.rs
+++ b/cvm-agent/src/routes/health.rs
@@ -1,6 +1,15 @@
+use crate::routes::SharedState;
 use axum::Json;
+use cvm_agent_models::health::HealthResponse;
 
-// TODO: eventually expose information about e.g. docker
-pub(crate) async fn handler() -> Json<()> {
-    Json(())
+use super::SystemState;
+
+pub(crate) async fn handler(state: SharedState) -> Json<HealthResponse> {
+    let (https, bootstrapped) = match &*state.system_state.lock().unwrap() {
+        SystemState::WaitingBootstrap => (false, false),
+        SystemState::Starting(_) => (false, true),
+        SystemState::Ready(_) => (true, true),
+    };
+    let response = HealthResponse { https, bootstrapped };
+    Json(response)
 }

--- a/cvm-agent/src/routes/mod.rs
+++ b/cvm-agent/src/routes/mod.rs
@@ -17,8 +17,9 @@ pub(crate) mod system;
 #[derive(Default)]
 pub enum SystemState {
     #[default]
-    Pending,
-    Running(Child),
+    WaitingBootstrap,
+    Starting(Child),
+    Ready(Child),
 }
 
 #[derive(Clone)]
@@ -35,7 +36,7 @@ pub struct BootstrapContext {
 pub struct AppState {
     pub docker: Docker,
     pub context: BootstrapContext,
-    pub system_state: Mutex<SystemState>,
+    pub system_state: Arc<Mutex<SystemState>>,
 }
 
 pub(crate) type SharedState = State<Arc<AppState>>;

--- a/nilcc-agent/src/clients/cvm_agent.rs
+++ b/nilcc-agent/src/clients/cvm_agent.rs
@@ -3,6 +3,7 @@ use async_trait::async_trait;
 use cvm_agent_models::{
     bootstrap::BootstrapRequest,
     container::Container,
+    health::HealthResponse,
     logs::{ContainerLogsRequest, ContainerLogsResponse},
 };
 use reqwest::Client;
@@ -18,7 +19,7 @@ pub trait CvmAgentClient: Send + Sync {
         cvm_agent_port: u16,
         request: &ContainerLogsRequest,
     ) -> Result<ContainerLogsResponse, CvmAgentRequestError>;
-    async fn check_health(&self, cvm_agent_port: u16) -> Result<(), CvmAgentRequestError>;
+    async fn check_health(&self, cvm_agent_port: u16) -> Result<HealthResponse, CvmAgentRequestError>;
     async fn bootstrap(&self, cvm_agent_port: u16, request: &BootstrapRequest) -> Result<(), CvmAgentRequestError>;
 }
 
@@ -69,7 +70,7 @@ impl CvmAgentClient for DefaultCvmAgentClient {
         self.get(cvm_agent_port, "/api/v1/containers/logs", &request).await
     }
 
-    async fn check_health(&self, cvm_agent_port: u16) -> Result<(), CvmAgentRequestError> {
+    async fn check_health(&self, cvm_agent_port: u16) -> Result<HealthResponse, CvmAgentRequestError> {
         self.get(cvm_agent_port, "/api/v1/health", &()).await
     }
 


### PR DESCRIPTION
This adds some logic so we only report a workload as `running` when caddy fetches a certificate successfully. This means when you see a workload as `running` then you should be able to hit it via https.

Closes #216