### PR TITLE
chore: use consistent names for identifiers

### DIFF
--- a/nilcc-agent/src/clients/nilcc_api.rs
+++ b/nilcc-agent/src/clients/nilcc_api.rs
@@ -155,6 +155,7 @@ impl NilccApiClient for DummyNilccApiClient {
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RegisterRequest {
+    #[serde(rename = "metalInstanceId")]
     id: Uuid,
     agent_version: String,
     public_ip: String,
@@ -179,6 +180,7 @@ struct Resource {
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct VmEventRequest {
+    #[serde(rename = "metalInstanceId")]
     agent_id: Uuid,
     workload_id: Uuid,
     event: VmEvent,
@@ -187,5 +189,6 @@ struct VmEventRequest {
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct HeartbeatRequest {
+    #[serde(rename = "metalInstanceId")]
     id: Uuid,
 }

--- a/nilcc-api/src/account/account.controller.ts
+++ b/nilcc-api/src/account/account.controller.ts
@@ -1,6 +1,7 @@
 import { describeRoute } from "hono-openapi";
 import { z } from "zod";
 import { adminAuthentication } from "#/common/auth";
+import { EntityNotFound } from "#/common/errors";
 import { OpenApiSpecCommonErrorResponses } from "#/common/openapi";
 import { PathsV1 } from "#/common/paths";
 import type { ControllerOptions } from "#/common/types";
@@ -83,7 +84,10 @@ export function read(options: ControllerOptions) {
     async (c) => {
       const params = c.req.valid("param");
       const account = await bindings.services.account.read(bindings, params.id);
-      return c.json(account);
+      if (!account) {
+        throw new EntityNotFound("account");
+      }
+      return c.json(accountMapper.entityToResponse(account));
     },
   );
 }

--- a/nilcc-api/src/account/account.dto.ts
+++ b/nilcc-api/src/account/account.dto.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 export const Account = z
   .object({
-    id: z.string(),
+    accountId: z.string(),
     name: z.string().max(32),
     apiToken: z.string(),
     createdAt: z.string().datetime(),

--- a/nilcc-api/src/account/account.mapper.ts
+++ b/nilcc-api/src/account/account.mapper.ts
@@ -4,7 +4,7 @@ import type { AccountEntity } from "./account.entity";
 export const accountMapper = {
   entityToResponse(account: AccountEntity): Account {
     return {
-      id: account.id,
+      accountId: account.id,
       createdAt: account.createdAt.toISOString(),
       name: account.name,
       apiToken: account.apiToken,

--- a/nilcc-api/src/metal-instance/metal-instance.controller.ts
+++ b/nilcc-api/src/metal-instance/metal-instance.controller.ts
@@ -167,7 +167,10 @@ export function remove(options: ControllerOptions) {
     payloadValidator(DeleteMetalInstanceRequest),
     async (c) => {
       const payload = c.req.valid("json");
-      await bindings.services.metalInstance.remove(bindings, payload.id);
+      await bindings.services.metalInstance.remove(
+        bindings,
+        payload.metalInstanceId,
+      );
       return c.json({});
     },
   );

--- a/nilcc-api/src/metal-instance/metal-instance.dto.ts
+++ b/nilcc-api/src/metal-instance/metal-instance.dto.ts
@@ -9,7 +9,7 @@ export type Resource = z.infer<typeof Resource>;
 
 export const RegisterMetalInstanceRequest = z
   .object({
-    id: Uuid,
+    metalInstanceId: Uuid,
     agentVersion: z.string().min(1, "Agent version is required"),
     publicIp: z.string().ip({ version: "v4" }),
     token: z.string(),
@@ -27,14 +27,14 @@ export type RegisterMetalInstanceRequest = z.infer<
 
 export const HeartbeatRequest = z
   .object({
-    id: Uuid,
+    metalInstanceId: Uuid,
   })
   .openapi({ ref: "HeartbeatRequest" });
 export type HeartbeatRequest = z.infer<typeof HeartbeatRequest>;
 
 export const GetMetalInstanceResponse = z
   .object({
-    id: Uuid,
+    metalInstanceId: Uuid,
     agentVersion: z.string(),
     hostname: z.string(),
     publicIp: z.string(),
@@ -61,7 +61,7 @@ export type ListMetalInstancesResponse = z.infer<
 
 export const DeleteMetalInstanceRequest = z
   .object({
-    id: Uuid,
+    metalInstanceId: Uuid,
   })
   .openapi({
     ref: "DeleteMetalInstanceRequest",
@@ -81,7 +81,7 @@ export type WorkloadEventKind = z.infer<typeof WorkloadEventKind>;
 
 export const SubmitEventRequest = z
   .object({
-    agentId: Uuid,
+    metalInstanceId: Uuid,
     workloadId: Uuid,
     event: WorkloadEventKind,
   })

--- a/nilcc-api/src/metal-instance/metal-instance.mapper.ts
+++ b/nilcc-api/src/metal-instance/metal-instance.mapper.ts
@@ -21,7 +21,7 @@ export const metalInstanceMapper = {
         total: metalInstance.totalDisk,
         reserved: metalInstance.osReservedDisk,
       },
-      id: metalInstance.id,
+      metalInstanceId: metalInstance.id,
       gpus: metalInstance.gpus,
       gpuModel: metalInstance.gpuModel ?? undefined,
       createdAt: metalInstance.createdAt.toISOString(),

--- a/nilcc-api/src/metal-instance/metal-instance.service.ts
+++ b/nilcc-api/src/metal-instance/metal-instance.service.ts
@@ -60,7 +60,11 @@ export class MetalInstanceService {
     request: RegisterMetalInstanceRequest,
     tx: QueryRunner,
   ) {
-    const maybeMetalInstance = await this.read(bindings, request.id, tx);
+    const maybeMetalInstance = await this.read(
+      bindings,
+      request.metalInstanceId,
+      tx,
+    );
     if (maybeMetalInstance) {
       return this.update(bindings, request, maybeMetalInstance, tx);
     }
@@ -72,7 +76,11 @@ export class MetalInstanceService {
     request: HeartbeatRequest,
     tx: QueryRunner,
   ) {
-    const metalInstance = await this.read(bindings, request.id, tx);
+    const metalInstance = await this.read(
+      bindings,
+      request.metalInstanceId,
+      tx,
+    );
     if (metalInstance === null) {
       throw new EntityNotFound("metal instance");
     }
@@ -158,7 +166,7 @@ export class MetalInstanceService {
     const repository = this.getRepository(bindings, tx);
     const now = new Date();
     const newMetalInstance = repository.create({
-      id: request.id,
+      id: request.metalInstanceId,
       agentVersion: request.agentVersion,
       token: request.token,
       publicIp: request.publicIp,
@@ -176,7 +184,7 @@ export class MetalInstanceService {
       lastSeenAt: now,
     });
     bindings.services.dns.metalInstances.createRecord(
-      request.id,
+      request.metalInstanceId,
       request.publicIp,
       "A",
     );

--- a/nilcc-api/src/workload-container/workload-container.dto.ts
+++ b/nilcc-api/src/workload-container/workload-container.dto.ts
@@ -4,7 +4,7 @@ import { Uuid } from "#/common/types";
 
 export const ListContainersRequest = z
   .object({
-    id: Uuid.openapi({
+    workloadId: Uuid.openapi({
       description:
         "The identifier for the workload to get a container list from.",
     }),
@@ -18,7 +18,7 @@ export const ListContainersResponse = z
 export type ListContainersResponse = z.infer<typeof ListContainersResponse>;
 
 export const WorkloadContainerLogsRequest = ContainerLogsRequest.extend({
-  id: Uuid.openapi({
+  workloadId: Uuid.openapi({
     description: "The identifier for the workloads to get container logs from.",
   }),
 }).openapi({ ref: "WorkloadContainerLogsRequest" });

--- a/nilcc-api/src/workload-event/workload-event.dto.ts
+++ b/nilcc-api/src/workload-event/workload-event.dto.ts
@@ -4,7 +4,7 @@ import { WorkloadEventKind } from "#/metal-instance/metal-instance.dto";
 
 export const WorkloadEvent = z
   .object({
-    id: Uuid,
+    eventId: Uuid,
     details: WorkloadEventKind,
     timestamp: z.string().datetime(),
   })

--- a/nilcc-api/src/workload/workload.controllers.ts
+++ b/nilcc-api/src/workload/workload.controllers.ts
@@ -179,7 +179,7 @@ export function remove(options: ControllerOptions): void {
     payloadValidator(DeleteWorkloadRequest),
     transactionMiddleware(bindings.dataSource),
     async (c) => {
-      const workloadId = c.req.valid("json").id;
+      const workloadId = c.req.valid("json").workloadId;
       await bindings.services.workload.remove(
         bindings,
         workloadId,

--- a/nilcc-api/src/workload/workload.dto.ts
+++ b/nilcc-api/src/workload/workload.dto.ts
@@ -101,7 +101,9 @@ export const CreateWorkloadRequest = z
 export type CreateWorkloadRequest = z.infer<typeof CreateWorkloadRequest>;
 
 export const CreateWorkloadResponse = CreateWorkloadRequest.extend({
-  id: Uuid.openapi({ description: "The identifier for this workload." }),
+  workloadId: Uuid.openapi({
+    description: "The identifier for this workload.",
+  }),
   status: z
     .enum(["scheduled", "starting", "running", "stopped", "error"])
     .openapi({ description: "The status of the workload." }),
@@ -114,7 +116,7 @@ export const CreateWorkloadResponse = CreateWorkloadRequest.extend({
   domain: z.string().openapi({
     description: "The domain where this workload is reachable via https.",
   }),
-  account: z.string().openapi({
+  accountId: z.string().openapi({
     description: "The account this workload belongs to.",
   }),
 }).openapi({ ref: "CreateWorkloadResponse" });
@@ -122,7 +124,7 @@ export type CreateWorkloadResponse = z.infer<typeof CreateWorkloadResponse>;
 
 export const DeleteWorkloadRequest = z
   .object({
-    id: Uuid.openapi({
+    workloadId: Uuid.openapi({
       description: "The identifier for the workload to be deleted.",
     }),
   })
@@ -140,7 +142,7 @@ export const ListWorkloadsResponse = z
 export type ListWorkloadsResponse = z.infer<typeof ListWorkloadsResponse>;
 
 export const WorkloadSystemLogsRequest = SystemLogsRequest.extend({
-  id: Uuid.openapi({
+  workloadId: Uuid.openapi({
     description: "The identifier for the workloads to get system logs from.",
   }),
 }).openapi({ ref: "WorkloadSystemLogsRequest" });

--- a/nilcc-api/src/workload/workload.mapper.ts
+++ b/nilcc-api/src/workload/workload.mapper.ts
@@ -7,7 +7,7 @@ export const workloadMapper = {
     workloadsDomain: string,
   ): CreateWorkloadResponse {
     return {
-      id: workload.id,
+      workloadId: workload.id,
       name: workload.name,
       dockerCompose: workload.dockerCompose,
       envVars: workload.envVars ?? undefined,
@@ -19,7 +19,7 @@ export const workloadMapper = {
       disk: workload.disk,
       status: workload.status,
       domain: `${workload.id}.${workloadsDomain}`,
-      account: workload.account.id,
+      accountId: workload.account.id,
       createdAt: workload.createdAt.toISOString(),
       updatedAt: workload.updatedAt.toISOString(),
     };

--- a/nilcc-api/src/workload/workload.service.ts
+++ b/nilcc-api/src/workload/workload.service.ts
@@ -231,7 +231,7 @@ export class WorkloadService {
           break;
       }
       return {
-        id: event.id,
+        eventId: event.id,
         details,
         timestamp: event.timestamp.toISOString(),
       };
@@ -245,9 +245,12 @@ export class WorkloadService {
     tx: QueryRunner,
   ): Promise<Array<string>> {
     const repository = this.getRepository(bindings, tx);
-    const workload = await this.findWorkload(repository, request.id, account, [
-      "metalInstance",
-    ]);
+    const workload = await this.findWorkload(
+      repository,
+      request.workloadId,
+      account,
+      ["metalInstance"],
+    );
     if (workload === null) {
       throw new EntityNotFound("workload");
     }
@@ -265,9 +268,12 @@ export class WorkloadService {
     tx: QueryRunner,
   ): Promise<Array<Container>> {
     const repository = this.getRepository(bindings, tx);
-    const workload = await this.findWorkload(repository, request.id, account, [
-      "metalInstance",
-    ]);
+    const workload = await this.findWorkload(
+      repository,
+      request.workloadId,
+      account,
+      ["metalInstance"],
+    );
     if (workload === null) {
       throw new EntityNotFound("workload");
     }
@@ -284,9 +290,12 @@ export class WorkloadService {
     tx: QueryRunner,
   ): Promise<Array<string>> {
     const repository = this.getRepository(bindings, tx);
-    const workload = await this.findWorkload(repository, request.id, account, [
-      "metalInstance",
-    ]);
+    const workload = await this.findWorkload(
+      repository,
+      request.workloadId,
+      account,
+      ["metalInstance"],
+    );
     if (workload === null) {
       throw new EntityNotFound("workload");
     }

--- a/nilcc-api/tests/account.test.ts
+++ b/nilcc-api/tests/account.test.ts
@@ -29,7 +29,7 @@ describe("Account", () => {
   it("should allow lookups", async ({ expect, clients }) => {
     const name = "yet another account";
     const account = await clients.admin.createAccount(name).submit();
-    const details = await clients.admin.getAccount(account.id).submit();
+    const details = await clients.admin.getAccount(account.accountId).submit();
     expect(details).toEqual(account);
   });
 });

--- a/nilcc-api/tests/fixture/test-client.ts
+++ b/nilcc-api/tests/fixture/test-client.ts
@@ -115,7 +115,7 @@ export class AdminClient extends TestClient {
   deleteMetalInstance(id: string): RequestPromise<unknown> {
     const promise = this.request(PathsV1.metalInstance.delete, {
       method: "POST",
-      body: { id },
+      body: { metalInstanceId: id },
     });
     return new RequestPromise(promise, z.unknown());
   }
@@ -172,7 +172,7 @@ export class UserClient extends TestClient {
     const promise = this.request(PathsV1.workload.delete, {
       method: "POST",
       body: {
-        id,
+        workloadId: id,
       },
     });
     return new RequestPromise(promise, z.unknown());
@@ -188,7 +188,7 @@ export class UserClient extends TestClient {
   }
 
   listContainers(id: string): RequestPromise<ListContainersResponse> {
-    const body: ListContainersRequest = { id };
+    const body: ListContainersRequest = { workloadId: id };
     const promise = this.request(PathsV1.workloadContainers.list, {
       method: "POST",
       body,
@@ -201,7 +201,7 @@ export class UserClient extends TestClient {
     container: string,
   ): RequestPromise<WorkloadContainerLogsResponse> {
     const body: WorkloadContainerLogsRequest = {
-      id,
+      workloadId: id,
       container,
       stream: "stdout",
       tail: false,
@@ -216,7 +216,7 @@ export class UserClient extends TestClient {
 
   logs(id: string): RequestPromise<WorkloadSystemLogsResponse> {
     const body: WorkloadSystemLogsRequest = {
-      id,
+      workloadId: id,
       source: "cvm-agent",
       tail: false,
       maxLines: 100,
@@ -241,7 +241,7 @@ export class MetalInstanceClient extends TestClient {
   heartbeat(id: string): RequestPromise<unknown> {
     const promise = this.request(PathsV1.metalInstance.heartbeat, {
       method: "POST",
-      body: { id },
+      body: { metalInstanceId: id },
     });
     return new RequestPromise(promise, z.unknown());
   }

--- a/nilcc-api/tests/metal-instance.test.ts
+++ b/nilcc-api/tests/metal-instance.test.ts
@@ -10,7 +10,7 @@ describe("Metal Instance", () => {
   afterAll(async (_ctx) => {});
 
   const myMetalInstance: RegisterMetalInstanceRequest = {
-    id: "c92c86e4-c7e5-4bb3-a5f5-45945b5593e4",
+    metalInstanceId: "c92c86e4-c7e5-4bb3-a5f5-45945b5593e4",
     agentVersion: "v0.1.0",
     publicIp: "127.0.0.1",
     token: "my_token",
@@ -35,13 +35,15 @@ describe("Metal Instance", () => {
     clients,
   }) => {
     expect(
-      await clients.admin.getMetalInstance(myMetalInstance.id).status(),
+      await clients.admin
+        .getMetalInstance(myMetalInstance.metalInstanceId)
+        .status(),
     ).equals(404);
 
     await clients.metalInstance.register(myMetalInstance).submit();
 
     const instance = await clients.admin
-      .getMetalInstance(myMetalInstance.id)
+      .getMetalInstance(myMetalInstance.metalInstanceId)
       .submit();
     const cleanInstance = {
       ...instance,
@@ -71,7 +73,7 @@ describe("Metal Instance", () => {
     await clients.metalInstance.register(updatedInstance).submit();
 
     const instance = await clients.admin
-      .getMetalInstance(myMetalInstance.id)
+      .getMetalInstance(myMetalInstance.metalInstanceId)
       .submit();
     const cleanInstance = {
       ...instance,
@@ -88,17 +90,19 @@ describe("Metal Instance", () => {
     clients,
   }) => {
     const instance = await clients.admin
-      .getMetalInstance(myMetalInstance.id)
+      .getMetalInstance(myMetalInstance.metalInstanceId)
       .submit();
     const lastSeen = new Date(instance.lastSeenAt);
 
     // sleep for a little bit and send a heartbeat
     await new Promise((resolve) => setTimeout(resolve, 200));
-    await clients.metalInstance.heartbeat(myMetalInstance.id).submit();
+    await clients.metalInstance
+      .heartbeat(myMetalInstance.metalInstanceId)
+      .submit();
 
     // now the last seen timestamp should be larger
     const updatedInstance = await clients.admin
-      .getMetalInstance(myMetalInstance.id)
+      .getMetalInstance(myMetalInstance.metalInstanceId)
       .submit();
     const currentLastSeen = new Date(updatedInstance.lastSeenAt);
     expect(currentLastSeen.getTime()).toBeGreaterThan(lastSeen.getTime());
@@ -106,7 +110,7 @@ describe("Metal Instance", () => {
 
   it("should allow deleting metal instances", async ({ expect, clients }) => {
     const instance = await clients.admin
-      .getMetalInstance(myMetalInstance.id)
+      .getMetalInstance(myMetalInstance.metalInstanceId)
       .submit();
 
     const createWorkloadRequest: CreateWorkloadRequest = {
@@ -130,12 +134,14 @@ services:
       .submit();
 
     // we shouldn't be able to delete it since it's running a workload
-    expect(await clients.admin.deleteMetalInstance(instance.id).status()).toBe(
-      412,
-    );
+    expect(
+      await clients.admin
+        .deleteMetalInstance(instance.metalInstanceId)
+        .status(),
+    ).toBe(412);
 
     // now delete the workload and successfully delete the instance
-    await clients.user.deleteWorkload(workload.id).submit();
-    clients.admin.deleteMetalInstance(instance.id).submit();
+    await clients.user.deleteWorkload(workload.workloadId).submit();
+    clients.admin.deleteMetalInstance(instance.metalInstanceId).submit();
   });
 });


### PR DESCRIPTION
This uses consistent names for all ids in nilcc-api.

Closes #268 