### PR TITLE
feat: print only measurement hash in nilcc-verifier

### DIFF
--- a/nilcc-verifier/Cargo.toml
+++ b/nilcc-verifier/Cargo.toml
@@ -17,7 +17,7 @@ sev = { version = "6.1", default-features = false, features = ["openssl", "snp"]
 thiserror = "2.0"
 tokio = { version = "1.45", features = ["rt"] }
 tracing = "0.1"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 x509-parser = { version = "0.17.0", features = ["verify"] } 
 
 [dev-dependencies]


### PR DESCRIPTION
By default now no logs are printed and the measurement hash is printed on its own. If you run with `--verbose` this uses `INFO` as the default log level, but can also be overridden via `RUST_LOG`.