### PR TITLE
fix: forward workload domain to haproxy

### DIFF
--- a/nilcc-agent/src/config.rs
+++ b/nilcc-agent/src/config.rs
@@ -120,9 +120,6 @@ pub struct DbConfig {
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct SniProxyConfig {
-    /// The DNS subdomain where workloads will be accessible.
-    pub dns_subdomain: String,
-
     /// Start of the port range for the SNI proxy.
     pub start_port_range: u16,
 

--- a/nilcc-agent/src/main.rs
+++ b/nilcc-agent/src/main.rs
@@ -188,7 +188,6 @@ async fn run_daemon(config: AgentConfig) -> Result<()> {
         config_file_path: config.sni_proxy.config_file_path.clone(),
         master_socket_path: config.sni_proxy.master_socket_path,
         timeouts: config.sni_proxy.timeouts,
-        dns_subdomain: config.sni_proxy.dns_subdomain,
         agent_domain: config.api.domain.clone(),
         agent_port: config.api.bind_endpoint.port(),
         max_connections: config.sni_proxy.max_connections,

--- a/nilcc-agent/src/services/workload.rs
+++ b/nilcc-agent/src/services/workload.rs
@@ -569,7 +569,7 @@ mod tests {
         builder
             .proxy_service
             .expect_start_vm_proxy()
-            .with(eq(ProxiedVm { id, http_port: 100, https_port: 101 }))
+            .with(eq(ProxiedVm { id, domain: "example.com".into(), http_port: 100, https_port: 101 }))
             .return_once(move |_| ());
 
         let service = builder.build().await;


### PR DESCRIPTION
The domain was being generated when we should have just passed the workload's domain directly. This is fine in "the real thing" but in standalone mode it breaks.