### PR TITLE
feat: allow computing measurement hashes via nilcc-verifier

### DIFF
--- a/nilcc-verifier/src/verify.rs
+++ b/nilcc-verifier/src/verify.rs
@@ -43,6 +43,7 @@ impl ReportVerifier {
 
         Self::verify_report_signature(&certs.vcek, &report).context("verifying report signature")?;
         Self::verify_attestation_tcb(&certs.vcek, &report, &processor).context("verifying attestation TCB")?;
+        info!("Verification successful");
         Ok(())
     }
 


### PR DESCRIPTION
This adds a `measurement-hash` subcommand to nilcc-verifier that downloads artifacts for a version and spits out the expected measurement hash.