### PR TITLE
feat: use read only disks and disk snapshots to avoid copies

### DIFF
--- a/nilcc-agent/src/workers/vm.rs
+++ b/nilcc-agent/src/workers/vm.rs
@@ -153,8 +153,9 @@ impl VmWorker {
                 error!("Failed to stop VM: {e}");
             }
         };
-        // Process all disks and the ISO at once
-        let paths = self.spec.hard_disks.iter().map(|s| &s.path).chain(self.spec.cdrom_iso_path.as_ref());
+        // Process all non read only disks and the ISO at once
+        let writeable_disks = self.spec.hard_disks.iter().filter(|d| !d.read_only);
+        let paths = writeable_disks.map(|s| &s.path).chain(self.spec.cdrom_iso_path.as_ref());
         for path in paths {
             let disk_display = path.display();
             info!("Deleting disk {disk_display}");


### PR DESCRIPTION
This PR reduces the need to copy disks when starting VMs, which lowers the disk usage for all VMs to essentially only their state disk + makes creating VMs much faster. The changes here are:

* Use `readonly` on the verity disk so we don't need to copy it at all.
* Use a disk snapshot (e.g. copy-on-write) for the base disk, which only weights a few hundred KBs as opposed to several GBs. I tried using `readonly` here too but it didn't work; not sure why but this works for now so it's not a problem.