### PR TITLE
feat: add admin API key to access metal instance endpoints

### DIFF
--- a/nilcc-api/.env.test
+++ b/nilcc-api/.env.test
@@ -4,6 +4,7 @@ APP_ENABLED_FEATURES=openapi,prometheus-metrics,migrations,response-validation,l
 APP_LOG_LEVEL=debug
 APP_METRICS_PORT=9091
 APP_HTTP_API_PORT=8080
+APP_ADMIN_API_KEY=admin-api-key
 APP_METAL_INSTANCE_API_KEY=your-metal-instance-api-key
 APP_USER_API_KEY=your-user-api-key
 APP_WORKLOADS_DNS_ZONE=public.localhost

--- a/nilcc-api/src/env.ts
+++ b/nilcc-api/src/env.ts
@@ -70,6 +70,7 @@ export const EnvVarsSchema = z.object({
   logLevel: z.enum(LOG_LEVELS),
   metricsPort: z.number().int().positive(),
   httpApiPort: z.number().int().positive(),
+  adminApiKey: z.string(),
   metalInstanceApiKey: z.string(),
   userApiKey: z.string(),
   workloadsDnsDomain: z.string(),
@@ -92,6 +93,7 @@ declare global {
       APP_LOG_LEVEL: string;
       APP_METRICS_PORT: string;
       APP_HTTP_API_PORT: string;
+      APP_ADMIN_API_KEY: string;
       APP_METAL_INSTANCE_API_KEY: string;
       APP_USER_API_KEY: string;
       APP_WORKLOADS_DNS_ZONE: string;
@@ -172,6 +174,7 @@ export function parseConfigFromEnv(overrides: Partial<EnvVars>): EnvVars {
     logLevel: process.env.APP_LOG_LEVEL,
     metricsPort: Number(process.env.APP_METRICS_PORT),
     httpApiPort: Number(process.env.APP_HTTP_API_PORT),
+    adminApiKey: process.env.APP_ADMIN_API_KEY,
     metalInstanceApiKey: process.env.APP_METAL_INSTANCE_API_KEY,
     userApiKey: process.env.APP_USER_API_KEY,
     workloadsDnsDomain: process.env.APP_WORKLOADS_DNS_DOMAIN,

--- a/nilcc-api/src/metal-instance/metal-instance.controller.ts
+++ b/nilcc-api/src/metal-instance/metal-instance.controller.ts
@@ -104,7 +104,7 @@ export function read(options: ControllerOptions) {
         ...OpenApiSpecCommonErrorResponses,
       },
     }),
-    apiKey(bindings.config.userApiKey),
+    apiKey(bindings.config.adminApiKey),
     pathValidator(idParamSchema),
     responseValidator(bindings, GetMetalInstanceResponse),
     async (c) => {
@@ -137,7 +137,7 @@ export function list(options: ControllerOptions) {
         ...OpenApiSpecCommonErrorResponses,
       },
     }),
-    apiKey(bindings.config.userApiKey),
+    apiKey(bindings.config.adminApiKey),
     responseValidator(bindings, ListMetalInstancesResponse),
     async (c) => {
       const instances = await bindings.services.metalInstance.list(bindings);
@@ -160,7 +160,7 @@ export function remove(options: ControllerOptions) {
         ...OpenApiSpecCommonErrorResponses,
       },
     }),
