### PR TITLE
feat: add initial account management support

### DIFF
--- a/nilcc-api/migrations/1755033746208-Account.ts
+++ b/nilcc-api/migrations/1755033746208-Account.ts
@@ -1,0 +1,15 @@
+import type { MigrationInterface, QueryRunner } from "typeorm";
+
+export class Account1755033746208 implements MigrationInterface {
+  name = "Account1755033746208";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "account_entity" ("id" character varying NOT NULL, "name" character varying NOT NULL, "apiToken" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL, CONSTRAINT "UQ_8caa8ac488d153a508cdd657011" UNIQUE ("name"), CONSTRAINT "PK_b482dad15becff9a89ad707dcbe" PRIMARY KEY ("id"))`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "account_entity"`);
+  }
+}

--- a/nilcc-api/src/account/account.controller.ts
+++ b/nilcc-api/src/account/account.controller.ts
@@ -1,0 +1,89 @@
+import { describeRoute } from "hono-openapi";
+import { z } from "zod";
+import { apiKey } from "#/common/auth";
+import { OpenApiSpecCommonErrorResponses } from "#/common/openapi";
+import { PathsV1 } from "#/common/paths";
+import type { ControllerOptions } from "#/common/types";
+import { pathValidator, payloadValidator } from "#/common/zod-utils";
+import { CreateAccountRequest } from "./account.dto";
+import { accountMapper } from "./account.mapper";
+
+const idParamSchema = z.object({ id: z.string().uuid() });
+
+export function create(options: ControllerOptions) {
+  const { app, bindings } = options;
+  app.post(
+    PathsV1.account.create,
+    describeRoute({
+      tags: ["account"],
+      summary: "Create a new account",
+      description:
+        "This will create an account and return its details including its API key",
+      responses: {
+        200: {
+          description: "Account created successfully",
+        },
+        ...OpenApiSpecCommonErrorResponses,
+      },
+    }),
+    apiKey(bindings.config.adminApiKey),
+    payloadValidator(CreateAccountRequest),
+    async (c) => {
+      const payload = c.req.valid("json");
+      const account = await bindings.services.account.create(
+        bindings,
+        payload.name,
+      );
+      return c.json(accountMapper.entityToResponse(account));
+    },
+  );
+}
+
+export function list(options: ControllerOptions) {
+  const { app, bindings } = options;
+  app.get(
+    PathsV1.account.list,
+    describeRoute({
+      tags: ["account"],
+      summary: "List all accounts",
+      description: "This endpoint lists all available accounts",
+      responses: {
+        200: {
+          description: "The accounts were listed successfully",
+        },
+        ...OpenApiSpecCommonErrorResponses,
+      },
+    }),
+    apiKey(bindings.config.adminApiKey),
+    async (c) => {
+      const accounts = await bindings.services.account.list(bindings);
+      return c.json(accounts.map(accountMapper.entityToResponse));
+    },
+  );
+}
+
+export function read(options: ControllerOptions) {
+  const { app, bindings } = options;
+  app.get(
+    PathsV1.account.read,
+    describeRoute({
+      tags: ["account"],
+      summary: "Get information about an account",
+      description:
+        "This endpoint fetches all information about an account by id",
+      responses: {
+        200: {
+          description: "The account information was retrieved successfully",
+        },
+        ...OpenApiSpecCommonErrorResponses,
+      },
+    }),
+    apiKey(bindings.config.adminApiKey),
+    pathValidator(idParamSchema),
+    async (c) => {
+      const params = c.req.valid("param");
+      const account = await bindings.services.account.read(bindings, params.id);
+      return c.json(account);
+    },
+  );
+}

--- a/nilcc-api/src/account/account.dto.ts
+++ b/nilcc-api/src/account/account.dto.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+export const Account = z
+  .object({
+    id: z.string(),
+    name: z.string().max(32),
+    apiToken: z.string(),
+    createdAt: z.string().datetime(),
+  })
+  .openapi({
+    ref: "Account",
+  });
+export type Account = z.infer<typeof Account>;
+
+export const CreateAccountRequest = z
+  .object({
+    name: z.string(),
+  })
+  .openapi({
+    ref: "CreateAccountRequest",
+  });
+export type CreateAccountRequest = z.infer<typeof CreateAccountRequest>;

--- a/nilcc-api/src/account/account.entity.ts
+++ b/nilcc-api/src/account/account.entity.ts
@@ -1,0 +1,16 @@
+import { Column, Entity, PrimaryColumn } from "typeorm";
+
+@Entity()
+export class AccountEntity {
+  @PrimaryColumn({ type: "varchar" })
+  id: string;
+
+  @Column({ type: "varchar", unique: true })
+  name: string;
+
+  @Column({ type: "varchar" })
+  apiToken: string;
+
+  @Column({ type: "timestamp" })
+  createdAt: Date;
+}

