### PR TITLE
chore: validate domains are unique

### DIFF
--- a/nilcc-agent/migrations/20250806154636_unique_domain_column.sql
+++ b/nilcc-agent/migrations/20250806154636_unique_domain_column.sql
@@ -1,0 +1,3 @@
+-- Make the `domain` column unique.
+
+CREATE UNIQUE INDEX workload_column ON workloads (domain);

--- a/nilcc-agent/src/services/workload.rs
+++ b/nilcc-agent/src/services/workload.rs
@@ -40,6 +40,9 @@ pub enum CreateWorkloadError {
 
     #[error("workload already exists")]
     AlreadyExists,
+
+    #[error("domain is already managed by another workload")]
+    DomainExists,
 }
 
 impl From<StartVmError> for CreateWorkloadError {
@@ -52,6 +55,7 @@ impl From<WorkloadRepositoryError> for CreateWorkloadError {
     fn from(e: WorkloadRepositoryError) -> Self {
         match e {
             WorkloadRepositoryError::DuplicateWorkload => Self::AlreadyExists,
+            WorkloadRepositoryError::DuplicateDomain => Self::DomainExists,
             WorkloadRepositoryError::WorkloadNotFound | WorkloadRepositoryError::Database(_) => {
                 Self::Internal(e.to_string())
             }


### PR DESCRIPTION
This validates that domains are only used once. This in general isn't an issue unless you're using the agent by hand but it's still a good check to have.

PS: error handling is duplicated and annoying, needs refactoring.