### PR TITLE
feat: attach GPUs in cvm-agent

### DIFF
--- a/cvm-agent/resources/docker-compose.yaml
+++ b/cvm-agent/resources/docker-compose.yaml
@@ -14,6 +14,7 @@ services:
       NO_COLOR: 1
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost/health"]
+    {DOCKER_COMPOSE_DEPLOY}
 
   nilcc-proxy:
     image: caddy:2.10.0
@@ -28,4 +29,3 @@ services:
       CADDY_ACME_EAB_MAC_KEY: ${CADDY_ACME_EAB_MAC_KEY}
     volumes:
       - ${CADDY_INPUT_FILE}:/etc/caddy/Caddyfile
-

--- a/cvm-agent/src/main.rs
+++ b/cvm-agent/src/main.rs
@@ -78,7 +78,7 @@ fn build_bootstrap_context(cli: &Cli) -> (TempDir, BootstrapContext) {
     let state_dir = tempdir().expect("failed to create tempdir");
     println!("Writing state files to {}", state_dir.path().display());
 
-    let resources = Resources::render(&metadata);
+    let resources = Resources::render(&metadata, &vm_type);
     let system_compose_path = state_dir.path().join("docker-compose.yaml");
     let caddy_path = state_dir.path().join("Caddyfile");
     let docker_config_path = state_dir.path().join("docker");


### PR DESCRIPTION
This makes the cvm-agent use a docker compose file with either a `deploy` section that attaches the GPUs to it or not depending on whether the VM is a cpu or gpu one.