### PR TITLE
fix: increase haproxy timeouts

### DIFF
--- a/nilcc-agent/src/config.rs
+++ b/nilcc-agent/src/config.rs
@@ -137,6 +137,7 @@ pub struct SniProxyConfig {
     pub master_socket_path: PathBuf,
 
     /// The timeouts for the SNI proxy.
+    #[serde(default)]
     pub timeouts: SniProxyConfigTimeouts,
 
     /// The maximum number of connections for the SNI proxy.
@@ -150,13 +151,22 @@ pub struct SniProxyConfig {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SniProxyConfigTimeouts {
     /// Timeout for connection establishment in ms.
+    #[serde(default = "default_connect_timeout")]
     pub connect: u64,
 
     /// Timeout for server in ms.
+    #[serde(default = "default_server_timeout")]
     pub server: u64,
 
     /// Timeout for client in ms.
+    #[serde(default = "default_client_timeout")]
     pub client: u64,
+}
+
+impl Default for SniProxyConfigTimeouts {
+    fn default() -> Self {
+        Self { connect: default_connect_timeout(), server: default_server_timeout(), client: default_client_timeout() }
+    }
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -248,6 +258,18 @@ fn u32_max() -> u32 {
 
 fn default_true() -> bool {
     true
+}
+
+fn default_connect_timeout() -> u64 {
+    5000
+}
+
+fn default_client_timeout() -> u64 {
+    30000
+}
+
+fn default_server_timeout() -> u64 {
+    30000
 }
 
 fn ha_proxy_master_socket_path() -> PathBuf {

--- a/nilcc-agent/src/services/proxy.rs
+++ b/nilcc-agent/src/services/proxy.rs
@@ -200,7 +200,7 @@ defaults
     mode tcp
     timeout connect 5000ms
     timeout client 50000ms
-    timeout server 5000050000ms
+    timeout server 50000ms
     option tcplog
     log global
 

--- a/nilcc-agent/src/services/workload.rs
+++ b/nilcc-agent/src/services/workload.rs
@@ -261,12 +261,12 @@ impl WorkloadService for DefaultWorkloadService {
             .await
             .map_err(|e| CreateWorkloadError::Internal(e.to_string()))?;
         repo.create(workload.clone()).await?;
-        repo.commit().await?;
 
         info!("Scheduling VM {id}");
         let proxied_vm = ProxiedVm::from(&workload);
         self.vm_service.create_vm(workload, InitialVmState::Enabled).await?;
         self.proxy_service.start_vm_proxy(proxied_vm).await;
+        repo.commit().await?;
 
         resources.cpus -= cpus;
         resources.gpus.drain(0..gpus);

--- a/nilcc-agent/src/templates/haproxy.cfg.j2
+++ b/nilcc-agent/src/templates/haproxy.cfg.j2
@@ -7,7 +7,7 @@ defaults
     mode tcp
     timeout connect {{ timeouts.connect }}ms
     timeout client {{ timeouts.client }}ms
-    timeout server {{ timeouts.server }}50000ms
+    timeout server {{ timeouts.server }}ms
     option tcplog
     log global
 


### PR DESCRIPTION
The haproxy timeouts were too low, which was causing it to drop the connection while the request was being handled.

Fixes #212