### PR TITLE
feat: publish nilcc-agent-cli docker image

### DIFF
--- a/.github/workflows/nilcc-agent-cli-cd.yml
+++ b/.github/workflows/nilcc-agent-cli-cd.yml
@@ -1,0 +1,44 @@
+name: nilcc-agent-cli docker
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  docker-build-nilcc-agent-cli:
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_TAG: ghcr.io/nillionnetwork/nilcc-agent-cli:latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: docker/nilcc-agent-cli.dockerfile
+          tags: ${{ env.DOCKER_TAG }}
+
+      - name: Log in to the container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: docker/nilcc-agent-cli.dockerfile
+          push: true
+          tags: ${{ env.DOCKER_TAG }}
+          build-args: |
+            VERSION=${{ env.PACKAGE_VERSION }}
+
+

--- a/docker/nilcc-agent-cli.dockerfile
+++ b/docker/nilcc-agent-cli.dockerfile
@@ -1,0 +1,14 @@
+FROM rust:1.86-alpine AS build
+
+WORKDIR /opt/nillion
+RUN apk add --no-cache musl-dev
+
+COPY . .
+RUN cargo build --release --locked -p nilcc-agent-cli
+
+FROM alpine
+
+WORKDIR /opt/nillion
+
+COPY --from=build /opt/nillion/target/release/nilcc-agent-cli /opt/nillion
+ENTRYPOINT ["/opt/nillion/nilcc-agent-cli"]

--- a/nilcc-agent-cli/Cargo.toml
+++ b/nilcc-agent-cli/Cargo.toml
@@ -8,7 +8,7 @@ anyhow = "1"
 clap = { version = "4.5", features = ["derive", "env"] }
 serde = "1.0"
 serde_json = "1.0"
-reqwest = { version = "0.12", default-features = false, features = ["blocking", "default-tls", "json"] }
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls", "json"] }
 thiserror = "2.0"
 uuid = { version = "1.17", features = ["v4"] }
 


### PR DESCRIPTION
This adds a new docker image for nilcc-agent-cli so we can pull and run easily