-    apiKey(bindings.config.userApiKey),
+    apiKey(bindings.config.adminApiKey),
     payloadValidator(DeleteMetalInstanceRequest),
     async (c) => {
       const payload = c.req.valid("json");

--- a/nilcc-api/tests/fixture/fixture.ts
+++ b/nilcc-api/tests/fixture/fixture.ts
@@ -5,14 +5,19 @@ import { type Logger, pino } from "pino";
 import { DataSource } from "typeorm";
 import { buildApp } from "#/app";
 import { type AppBindings, type AppEnv, loadBindings } from "#/env";
-import { MetalInstanceClient, UserClient } from "./test-client";
+import { AdminClient, MetalInstanceClient, UserClient } from "./test-client";
+
+export type TestClients = {
+  admin: AdminClient;
+  user: UserClient;
+  metalInstance: MetalInstanceClient;
+};
 
 export type TestFixture = {
   app: Hono<AppEnv>;
   log: Logger;
   bindings: AppBindings;
-  userClient: UserClient;
-  metalInstanceClient: MetalInstanceClient;
+  clients: TestClients;
 };
 
 function createTestLogger(id: string): Logger {
@@ -46,16 +51,22 @@ export async function buildFixture(): Promise<TestFixture> {
   log.info("Creating app");
   const { app } = await buildApp(bindings);
 
-  const userClient = new UserClient({
-    app,
-    bindings,
-  });
-  const metalInstanceClient = new MetalInstanceClient({
-    app,
-    bindings,
-  });
+  const clients = {
+    admin: new AdminClient({
+      app,
+      bindings,
+    }),
+    user: new UserClient({
+      app,
+      bindings,
+    }),
+    metalInstance: new MetalInstanceClient({
+      app,
+      bindings,
+    }),
+  };
   log.info("Test suite ready");
-  return { app, log, bindings, userClient, metalInstanceClient };
+  return { app, log, bindings, clients };
 }
 
 async function createDatabase(dbUri: string, log: Logger): Promise<void> {

--- a/nilcc-api/tests/fixture/it.ts
+++ b/nilcc-api/tests/fixture/it.ts
@@ -2,14 +2,12 @@ import type { Logger } from "pino";
 import * as vitest from "vitest";
 import type { App } from "#/app";
 import type { AppBindings } from "#/env";
-import { buildFixture, type TestFixture } from "./fixture";
-import type { MetalInstanceClient, UserClient } from "./test-client";
+import { buildFixture, type TestClients, type TestFixture } from "./fixture";
 
 export type FixtureContext = {
   app: App;
   bindings: AppBindings;
-  userClient: UserClient;
-  metalInstanceClient: MetalInstanceClient; // Assuming you have a metal instance client similar to workload client
+  clients: TestClients;
 };
 
 type TestFixtureExtension = {
@@ -31,13 +29,9 @@ export function createTestFixtureExtension(): TestFixtureExtension {
       if (!fixture) throw new Error("Fixture is not initialized");
       await use(fixture.bindings);
     },
-    userClient: async ({}, use) => {
+    clients: async ({}, use) => {
       if (!fixture) throw new Error("Fixture is not initialized");
-      await use(fixture.userClient);
-    },
-    metalInstanceClient: async ({}, use) => {
-      if (!fixture) throw new Error("Fixture is not initialized");
-      await use(fixture.metalInstanceClient);
+      await use(fixture.clients);
     },
   });
   // biome-ignore-end lint/correctness/noEmptyPattern: Vitest fixture API requires this parameter structure

--- a/nilcc-api/tests/fixture/test-client.ts
+++ b/nilcc-api/tests/fixture/test-client.ts
@@ -87,6 +87,31 @@ export class ParseableResponse<T> {
   }
 }
 
+export class AdminClient extends TestClient {
+  override extraHeaders(): Record<string, string> {
+    return {
+      "x-api-key": this.bindings.config.adminApiKey,
+    };
+  }
+
+  async getMetalInstance(params: { id: string }) {
+    const response = await this.request(
+      PathsV1.metalInstance.read.replace(":id", params.id),
+      {
+        method: "GET",
+      },
+    );
+    return new ParseableResponse(response, GetMetalInstanceResponse);
+  }
+
+  async deleteMetalInstance(id: string): Promise<Response> {
+    return await this.request(PathsV1.metalInstance.delete, {
+      method: "POST",
+      body: { id },
+    });
+  }
+}
+
 export class UserClient extends TestClient {
   override extraHeaders(): Record<string, string> {
     return {
@@ -135,26 +160,6 @@ export class UserClient extends TestClient {
     });
   }
 
-  async getMetalInstance(params: { id: string }) {
-    const response = await this.request(
-      PathsV1.metalInstance.read.replace(":id", params.id),
-      {
-        method: "GET",
-      },
-    );
-    return new ParseableResponse(response, GetMetalInstanceResponse);
-  }
-
-  async submitEvent(request: SubmitEventRequest) {
-    return this.request(PathsV1.workloadEvents.submit, {
-      method: "POST",
-      body: request,
-      headers: {
-        "x-api-key": this.bindings.config.metalInstanceApiKey,
-      },
-    });
-  }
-
   async getWorkloadEvents(
     request: ListWorkloadEventsRequest,
   ): Promise<ParseableResponse<ListWorkloadEventsResponse>> {
@@ -163,13 +168,6 @@ export class UserClient extends TestClient {
       body: request,
     });
     return new ParseableResponse(response, ListWorkloadEventsResponse);
-  }
-
-  async deleteMetalInstance(id: string): Promise<Response> {
-    return await this.request(PathsV1.metalInstance.delete, {
-      method: "POST",
-      body: { id },
-    });
   }
 }
 
@@ -191,6 +189,16 @@ export class MetalInstanceClient extends TestClient {
     return await this.request(PathsV1.metalInstance.heartbeat, {
       method: "POST",
       body,
+    });
+  }
+
+  async submitEvent(request: SubmitEventRequest) {
+    return this.request(PathsV1.workloadEvents.submit, {
+      method: "POST",
+      body: request,
+      headers: {
+        "x-api-key": this.bindings.config.metalInstanceApiKey,
+      },
     });
   }
 }


### PR DESCRIPTION
This adds an admin API key and uses it for metal instance management endpoints, e.g. listing, deleting, etc. 

Closes #239 