### PR TITLE
feat: validate domains in nilcc-agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2216,7 +2216,6 @@ dependencies = [
  "async-trait",
  "axum",
  "axum-server",
- "axum-valid",
  "chrono",
  "clap",
  "cvm-agent-models",

--- a/crates/nilcc-agent-models/src/lib.rs
+++ b/crates/nilcc-agent-models/src/lib.rs
@@ -90,7 +90,7 @@ pub mod workloads {
     pub mod delete {
         use super::*;
 
-        #[derive(Clone, Debug, Serialize, Deserialize)]
+        #[derive(Clone, Debug, Serialize, Deserialize, Validate)]
         #[serde(rename_all = "camelCase")]
         pub struct DeleteWorkloadRequest {
             pub id: Uuid,
@@ -100,7 +100,7 @@ pub mod workloads {
     pub mod start {
         use super::*;
 
-        #[derive(Clone, Debug, Serialize, Deserialize)]
+        #[derive(Clone, Debug, Serialize, Deserialize, Validate)]
         #[serde(rename_all = "camelCase")]
         pub struct StartWorkloadRequest {
             pub id: Uuid,
@@ -110,7 +110,7 @@ pub mod workloads {
     pub mod stop {
         use super::*;
 
-        #[derive(Clone, Debug, Serialize, Deserialize)]
+        #[derive(Clone, Debug, Serialize, Deserialize, Validate)]
         #[serde(rename_all = "camelCase")]
         pub struct StopWorkloadRequest {
             pub id: Uuid,
@@ -120,7 +120,7 @@ pub mod workloads {
     pub mod restart {
         use super::*;
 
-        #[derive(Clone, Debug, Serialize, Deserialize)]
+        #[derive(Clone, Debug, Serialize, Deserialize, Validate)]
         #[serde(rename_all = "camelCase")]
         pub struct RestartWorkloadRequest {
             pub id: Uuid,
@@ -132,7 +132,7 @@ pub mod errors {
     use super::*;
 
     /// An error when handling a request.
-    #[derive(Debug, Serialize, Deserialize)]
+    #[derive(Clone, Debug, Serialize, Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct RequestHandlerError {
         /// A descriptive message about the error that was encountered.

--- a/nilcc-agent/Cargo.toml
+++ b/nilcc-agent/Cargo.toml
@@ -8,7 +8,6 @@ anyhow = "1.0"
 async-trait = "0.1"
 axum = { version = "0.8", features = ["json"] }
 axum-server = "0.7"
-axum-valid = "0.24"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.5", features = ["derive", "env"] }
 docker-compose-types = "0.19.0"

--- a/nilcc-agent/clippy.toml
+++ b/nilcc-agent/clippy.toml
@@ -1,0 +1,5 @@
+disallowed-types = [
+  { path = "axum::Json", reason = "use crate::routes::Json"},
+  { path = "axum::extract::Json", reason = "use crate::routes::Json"},
+  { path = "axum::extract::Query", reason = "use crate::routes::Query"},
+]

--- a/nilcc-agent/src/routes/workloads/containers/list.rs
+++ b/nilcc-agent/src/routes/workloads/containers/list.rs
@@ -1,8 +1,5 @@
-use crate::routes::{workloads::containers::CvmAgentHandlerError, AppState};
-use axum::{
-    extract::{Path, State},
-    Json,
-};
+use crate::routes::{workloads::containers::CvmAgentHandlerError, AppState, Json};
+use axum::extract::{Path, State};
 use cvm_agent_models::container::Container;
 use uuid::Uuid;
 

--- a/nilcc-agent/src/routes/workloads/containers/logs.rs
+++ b/nilcc-agent/src/routes/workloads/containers/logs.rs
@@ -1,12 +1,8 @@
 use crate::{
     clients::cvm_agent::CvmAgentRequestError,
-    routes::{workloads::containers::CvmAgentHandlerError, AppState},
+    routes::{workloads::containers::CvmAgentHandlerError, AppState, Json, Query},
 };
-use axum::{
-    extract::{Path, Query, State},
-    Json,
-};
-use axum_valid::Valid;
+use axum::extract::{Path, State};
 use cvm_agent_models::logs::{ContainerLogsRequest, ContainerLogsResponse};
 use reqwest::StatusCode;
 use uuid::Uuid;
@@ -14,7 +10,7 @@ use uuid::Uuid;
 pub(crate) async fn handler(
     state: State<AppState>,
     path: Path<Uuid>,
-    request: Valid<Query<ContainerLogsRequest>>,
+    request: Query<ContainerLogsRequest>,
 ) -> Result<Json<ContainerLogsResponse>, CvmAgentHandlerError> {
     let port = state.services.workload.cvm_agent_port(path.0).await?;
     let result = state.clients.cvm_agent.container_logs(port, &request.0).await;

--- a/nilcc-agent/src/routes/workloads/create.rs
+++ b/nilcc-agent/src/routes/workloads/create.rs
@@ -7,7 +7,6 @@ use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
 };
-use axum_valid::Valid;
 use cvm_agent_models::bootstrap::CADDY_ACME_EAB_KEY_ID;
 use docker_compose_types::Compose;
 use nilcc_agent_models::workloads::create::{CreateWorkloadRequest, CreateWorkloadResponse};
@@ -17,7 +16,7 @@ use tracing::error;
 
 pub(crate) async fn handler(
     state: State<AppState>,
-    request: Valid<Json<CreateWorkloadRequest>>,
+    request: Json<CreateWorkloadRequest>,
 ) -> Result<Json<CreateWorkloadResponse>, HandlerError> {
     let limits = &state.resource_limits;
     let checks = [
@@ -37,7 +36,7 @@ pub(crate) async fn handler(
     validate_compose_file(&request)?;
 
     let id = request.id;
-    state.services.workload.create_workload(request.0 .0).await?;
+    state.services.workload.create_workload(request.0).await?;
     Ok(Json(CreateWorkloadResponse { id }))
 }
 

--- a/nilcc-agent/src/routes/workloads/list.rs
+++ b/nilcc-agent/src/routes/workloads/list.rs
@@ -1,5 +1,8 @@
-use crate::{routes::AppState, services::workload::WorkloadLookupError};
-use axum::{extract::State, Json};
+use crate::{
+    routes::{AppState, Json},
+    services::workload::WorkloadLookupError,
+};
+use axum::extract::State;
 use nilcc_agent_models::workloads::list::WorkloadSummary;
 
 pub(crate) async fn handler(state: State<AppState>) -> Result<Json<Vec<WorkloadSummary>>, WorkloadLookupError> {


### PR DESCRIPTION
This validates the domain for workloads in nilcc-agent using a somewhat simple regex.

While doing this I also realized the `axum_valid::Valid` error was bypassing the JSON error response and after trying to catch it properly I ended up dropping the crate and making our `Json` type validate that too. I also added a `Query` that does the same. In order to avoid accidentally using the axum types with the same name I added some clippy rules to warn when those are in use.