--- a/nilcc-api/src/account/account.mapper.ts
+++ b/nilcc-api/src/account/account.mapper.ts
@@ -1,0 +1,13 @@
+import type { Account } from "./account.dto";
+import type { AccountEntity } from "./account.entity";
+
+export const accountMapper = {
+  entityToResponse(account: AccountEntity): Account {
+    return {
+      id: account.id,
+      createdAt: account.createdAt.toISOString(),
+      name: account.name,
+      apiToken: account.apiToken,
+    };
+  },
+};

--- a/nilcc-api/src/account/account.router.ts
+++ b/nilcc-api/src/account/account.router.ts
@@ -1,0 +1,8 @@
+import type { ControllerOptions } from "#/common/types";
+import * as AccountController from "./account.controller";
+
+export function buildAccountRouter(options: ControllerOptions): void {
+  AccountController.create(options);
+  AccountController.list(options);
+  AccountController.read(options);
+}

--- a/nilcc-api/src/account/account.service.ts
+++ b/nilcc-api/src/account/account.service.ts
@@ -1,0 +1,47 @@
+import * as crypto from "node:crypto";
+import { QueryFailedError, type QueryRunner, type Repository } from "typeorm";
+import { v4 as uuidv4 } from "uuid";
+import { AccountAlreadyExists } from "#/common/errors";
+import type { AppBindings } from "#/env";
+import { AccountEntity } from "./account.entity";
+
+const API_TOKEN_BYTE_LENGTH: number = 16;
+
+export class AccountService {
+  getRepository(
+    bindings: AppBindings,
+    tx?: QueryRunner,
+  ): Repository<AccountEntity> {
+    if (tx) {
+      return tx.manager.getRepository(AccountEntity);
+    }
+    return bindings.dataSource.getRepository(AccountEntity);
+  }
+
+  async create(bindings: AppBindings, name: string): Promise<AccountEntity> {
+    const repository = this.getRepository(bindings);
+    try {
+      return await repository.save({
+        id: uuidv4(),
+        name,
+        apiToken: crypto.randomBytes(API_TOKEN_BYTE_LENGTH).toString("hex"),
+        createdAt: new Date(),
+      });
+    } catch (e: unknown) {
+      if (e instanceof QueryFailedError && e.driverError.code === "23505") {
+        throw new AccountAlreadyExists();
+      }
+      throw e;
+    }
+  }
+
+  async read(bindings: AppBindings, id: string): Promise<AccountEntity | null> {
+    const repository = this.getRepository(bindings);
+    return await repository.findOneBy({ id });
+  }
+
+  async list(bindings: AppBindings): Promise<AccountEntity[]> {
+    const repository = this.getRepository(bindings);
+    return await repository.find();
+  }
+}

--- a/nilcc-api/src/app.ts
+++ b/nilcc-api/src/app.ts
@@ -6,6 +6,7 @@ import { bodyLimit } from "hono/body-limit";
 import { timeout } from "hono/timeout";
 import { Temporal } from "temporal-polyfill";
 import { errorHandler } from "#/common/handler";
+import { buildAccountRouter } from "./account/account.router";
 import {
   type AppBindings,
   type AppEnv,
@@ -42,6 +43,7 @@ export async function buildApp(
     createOpenApiRouter({ app, bindings });
   }
 
+  buildAccountRouter({ app, bindings });
   buildWorkloadRouter({ app, bindings });
   buildWorkloadContainerRouter({ app, bindings });
   buildWorkloadEventRouter({ app, bindings });

--- a/nilcc-api/src/common/errors.ts
+++ b/nilcc-api/src/common/errors.ts
@@ -54,3 +54,13 @@ export class EntityNotFound extends AppError {
     this.description = `${entity} not found`;
   }
 }
+
+export class AccountAlreadyExists extends AppError {
+  kind = "ACCOUNT_ALREADY_EXISTS";
+  override statusCode: ContentfulStatusCode = StatusCodes.CONFLICT;
+
+  constructor() {
+    super();
+    this.description = "account already exists";
+  }
+}

