### PR TITLE
feat: expose stats/logs endpoints in nilcc-agent and nilcc-agent-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2251,6 +2260,7 @@ dependencies = [
 name = "nilcc-agent-cli"
 version = "0.1.0"
 dependencies = [
+ "ansi_term",
  "anyhow",
  "clap",
  "cvm-agent-models",

--- a/crates/cvm-agent-models/src/lib.rs
+++ b/crates/cvm-agent-models/src/lib.rs
@@ -159,7 +159,7 @@ pub mod stats {
         /// The CPU name.
         pub name: String,
 
-        /// The CPU usage.
+        /// The CPU usage, as a percentage between 0-100.
         pub usage: f32,
 
         /// The frequency, in MHz.

--- a/nilcc-agent-cli/Cargo.toml
+++ b/nilcc-agent-cli/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+ansi_term = "0.12"
 anyhow = "1"
 clap = { version = "4.5", features = ["derive", "env"] }
 serde = "1.0"

--- a/nilcc-agent/src/clients/cvm_agent.rs
+++ b/nilcc-agent/src/clients/cvm_agent.rs
@@ -4,7 +4,8 @@ use cvm_agent_models::{
     bootstrap::BootstrapRequest,
     container::Container,
     health::HealthResponse,
-    logs::{ContainerLogsRequest, ContainerLogsResponse},
+    logs::{ContainerLogsRequest, ContainerLogsResponse, SystemLogsRequest, SystemLogsResponse},
+    stats::SystemStatsResponse,
 };
 use reqwest::Client;
 use serde::{de::DeserializeOwned, Serialize};
@@ -14,11 +15,17 @@ use tracing::info;
 #[cfg_attr(test, mockall::automock)]
 pub trait CvmAgentClient: Send + Sync {
     async fn list_containers(&self, cvm_agent_port: u16) -> Result<Vec<Container>, CvmAgentRequestError>;
-    async fn logs(
+    async fn container_logs(
         &self,
         cvm_agent_port: u16,
         request: &ContainerLogsRequest,
     ) -> Result<ContainerLogsResponse, CvmAgentRequestError>;
+    async fn system_logs(
+        &self,
+        cvm_agent_port: u16,
+        request: &SystemLogsRequest,
+    ) -> Result<SystemLogsResponse, CvmAgentRequestError>;
+    async fn system_stats(&self, cvm_agent_port: u16) -> Result<SystemStatsResponse, CvmAgentRequestError>;
     async fn check_health(&self, cvm_agent_port: u16) -> Result<HealthResponse, CvmAgentRequestError>;
     async fn bootstrap(&self, cvm_agent_port: u16, request: &BootstrapRequest) -> Result<(), CvmAgentRequestError>;
 }
@@ -62,12 +69,24 @@ impl CvmAgentClient for DefaultCvmAgentClient {
         self.get(cvm_agent_port, "/api/v1/containers/list", &()).await
     }
 
-    async fn logs(
+    async fn container_logs(
         &self,
         cvm_agent_port: u16,
         request: &ContainerLogsRequest,
     ) -> Result<ContainerLogsResponse, CvmAgentRequestError> {
         self.get(cvm_agent_port, "/api/v1/containers/logs", &request).await
+    }
+
+    async fn system_logs(
+        &self,
+        cvm_agent_port: u16,
+        request: &SystemLogsRequest,
+    ) -> Result<SystemLogsResponse, CvmAgentRequestError> {
+        self.get(cvm_agent_port, "/api/v1/system/logs", &request).await
+    }
+
+    async fn system_stats(&self, cvm_agent_port: u16) -> Result<SystemStatsResponse, CvmAgentRequestError> {
+        self.get(cvm_agent_port, "/api/v1/system/stats", &()).await
     }
 
     async fn check_health(&self, cvm_agent_port: u16) -> Result<HealthResponse, CvmAgentRequestError> {

--- a/nilcc-agent/src/routes/mod.rs
+++ b/nilcc-agent/src/routes/mod.rs
@@ -37,16 +37,18 @@ pub struct AppState {
 
 pub fn build_router(state: AppState, token: String) -> Router {
     Router::new().route("/health", get(health)).nest(
-        "/api/v1",
+        "/api/v1/workloads",
         Router::new()
-            .route("/workloads/create", post(workloads::create::handler))
-            .route("/workloads/delete", post(workloads::delete::handler))
-            .route("/workloads/restart", post(workloads::restart::handler))
-            .route("/workloads/stop", post(workloads::stop::handler))
-            .route("/workloads/start", post(workloads::start::handler))
-            .route("/workloads/list", get(workloads::list::handler))
-            .route("/workloads/{workload_id}/containers/list", get(workloads::containers::list::handler))
-            .route("/workloads/{workload_id}/containers/logs", get(workloads::containers::logs::handler))
+            .route("/create", post(workloads::create::handler))
+            .route("/delete", post(workloads::delete::handler))
+            .route("/restart", post(workloads::restart::handler))
+            .route("/stop", post(workloads::stop::handler))
+            .route("/start", post(workloads::start::handler))
+            .route("/list", get(workloads::list::handler))
+            .route("/{workload_id}/containers/list", get(workloads::containers::list::handler))
+            .route("/{workload_id}/containers/logs", get(workloads::containers::logs::handler))
+            .route("/{workload_id}/system/logs", get(workloads::system::logs::handler))
+            .route("/{workload_id}/system/stats", get(workloads::system::stats::handler))
             .with_state(state)
             .layer(ServiceBuilder::new().layer(AuthLayer::new(token))),
     )

--- a/nilcc-agent/src/routes/workloads/containers/logs.rs
+++ b/nilcc-agent/src/routes/workloads/containers/logs.rs
@@ -16,7 +16,7 @@ pub(crate) async fn handler(
     request: Query<ContainerLogsRequest>,
 ) -> Result<Json<ContainerLogsResponse>, CvmAgentHandlerError> {
     let port = state.services.workload.cvm_agent_port(path.0).await?;
-    let result = state.clients.cvm_agent.logs(port, &request.0).await;
+    let result = state.clients.cvm_agent.container_logs(port, &request.0).await;
     match result {
         Ok(response) => Ok(Json(response)),
         Err(CvmAgentRequestError::Http(e)) if e.status() == Some(StatusCode::NOT_FOUND) => {

--- a/nilcc-agent/src/routes/workloads/mod.rs
+++ b/nilcc-agent/src/routes/workloads/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod list;
 pub(crate) mod restart;
 pub(crate) mod start;
 pub(crate) mod stop;
+pub(crate) mod system;
 
 impl IntoResponse for WorkloadLookupError {
     fn into_response(self) -> Response {

--- a/nilcc-agent/src/routes/workloads/system/logs.rs
+++ b/nilcc-agent/src/routes/workloads/system/logs.rs
@@ -1,0 +1,17 @@
+use crate::routes::{workloads::containers::CvmAgentHandlerError, AppState, Json};
+use axum::extract::{Path, Query, State};
+use cvm_agent_models::logs::{SystemLogsRequest, SystemLogsResponse};
+use uuid::Uuid;
+
+pub(crate) async fn handler(
+    state: State<AppState>,
+    path: Path<Uuid>,
+    request: Query<SystemLogsRequest>,
+) -> Result<Json<SystemLogsResponse>, CvmAgentHandlerError> {
+    let port = state.services.workload.cvm_agent_port(path.0).await?;
+    let result = state.clients.cvm_agent.system_logs(port, &request.0).await;
+    match result {
+        Ok(response) => Ok(Json(response)),
+        Err(e) => Err(CvmAgentHandlerError::Internal(e.to_string())),
+    }
+}

--- a/nilcc-agent/src/routes/workloads/system/mod.rs
+++ b/nilcc-agent/src/routes/workloads/system/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod logs;
+pub(crate) mod stats;

--- a/nilcc-agent/src/routes/workloads/system/stats.rs
+++ b/nilcc-agent/src/routes/workloads/system/stats.rs
@@ -1,0 +1,16 @@
+use crate::routes::{workloads::containers::CvmAgentHandlerError, AppState, Json};
+use axum::extract::{Path, State};
+use cvm_agent_models::stats::SystemStatsResponse;
+use uuid::Uuid;
+
+pub(crate) async fn handler(
+    state: State<AppState>,
+    path: Path<Uuid>,
+) -> Result<Json<SystemStatsResponse>, CvmAgentHandlerError> {
+    let port = state.services.workload.cvm_agent_port(path.0).await?;
+    let result = state.clients.cvm_agent.system_stats(port).await;
+    match result {
+        Ok(response) => Ok(Json(response)),
+        Err(e) => Err(CvmAgentHandlerError::Internal(e.to_string())),
+    }
+}


### PR DESCRIPTION
This exposes the new cvm-agent endpoints to get system logs and memory/cpu stats nilcc-agent and nilcc-agent-cli:

<img width="1996" height="198" alt="image" src="https://github.com/user-attachments/assets/73bf3d27-97b0-494a-a61a-3848e9994361" />
