### PR TITLE
fix: rollback DNS record creation if nilcc-agent call fails

### DIFF
--- a/nilcc-api/src/workload/workload.service.ts
+++ b/nilcc-api/src/workload/workload.service.ts
@@ -85,11 +85,17 @@ export class WorkloadService {
       createdWorkload.id,
       metalInstance.id,
     );
-    await bindings.services.nilccAgentClient.createWorkload(
-      metalInstance,
-      entity,
-      domain,
-    );
+    try {
+      await bindings.services.nilccAgentClient.createWorkload(
+        metalInstance,
+        entity,
+        domain,
+      );
+    } catch (e) {
+      bindings.log.warn("Could not create workload, removing CNAME record");
+      await this.removeCnameForWorkload(bindings, entity.id);
+      throw e;
+    }
     return createdWorkload;
   }
 


### PR DESCRIPTION
This was otherwise leaving DNS records behind if something fails when talking to nilcc-agent.