--- a/nilcc-api/src/common/paths.ts
+++ b/nilcc-api/src/common/paths.ts
@@ -12,6 +12,11 @@ export type Path = z.infer<typeof PathSchema>;
 
 export const PathsV1 = {
   docs: PathSchema.parse("/openapi.json"),
+  account: {
+    create: PathSchema.parse("/api/v1/accounts/create"),
+    list: PathSchema.parse("/api/v1/accounts/list"),
+    read: PathSchema.parse("/api/v1/accounts/:id"),
+  },
   workload: {
     create: PathSchema.parse("/api/v1/workloads/create"),
     list: PathSchema.parse("/api/v1/workloads/list"),

--- a/nilcc-api/src/data-source.ts
+++ b/nilcc-api/src/data-source.ts
@@ -8,6 +8,7 @@ import {
 import "reflect-metadata";
 import type { Context, Next } from "hono";
 import { InitialState1754946297570 } from "migrations/1754946297570-InitialState";
+import { Account1755033746208 } from "migrations/1755033746208-Account";
 import { DataSource } from "typeorm";
 import type { EnvVars } from "#/env";
 import { MetalInstanceEntity } from "#/metal-instance/metal-instance.entity";
@@ -15,15 +16,21 @@ import {
   WorkloadEntity,
   WorkloadEventEntity,
 } from "#/workload/workload.entity";
+import { AccountEntity } from "./account/account.entity";
 
 export async function buildDataSource(config: EnvVars): Promise<DataSource> {
   const dataSource = new DataSource({
     type: "postgres",
     url: config.dbUri,
-    entities: [WorkloadEntity, MetalInstanceEntity, WorkloadEventEntity],
+    entities: [
+      AccountEntity,
+      WorkloadEntity,
+      MetalInstanceEntity,
+      WorkloadEventEntity,
+    ],
     subscribers: [NullToUndefinedSubscriber],
     // We can't use globs (e.g. `migrations/*.ts`) here because of some very reasonable problem with typescript
-    migrations: [InitialState1754946297570],
+    migrations: [InitialState1754946297570, Account1755033746208],
     synchronize: false,
     logging: false,
     migrationsRun: true,

--- a/nilcc-api/src/env.ts
+++ b/nilcc-api/src/env.ts
@@ -5,6 +5,7 @@ import { createLogger } from "#/common/logger";
 import { buildDataSource } from "#/data-source";
 import { MetalInstanceService } from "#/metal-instance/metal-instance.service";
 import { WorkloadService } from "#/workload/workload.service";
+import { AccountService } from "./account/account.service";
 import {
   DefaultNilccAgentClient,
   type NilccAgentClient,
@@ -51,6 +52,7 @@ export type DnsServices = {
 export type AppServices = {
   metalInstance: MetalInstanceService;
   workload: WorkloadService;
+  account: AccountService;
   dns: DnsServices;
   nilccAgentClient: NilccAgentClient;
 };
@@ -152,6 +154,7 @@ async function buildServices(
 
   const metalInstanceService = new MetalInstanceService();
   const workloadService = new WorkloadService();
+  const accountService = new AccountService();
   const nilccAgentClient = new DefaultNilccAgentClient(
     config.metalInstancesEndpointScheme,
     config.metalInstancesDnsDomain,
@@ -162,6 +165,7 @@ async function buildServices(
   return {
     metalInstance: metalInstanceService,
     workload: workloadService,
+    account: accountService,
     dns,
     nilccAgentClient,
   };

--- a/nilcc-api/tests/account.test.ts
+++ b/nilcc-api/tests/account.test.ts
@@ -1,0 +1,35 @@
+import { describe } from "vitest";
+import { createTestFixtureExtension } from "./fixture/it";
+
+describe("Account", () => {
+  const { it, beforeAll, afterAll } = createTestFixtureExtension();
+
+  beforeAll(async (_ctx) => {});
+  afterAll(async (_ctx) => {});
+
+  it("should create an account that hasn't been created", async ({
+    expect,
+    clients,
+  }) => {
+    const name = "my favorite account";
+    const account = await clients.admin.createAccount(name).submit();
+    expect(account.name).toBe(name);
+
+    // Creating it again should fail
+    expect(await clients.admin.createAccount(name).status()).toBe(409);
+  });
+
+  it("should allow listing", async ({ expect, clients }) => {
+    const name = "another account";
+    const account = await clients.admin.createAccount(name).submit();
+    const accounts = await clients.admin.listAccounts().submit();
+    expect(accounts).toContainEqual(account);
+  });
+
+  it("should allow lookups", async ({ expect, clients }) => {
+    const name = "yet another account";
+    const account = await clients.admin.createAccount(name).submit();
+    const details = await clients.admin.getAccount(account.id).submit();
+    expect(details).toEqual(account);
+  });
+});

--- a/nilcc-api/tests/fixture/test-client.ts
+++ b/nilcc-api/tests/fixture/test-client.ts
@@ -1,4 +1,5 @@
 import { type ZodType, z } from "zod";
+import { Account } from "#/account/account.dto";
 import type { App } from "#/app";
 import { PathsV1 } from "#/common/paths";
 import type { AppBindings } from "#/env";
@@ -113,6 +114,28 @@ export class AdminClient extends TestClient {
       body: { id },
     });
     return new RequestPromise(promise, z.unknown());
+  }
+
+  createAccount(name: string): RequestPromise<Account> {
+    const promise = this.request(PathsV1.account.create, {
+      method: "POST",
+      body: { name },
+    });
+    return new RequestPromise(promise, Account);
+  }
+
+  listAccounts(): RequestPromise<Account[]> {
+    const promise = this.request(PathsV1.account.list, {
+      method: "GET",
+    });
+    return new RequestPromise(promise, Account.array());
+  }
+
+  getAccount(id: string): RequestPromise<Account> {
+    const promise = this.request(PathsV1.account.read.replace(":id", id), {
+      method: "GET",
+    });
+    return new RequestPromise(promise, Account);
   }
 }
 


### PR DESCRIPTION
This adds endpoints to create and list accounts. 

Relates to #248 