### PR TITLE
chore: refactor nilcc-api tests

### DIFF
--- a/nilcc-api/src/metal-instance/metal-instance.controller.ts
+++ b/nilcc-api/src/metal-instance/metal-instance.controller.ts
@@ -49,7 +49,7 @@ export function register(options: ControllerOptions) {
         payload,
         c.get("txQueryRunner"),
       );
-      return c.body(null);
+      return c.json({});
     },
   );
 }
@@ -80,7 +80,7 @@ export function heartbeat(options: ControllerOptions) {
         payload,
         c.get("txQueryRunner"),
       );
-      return c.body(null);
+      return c.json({});
     },
   );
 }
@@ -164,11 +164,8 @@ export function remove(options: ControllerOptions) {
     payloadValidator(DeleteMetalInstanceRequest),
     async (c) => {
       const payload = c.req.valid("json");
-      const instances = await bindings.services.metalInstance.remove(
-        bindings,
-        payload.id,
-      );
-      return c.json(instances);
+      await bindings.services.metalInstance.remove(bindings, payload.id);
+      return c.json({});
     },
   );
 }

--- a/nilcc-api/src/metal-instance/metal-instance.service.ts
+++ b/nilcc-api/src/metal-instance/metal-instance.service.ts
@@ -35,10 +35,7 @@ export class MetalInstanceService {
     return await repository.findOneBy({ id: metalInstanceId });
   }
 
-  async remove(
-    bindings: AppBindings,
-    metalInstanceId: string,
-  ): Promise<boolean> {
+  async remove(bindings: AppBindings, metalInstanceId: string): Promise<void> {
     const repository = this.getRepository(bindings);
     const instances = await repository.find({
       where: { id: metalInstanceId },
@@ -51,12 +48,11 @@ export class MetalInstanceService {
     if (instance.workloads.length > 0) {
       throw new MetalInstanceManagingWorkloads();
     }
-    const result = await repository.delete({ id: metalInstanceId });
+    await repository.delete({ id: metalInstanceId });
     await bindings.services.dns.metalInstances.deleteRecord(
       metalInstanceId,
       "CNAME",
     );
-    return result.affected ? result.affected > 0 : false;
   }
 
   async createOrUpdate(

--- a/nilcc-api/src/workload-event/workload-event.controllers.ts
+++ b/nilcc-api/src/workload-event/workload-event.controllers.ts
@@ -38,7 +38,7 @@ export function submitEvent(options: ControllerOptions) {
         payload,
         c.get("txQueryRunner"),
       );
-      return c.body(null);
+      return c.json({});
     },
   );
 }

--- a/nilcc-api/src/workload/workload.controllers.ts
+++ b/nilcc-api/src/workload/workload.controllers.ts
@@ -180,7 +180,7 @@ export function remove(options: ControllerOptions): void {
         workloadId,
         c.get("txQueryRunner"),
       );
-      return c.body(null);
+      return c.json({});
     },
   );
 }


### PR DESCRIPTION
This simplifies tests in nilcc-api so we don't need so many function calls and intermediate variables.