### PR TITLE
feat: add migrations support in nilcc-api

### DIFF
--- a/nilcc-api/.env.dev
+++ b/nilcc-api/.env.dev
@@ -1,6 +1,6 @@
 APP_DB_URI=postgres://postgres:postgres@postgress:5432/nilcc_db
 APP_LOCALSTACK_URI=http://localstack:4566
-APP_ENABLED_FEATURES=openapi,prometheus-metrics,migrations,response-validation,localstack,pretty-logs,http-error-stacktrace
+APP_ENABLED_FEATURES=openapi,prometheus-metrics,response-validation,localstack,pretty-logs,http-error-stacktrace
 APP_LOG_LEVEL=debug
 APP_METRICS_PORT=9091
 APP_HTTP_API_PORT=8080

--- a/nilcc-api/.env.sample
+++ b/nilcc-api/.env.sample
@@ -1,5 +1,5 @@
 APP_DB_URI=postgres://postgres:postgres@localhost:5432/postgres
-APP_ENABLED_FEATURES=openapi,prometheus-metrics,migrations,response-validation
+APP_ENABLED_FEATURES=openapi,prometheus-metrics,response-validation
 APP_LOG_LEVEL=debug
 APP_METRICS_PORT=9091
 APP_HTTP_API_PORT=8080

--- a/nilcc-api/.env.test
+++ b/nilcc-api/.env.test
@@ -1,6 +1,6 @@
 APP_DB_URI=postgres://postgres:postgres@localhost:35432/postgres
 APP_LOCALSTACK_URI=http://localhost:4566
-APP_ENABLED_FEATURES=openapi,prometheus-metrics,migrations,response-validation,localstack,pretty-logs,http-error-stacktrace
+APP_ENABLED_FEATURES=openapi,prometheus-metrics,response-validation,localstack,pretty-logs,http-error-stacktrace,auto-migrations
 APP_LOG_LEVEL=debug
 APP_METRICS_PORT=9091
 APP_HTTP_API_PORT=8080

