### PR TITLE
feat: structurally validate docker compose in nilcc-agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -974,6 +974,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1015,6 +1046,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "docker-compose-types"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd0905d0ae048885d8575c8c3dc9639408a9300f62767f1473318379dbf03f9"
+dependencies = [
+ "derive_builder",
+ "indexmap 2.9.0",
+ "serde",
+ "serde_yaml",
 ]
 
 [[package]]
@@ -2156,6 +2199,7 @@ dependencies = [
  "chrono",
  "clap",
  "cvm-agent-models",
+ "docker-compose-types",
  "futures-core",
  "hex",
  "humantime",

--- a/nilcc-agent/Cargo.toml
+++ b/nilcc-agent/Cargo.toml
@@ -11,6 +11,7 @@ axum-server = "0.7"
 axum-valid = "0.24"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.5", features = ["derive", "env"] }
+docker-compose-types = "0.19.0"
 futures-core = "0.3"
 hex = { version = "0.4", features = ["serde"] }
 humantime = { version = "2.2"}


### PR DESCRIPTION
This ensures the docker compose file is well formed and that it at least contains the public container name that we're supposed to route traffic to before launching a vm in nilcc-agent. This is already done (plus more validations) in nilcc-api but since we want to run this by hand via nilcc-agent-cli, we want to apply a minimum validation to avoid headaches while deploying. 