### PR TITLE
feat: add GPU attestations back

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2277,6 +2277,7 @@ dependencies = [
  "num_cpus",
  "rand 0.9.1",
  "serde",
+ "serde_with",
  "sev",
  "thiserror 2.0.12",
  "tokio",

--- a/nilcc-attester/Cargo.toml
+++ b/nilcc-attester/Cargo.toml
@@ -13,6 +13,7 @@ hex = { version = "0.4", features = ["serde"] }
 num_cpus = "1.16"
 rand = "0.9"
 serde = { version = "1.0", features = ["derive"] }
+serde_with = { version = "3.14", default-features = false, features = ["hex", "macros"] }
 sev = { version = "6.1", default-features = false, features = ["snp"] }
 thiserror = "2.0"
 tokio = { version = "1.45", features = ["rt-multi-thread", "macros", "process", "signal"] }


### PR DESCRIPTION
This adds GPU attestations back. Now this requires sending an additional `gpuNonce` field that contains a hex encoded 32 byte sequence (as opposed to the 64 bytes hex encoded SEV nonce). 