### PR TITLE
feat: login to docker hub to prevent rate limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,6 +869,7 @@ dependencies = [
 name = "cvm-agent"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "axum",
  "axum-valid",
  "bollard",

--- a/crates/cvm-agent-models/src/lib.rs
+++ b/crates/cvm-agent-models/src/lib.rs
@@ -13,11 +13,40 @@ pub mod bootstrap {
     /// A request to bootstrap the CVM.
     #[derive(Deserialize, Serialize)]
     pub struct BootstrapRequest {
-        /// The ACME EAB key id.
+        /// Deprecated: The ACME EAB key id.
         pub acme_eab_key_id: String,
 
-        /// The ACME EAB MAC key.
+        /// Deprecated: The ACME EAB MAC key.
         pub acme_eab_mac_key: String,
+
+        /// The ACME credentials.
+        pub acme: AcmeCredentials,
+
+        /// The docker credentials to use.
+        pub docker: Vec<DockerCredentials>,
+    }
+
+    /// The ACME credentials.
+    #[derive(Deserialize, Serialize)]
+    pub struct AcmeCredentials {
+        /// The ACME EAB key id.
+        pub eab_key_id: String,
+
+        /// The ACME EAB MAC key.
+        pub eab_mac_key: String,
+    }
+
+    /// A set of docker credentials to use.
+    #[derive(Deserialize, Serialize)]
+    pub struct DockerCredentials {
+        /// The username.
+        pub username: String,
+
+        /// The password.
+        pub password: String,
+
+        /// The optional server.
+        pub server: Option<String>,
     }
 }
 

--- a/cvm-agent/Cargo.toml
+++ b/cvm-agent/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 axum = { version = "0.8", features = ["json"] }
 axum-valid = "0.24"
+anyhow = "1"
 bollard = "0.19"
 clap = { version = "4.5", features = ["derive", "string"] }
 futures = "0.3"

--- a/cvm-agent/src/main.rs
+++ b/cvm-agent/src/main.rs
@@ -81,6 +81,8 @@ fn build_bootstrap_context(cli: &Cli) -> (TempDir, BootstrapContext) {
     let resources = Resources::render(&metadata);
     let system_compose_path = state_dir.path().join("docker-compose.yaml");
     let caddy_path = state_dir.path().join("Caddyfile");
+    let docker_config_path = state_dir.path().join("docker");
+    fs::create_dir_all(&docker_config_path).expect("failed to create docker config path");
     fs::write(&system_compose_path, resources.docker_compose).expect("failed to write docker-compose.yaml");
     fs::write(&caddy_path, resources.caddyfile).expect("failed to write Caddyfile");
 
@@ -91,6 +93,7 @@ fn build_bootstrap_context(cli: &Cli) -> (TempDir, BootstrapContext) {
         user_docker_compose: user_compose_path,
         external_files: external_files_path,
         caddy_config: caddy_path,
+        docker_config: docker_config_path,
         version,
         vm_type,
         iso_mount: cli.iso_mount_path.clone(),

--- a/cvm-agent/src/monitors/compose.rs
+++ b/cvm-agent/src/monitors/compose.rs
@@ -1,7 +1,10 @@
 use crate::routes::BootstrapContext;
-use cvm_agent_models::bootstrap::{CADDY_ACME_EAB_KEY_ID, CADDY_ACME_EAB_MAC_KEY};
+use anyhow::{bail, Context};
+use cvm_agent_models::bootstrap::{AcmeCredentials, DockerCredentials, CADDY_ACME_EAB_KEY_ID, CADDY_ACME_EAB_MAC_KEY};
 use std::{io, process::Stdio, time::Duration};
 use tokio::{
+    fs,
+    io::AsyncWriteExt,
     process::{Child, Command},
     time::sleep,
 };
@@ -12,13 +15,13 @@ const RETRY_INTERVAL: Duration = Duration::from_secs(10);
 
 pub(crate) struct ComposeMonitor {
     ctx: BootstrapContext,
-    acme_eab_key_id: String,
-    acme_eab_mac_key: String,
+    acme: AcmeCredentials,
+    docker: Vec<DockerCredentials>,
 }
 
 impl ComposeMonitor {
-    pub(crate) fn spawn(ctx: BootstrapContext, acme_eab_key_id: String, acme_eab_mac_key: String) {
-        let monitor = ComposeMonitor { ctx, acme_eab_key_id, acme_eab_mac_key };
+    pub(crate) fn spawn(ctx: BootstrapContext, acme: AcmeCredentials, docker: Vec<DockerCredentials>) {
+        let monitor = ComposeMonitor { ctx, acme, docker };
         info!("Spawning docker compose monitor");
         tokio::spawn(async move {
             monitor.run().await;
@@ -26,6 +29,20 @@ impl ComposeMonitor {
     }
 
     async fn run(self) {
+        loop {
+            info!("Pulling docker images");
+            match self.pull_images().await {
+                Ok(_) => {
+                    info!("Images pulled successfully");
+                    break;
+                }
+                Err(e) => {
+                    error!("Failed to pull images: {e:#}");
+                    info!("Sleeping for {RETRY_INTERVAL:?}");
+                    sleep(RETRY_INTERVAL).await;
+                }
+            }
+        }
         loop {
             info!("Launching docker compose");
             match self.launch_compose().await {
@@ -45,9 +62,69 @@ impl ComposeMonitor {
         }
     }
 
-    async fn launch_compose(&self) -> io::Result<Child> {
+    async fn docker_login(&self, credentials: &DockerCredentials) -> anyhow::Result<()> {
+        let registry = match &credentials.server {
+            Some(server) => server.as_str(),
+            None => "docker hub",
+        };
+        info!("Logging in to {registry}");
+
         let mut command = Command::new("docker");
-        let command = command
+        let mut command = command
+            .arg("--config")
+            .arg(&self.ctx.docker_config)
+            .arg("login")
+            .arg("-u")
+            .arg(&credentials.username)
+            .arg("--password-stdin")
+            .stdin(Stdio::piped())
+            .stderr(Stdio::piped());
+        if let Some(server) = &credentials.server {
+            command = command.arg(server);
+        }
+        let mut child = command.spawn().context("Failed to invoke docker login")?;
+        {
+            let mut stdin = child.stdin.take().expect("no stdin");
+            stdin.write_all(credentials.password.as_bytes()).await.context("Failed to write docker login password")?;
+        }
+        let output = child.wait_with_output().await.context("Failed to wait for docker login")?;
+        if output.status.success() {
+            Ok(())
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            bail!("docker login failed: {stderr}")
+        }
+    }
+
+    async fn pull_images(&self) -> anyhow::Result<()> {
+        for credential in &self.docker {
+            self.docker_login(credential).await.context("Failed to docker login")?;
+        }
+        info!("Running docker compose pull");
+        let output =
+            self.base_docker_command().arg("pull").output().await.context("Failed to run docker compose pull")?;
+        if output.status.success() {
+            if !self.docker.is_empty() {
+                info!("Removing docker config.json file");
+                // this isn't needed anymore because we already pulled images
+                fs::remove_file(&self.ctx.docker_config.join("config.json"))
+                    .await
+                    .context("Failed to remove docker config")?;
+            }
+            Ok(())
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            bail!("docker compose pull failed: {stderr}")
+        }
+    }
+
+    async fn launch_compose(&self) -> io::Result<Child> {
+        self.base_docker_command().arg("up").arg("-d").spawn()
+    }
+
+    fn base_docker_command(&self) -> Command {
+        let mut command = Command::new("docker");
+        command
             .current_dir(&self.ctx.iso_mount)
             // pass in `FILES` which points to `<iso>/files`
             .env("FILES", self.ctx.external_files.as_os_str())
@@ -55,9 +132,11 @@ impl ComposeMonitor {
             .env("CADDY_INPUT_FILE", self.ctx.caddy_config.as_os_str())
             .env("NILCC_VERSION", &self.ctx.version)
             .env("NILCC_VM_TYPE", self.ctx.vm_type.to_string())
-            .env(CADDY_ACME_EAB_KEY_ID, &self.acme_eab_key_id)
-            .env(CADDY_ACME_EAB_MAC_KEY, &self.acme_eab_mac_key)
+            .env(CADDY_ACME_EAB_KEY_ID, &self.acme.eab_key_id)
+            .env(CADDY_ACME_EAB_MAC_KEY, &self.acme.eab_mac_key)
             .stderr(Stdio::piped())
+            .arg("--config")
+            .arg(&self.ctx.docker_config)
             .arg("compose")
             // set a well defined project name, this is used as a prefix for container names
             .arg("-p")
@@ -67,10 +146,8 @@ impl ComposeMonitor {
             .arg(&self.ctx.user_docker_compose)
             // then ours
             .arg("-f")
-            .arg(&self.ctx.system_docker_compose)
-            .arg("up")
-            .arg("-d");
-        command.spawn()
+            .arg(&self.ctx.system_docker_compose);
+        command
     }
 
     async fn check_process_output(child: Child) -> bool {

--- a/cvm-agent/src/routes/mod.rs
+++ b/cvm-agent/src/routes/mod.rs
@@ -29,6 +29,7 @@ pub struct BootstrapContext {
     pub user_docker_compose: PathBuf,
     pub external_files: PathBuf,
     pub caddy_config: PathBuf,
+    pub docker_config: PathBuf,
     pub version: String,
     pub vm_type: VmType,
     pub iso_mount: PathBuf,

--- a/cvm-agent/src/routes/system/bootstrap.rs
+++ b/cvm-agent/src/routes/system/bootstrap.rs
@@ -13,7 +13,7 @@ pub(crate) async fn handler(state: SharedState, request: Json<BootstrapRequest>)
     let request = request.0;
     let ctx = state.context.clone();
     *system_state = SystemState::Starting;
-    ComposeMonitor::spawn(ctx, request.acme_eab_key_id, request.acme_eab_mac_key);
+    ComposeMonitor::spawn(ctx, request.acme, request.docker);
     CaddyMonitor::spawn(state.docker.clone(), state.system_state.clone());
     StatusCode::OK
 }

--- a/nilcc-agent/src/config.rs
+++ b/nilcc-agent/src/config.rs
@@ -38,6 +38,9 @@ pub struct AgentConfig {
     /// The zero SSL config.
     pub zerossl: ZeroSslConfig,
 
+    /// The docker hub credentials.
+    pub docker: DockerConfig,
+
     /// The optional TLS configuration.
     #[serde(default)]
     pub tls: Option<TlsConfig>,
@@ -236,6 +239,16 @@ pub struct TlsConfig {
 
     /// The contact email address to use for ACME requests.
     pub acme_contact: String,
+}
+
+/// The docker hub credentials to use.
+#[derive(Clone, Debug, Deserialize)]
+pub struct DockerConfig {
+    /// The username.
+    pub username: String,
+
+    /// The password.
+    pub password: String,
 }
 
 pub fn read_file_as_string<'de, D>(deserializer: D) -> Result<String, D::Error>

--- a/nilcc-agent/src/main.rs
+++ b/nilcc-agent/src/main.rs
@@ -216,6 +216,7 @@ async fn run_daemon(config: AgentConfig) -> Result<()> {
         disk_service: Box::new(DefaultDiskService::new(config.qemu.img_bin)),
         cvm_config: config.cvm,
         zerossl_config: config.zerossl,
+        docker_config: config.docker,
     })
     .await?;
     let workload_service = DefaultWorkloadService::new(WorkloadServiceArgs {


### PR DESCRIPTION
This PR: 

* Adds docker hub credentials in nilcc-agent which are sent as part of the bootstrap request to cvm-agent.
* cvm-agent now logs in with those credentials, does a docker compose pull and deletes the credentials file.

This will help prevent docker hub rate limits _and_ it also sets the groundwork to be able to support private registries.

#255