### PR TITLE
feat: expose disk stats in cvm-agent

### DIFF
--- a/crates/cvm-agent-models/src/lib.rs
+++ b/crates/cvm-agent-models/src/lib.rs
@@ -128,6 +128,8 @@ pub mod logs {
 }
 
 pub mod stats {
+    use std::path::PathBuf;
+
     use super::*;
 
     /// The stats response.
@@ -137,8 +139,11 @@ pub mod stats {
         /// Stats about the memory usage.
         pub memory: MemoryStats,
 
-        /// Stats about CPUs.
+        /// Stats about every CPU.
         pub cpus: Vec<CpuStats>,
+
+        /// Stats about every disk.
+        pub disks: Vec<DiskStats>,
     }
 
     /// Memory stats.
@@ -164,5 +169,25 @@ pub mod stats {
 
         /// The frequency, in MHz.
         pub frequency: u64,
+    }
+
+    /// Disk stats.
+    #[derive(Deserialize, Serialize)]
+    #[serde(rename_all = "kebab-case")]
+    pub struct DiskStats {
+        /// The name of this disk.
+        pub name: String,
+
+        /// The path where the filesystem is mounted.
+        pub mount_point: PathBuf,
+
+        /// The type of filesystem.
+        pub filesystem: String,
+
+        /// The total size of this disk.
+        pub size: u64,
+
+        /// The used space this disk.
+        pub used: u64,
     }
 }

--- a/cvm-agent/Cargo.toml
+++ b/cvm-agent/Cargo.toml
@@ -11,7 +11,7 @@ clap = { version = "4.5", features = ["derive", "string"] }
 futures = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-sysinfo = { version = "0.36", default-features = false, features = ["system"] }
+sysinfo = { version = "0.36", default-features = false, features = ["system", "disk"] }
 tempfile = "3.20"
 tokio = { version =  "1.46", features = ["fs", "macros", "process", "rt", "signal"] }
 tokio-stream = { version = "0.1", features = ["io-util"]}

--- a/cvm-agent/src/routes/system/stats.rs
+++ b/cvm-agent/src/routes/system/stats.rs
@@ -1,6 +1,8 @@
 use axum::{http::StatusCode, Json};
-use cvm_agent_models::stats::{CpuStats, MemoryStats, SystemStatsResponse};
-use sysinfo::{CpuRefreshKind, MemoryRefreshKind, RefreshKind, System, MINIMUM_CPU_UPDATE_INTERVAL};
+use cvm_agent_models::stats::{CpuStats, DiskStats, MemoryStats, SystemStatsResponse};
+use sysinfo::{
+    CpuRefreshKind, DiskRefreshKind, Disks, MemoryRefreshKind, RefreshKind, System, MINIMUM_CPU_UPDATE_INTERVAL,
+};
 use tokio::time::sleep;
 
 pub(crate) async fn handler() -> Result<Json<SystemStatsResponse>, StatusCode> {
@@ -11,12 +13,37 @@ pub(crate) async fn handler() -> Result<Json<SystemStatsResponse>, StatusCode> {
     sleep(MINIMUM_CPU_UPDATE_INTERVAL).await;
     stats.refresh_cpu_usage();
 
-    let cpus = stats
+    let cpus = cpu_stats(&stats);
+    let memory = memory_stats(&stats);
+    let disks = disk_stats();
+    let response = SystemStatsResponse { memory, cpus, disks };
+    Ok(Json(response))
+}
+
+fn cpu_stats(stats: &System) -> Vec<CpuStats> {
+    stats
         .cpus()
         .iter()
         .map(|cpu| CpuStats { name: cpu.name().to_string(), usage: cpu.cpu_usage(), frequency: cpu.frequency() })
-        .collect();
-    let memory = MemoryStats { total: stats.total_memory(), used: stats.used_memory() };
-    let response = SystemStatsResponse { memory, cpus };
-    Ok(Json(response))
+        .collect()
+}
+
+fn memory_stats(stats: &System) -> MemoryStats {
+    MemoryStats { total: stats.total_memory(), used: stats.used_memory() }
+}
+
+fn disk_stats() -> Vec<DiskStats> {
+    let specifics = DiskRefreshKind::nothing().with_storage();
+    let disks = Disks::new_with_refreshed_list_specifics(specifics);
+    disks
+        .list()
+        .iter()
+        .map(|d| DiskStats {
+            name: d.name().to_string_lossy().to_string(),
+            filesystem: d.file_system().to_string_lossy().to_string(),
+            mount_point: d.mount_point().to_path_buf(),
+            size: d.total_space(),
+            used: d.total_space().saturating_sub(d.available_space()),
+        })
+        .collect()
 }


### PR DESCRIPTION
This exposes disk stats in cvm-agent, nilcc-agent and nilcc-agent-cli:

```
/o/w/n/nilcc-agent-cli (feat/disk-stats|✔) $ ../target/debug/nilcc-agent-cli system stats 4b5bd559-7235-43e0-a42a-5a7e4a4d5c21
Mem usage: 352MB/900MB
CPU usage:
* cpu0 (2999 MHz): 0.0%
Disks:
* /dev/mapper/root mounted at / (ext4): 3.69GB/9.23GB
* /dev/mapper/state mounted at /var (ext4): 1.11GB/9.73GB
* /dev/sda1 mounted at /boot/efi (vfat): 0.01GB/0.52GB
* overlay mounted at /var/lib/docker/overlay2/290f88bfe12b3a2a026e4208722b940a108a48ba00595c84e700c7108b7694be/merged (overlay): 1.11GB/9.73GB
* overlay mounted at /var/lib/docker/overlay2/a2f8433ce0880f5b08d588fa898827151cc5da5f4ff005998544a51dd8146956/merged (overlay): 1.11GB/9.73GB
* overlay mounted at /var/lib/docker/overlay2/3b38b18ca188a641143af6993728684fae438f09889719dfb901c3bb7cc8ec69/merged (overlay): 1.11GB/9.73GB
/o/w/n/nilcc-agent-cli (feat/disk-stats|✔) $
```

Closes #236