--- a/nilcc-api/README.md
+++ b/nilcc-api/README.md
@@ -1,0 +1,17 @@
+# nilcc-api
+
+This is the public facing API that allows interacting with nilcc.
+
+# Migrations
+
+nilcc-api uses [typeorm](https://typeorm.io/) to manage database interactions and migrations.
+
+Adding new migrations can be done by using `pnpm typeorm`:
+
+```bash
+pnpm typeorm migration:create migrations/AddSomethingCool
+```
+
+Migrations also need to be added to the `DataSource` setup in the [buildDataSource](src/data-source.ts) function.
+
+

--- a/nilcc-api/bin/migrate.ts
+++ b/nilcc-api/bin/migrate.ts
@@ -1,1 +1,0 @@
-throw new Error("TODO do migrations");

--- a/nilcc-api/migrations/1754946297570-InitialState.ts
+++ b/nilcc-api/migrations/1754946297570-InitialState.ts
@@ -1,0 +1,35 @@
+import type { MigrationInterface, QueryRunner } from "typeorm";
+
+export class InitialState1754946297570 implements MigrationInterface {
+  name = "InitialState1754946297570";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "workload_entity" ("id" uuid NOT NULL, "name" character varying NOT NULL, "description" character varying, "tags" text, "dockerCompose" text NOT NULL, "envVars" text, "files" text, "serviceToExpose" character varying NOT NULL, "servicePortToExpose" integer NOT NULL, "memory" integer NOT NULL, "cpus" integer NOT NULL, "gpus" integer NOT NULL, "disk" integer NOT NULL, "status" character varying NOT NULL DEFAULT 'scheduled', "createdAt" TIMESTAMP NOT NULL, "updatedAt" TIMESTAMP NOT NULL, "metalInstanceId" uuid, CONSTRAINT "PK_4ab39b05ae550427c975bcb8918" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "workload_event_entity" ("id" uuid NOT NULL, "event" character varying NOT NULL, "details" character varying, "timestamp" TIMESTAMP NOT NULL, "workloadId" uuid, CONSTRAINT "PK_c6871be28c1582e2c9fb25b3371" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "metal_instance_entity" ("id" uuid NOT NULL, "hostname" character varying NOT NULL, "publicIp" character varying NOT NULL, "token" character varying NOT NULL, "agentVersion" character varying NOT NULL, "totalMemory" integer NOT NULL, "osReservedMemory" integer NOT NULL, "totalCpus" integer NOT NULL, "osReservedCpus" integer NOT NULL, "totalDisk" integer NOT NULL, "osReservedDisk" integer NOT NULL, "gpus" integer NOT NULL, "gpuModel" character varying, "createdAt" TIMESTAMP NOT NULL, "updatedAt" TIMESTAMP NOT NULL, "lastSeenAt" TIMESTAMP NOT NULL, CONSTRAINT "PK_8a9c95e60531975c99dc1859567" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "workload_entity" ADD CONSTRAINT "FK_8e17bda79146efc4778f1d96d11" FOREIGN KEY ("metalInstanceId") REFERENCES "metal_instance_entity"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "workload_event_entity" ADD CONSTRAINT "FK_2020172c2f6e609ec597f6fc215" FOREIGN KEY ("workloadId") REFERENCES "workload_entity"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "workload_event_entity" DROP CONSTRAINT "FK_2020172c2f6e609ec597f6fc215"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "workload_entity" DROP CONSTRAINT "FK_8e17bda79146efc4778f1d96d11"`,
+    );
+    await queryRunner.query(`DROP TABLE "metal_instance_entity"`);
+    await queryRunner.query(`DROP TABLE "workload_event_entity"`);
+    await queryRunner.query(`DROP TABLE "workload_entity"`);
+  }
+}

--- a/nilcc-api/package.json
+++ b/nilcc-api/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "tsx src/main.ts",
     "test": "vitest --run tests/",
-    "migrate": "tsx bin/migrate.ts",
+    "typeorm": "tsx ./node_modules/typeorm/cli.js",
     "fetch-compose-schema": "tsx bin/fetch-compose-schema.ts",
     "fmt": "biome format .",
     "compile": "tsc"

--- a/nilcc-api/src/data-source.ts
+++ b/nilcc-api/src/data-source.ts
@@ -7,35 +7,27 @@ import {
 } from "typeorm";
 import "reflect-metadata";
 import type { Context, Next } from "hono";
-import type { Logger } from "pino";
+import { InitialState1754946297570 } from "migrations/1754946297570-InitialState";
 import { DataSource } from "typeorm";
-import { type EnvVars, FeatureFlag, hasFeatureFlag } from "#/env";
+import type { EnvVars } from "#/env";
 import { MetalInstanceEntity } from "#/metal-instance/metal-instance.entity";
 import {
   WorkloadEntity,
   WorkloadEventEntity,
 } from "#/workload/workload.entity";
 
-export async function buildDataSource(
-  config: EnvVars,
-  log: Logger,
-): Promise<DataSource> {
-  const synchronize = hasFeatureFlag(
-    config.enabledFeatures,
-    FeatureFlag.MIGRATIONS,
-  );
-
+export async function buildDataSource(config: EnvVars): Promise<DataSource> {
   const dataSource = new DataSource({
     type: "postgres",
     url: config.dbUri,
     entities: [WorkloadEntity, MetalInstanceEntity, WorkloadEventEntity],
     subscribers: [NullToUndefinedSubscriber],
-    synchronize,
+    // We can't use globs (e.g. `migrations/*.ts`) here because of some very reasonable problem with typescript
+    migrations: [InitialState1754946297570],
+    synchronize: false,
     logging: false,
+    migrationsRun: true,
   });
-
-  log.debug("Initializing database");
-  await dataSource.initialize();
 
   return dataSource;
 }

--- a/nilcc-api/src/env.ts
+++ b/nilcc-api/src/env.ts
@@ -19,10 +19,10 @@ export const LOG_LEVELS = ["debug", "info", "warn", "error"] as const;
 export const FeatureFlag = {
   OPENAPI_SPEC: "openapi",
   PROMETHEUS_METRICS: "prometheus-metrics",
-  MIGRATIONS: "migrations",
   LOCALSTACK: "localstack",
   PRETTY_LOGS: "pretty-logs",
   HTTP_ERROR_STACKTRACE: "http-error-stacktrace",
+  AUTO_MIGRATIONS: "auto-migrations",
 } as const;
 
 export type FeatureFlag = (typeof FeatureFlag)[keyof typeof FeatureFlag];
@@ -116,7 +116,9 @@ export async function loadBindings(
     hasFeatureFlag(config.enabledFeatures, FeatureFlag.PRETTY_LOGS),
   );
 
-  const dataSource = await buildDataSource(config, log);
+  const dataSource = await buildDataSource(config);
+  log.debug("Initializing database");
+  await dataSource.initialize();
 
   const services = await buildServices(config, log);
 

--- a/nilcc-api/src/migration.data-source.ts
+++ b/nilcc-api/src/migration.data-source.ts
@@ -1,0 +1,7 @@
+import "./effects";
+
+import { buildDataSource } from "./data-source";
+import { parseConfigFromEnv } from "./env";
+
+const config = parseConfigFromEnv({});
+export default buildDataSource(config);

--- a/nilcc-api/vitest.config.ts
+++ b/nilcc-api/vitest.config.ts
@@ -3,6 +3,11 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   plugins: [tsconfigPaths()],
+  esbuild: {
+    // Transpile all files with ESBuild to remove comments from code coverage.
+    // Required for `test.coverage.ignoreEmptyLines` to work:
+    include: ["**/*.js", "**/*.jsx", "**/*.mjs", "**/*.ts", "**/*.tsx"],
+  },
   test: {
     globalSetup: "./tests/fixture/global-setup.ts",
     testTimeout: 0,


### PR DESCRIPTION
This adds db migrations support in nilcc-api. I hit some typescript issue when using glob imports for migration files so for now I'm importing the types directly which isn't great but works.

Migrations are applied automatically as part of the app's initialization.