### PR TITLE
feat: perform db operations transactionally where required

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2156,6 +2156,7 @@ dependencies = [
  "chrono",
  "clap",
  "cvm-agent-models",
+ "futures-core",
  "hex",
  "humantime",
  "humantime-serde",

--- a/nilcc-agent/Cargo.toml
+++ b/nilcc-agent/Cargo.toml
@@ -11,6 +11,7 @@ axum-server = "0.7"
 axum-valid = "0.24"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.5", features = ["derive", "env"] }
+futures-core = "0.3"
 hex = { version = "0.4", features = ["serde"] }
 humantime = { version = "2.2"}
 humantime-serde = "1.1"

--- a/nilcc-agent/src/workers/vm.rs
+++ b/nilcc-agent/src/workers/vm.rs
@@ -184,10 +184,12 @@ impl VmWorker {
         match self.vm_client.stop_vm(&self.socket_path, true).await {
             Ok(_) => {
                 self.vm_state = VmState::Disabled;
+                self.submit_event(VmEvent::Stopped).await;
                 info!("VM is stopped");
             }
             Err(QemuClientError::VmNotRunning) => {
                 self.vm_state = VmState::Disabled;
+                self.submit_event(VmEvent::Stopped).await;
                 warn!("VM was not running");
             }
             Err(e) => {


### PR DESCRIPTION
This runs db operations transactionally where needed. For this I added a new layer of abstraction that lets you "build repositories" where the repository is built over either a single connection or a transaction and you must commit the use of a repository at the end of whatever flow is using it.