### PR TITLE
feat: allow using custom domains in nilcc-api

### DIFF
--- a/nilcc-api/migrations/1755621623214-WorkloadDomain.ts
+++ b/nilcc-api/migrations/1755621623214-WorkloadDomain.ts
@@ -1,0 +1,17 @@
+import type { MigrationInterface, QueryRunner } from "typeorm";
+
+export class WorkloadDomain1755621623214 implements MigrationInterface {
+  name = "WorkloadDomain1755621623214";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "workload_entity" ADD COLUMN "domain" character varying DEFAULT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "workload_entity" DROP COLUMN "domain"`,
+    );
+  }
+}

--- a/nilcc-api/src/data-source.ts
+++ b/nilcc-api/src/data-source.ts
@@ -10,6 +10,7 @@ import type { Context, Next } from "hono";
 import { InitialState1754946297570 } from "migrations/1754946297570-InitialState";
 import { Account1755033746208 } from "migrations/1755033746208-Account";
 import { WorkloadAccount1755195024670 } from "migrations/1755195024670-WorkloadAccount";
+import { WorkloadDomain1755621623214 } from "migrations/1755621623214-WorkloadDomain";
 import { DataSource } from "typeorm";
 import type { EnvVars } from "#/env";
 import { MetalInstanceEntity } from "#/metal-instance/metal-instance.entity";
@@ -35,6 +36,7 @@ export async function buildDataSource(config: EnvVars): Promise<DataSource> {
       InitialState1754946297570,
       Account1755033746208,
       WorkloadAccount1755195024670,
+      WorkloadDomain1755621623214,
     ],
     synchronize: false,
     logging: false,

--- a/nilcc-api/src/dns/dns.service.ts
+++ b/nilcc-api/src/dns/dns.service.ts
@@ -71,7 +71,7 @@ export class Route53DnsService implements DnsService {
       },
     });
     this.log.info(
-      `Creating ${recordType} record ${fullDomain} pointing to ${to}`,
+      `Creating ${recordType} record ${fullDomain} pointing to ${to} on zone ${this.zoneId}`,
     );
     await this.route53.send(command);
   }
@@ -88,7 +88,9 @@ export class Route53DnsService implements DnsService {
       this.log.warn(`Domain ${fullDomain} does not exist, ignoring`);
       return;
     }
-    this.log.info(`Removing record for domain ${fullDomain}`);
+    this.log.info(
+      `Removing record for domain ${fullDomain} on zone ${this.zoneId}`,
+    );
     const command = new ChangeResourceRecordSetsCommand({
       HostedZoneId: this.zoneId,
       ChangeBatch: {
@@ -162,10 +164,8 @@ export class LocalStackDnsService extends Route53DnsService {
       },
     });
 
-    const zoneId = await LocalStackDnsService.createHostedZone(
-      subdomain,
-      route53,
-    );
+    const zoneId = await LocalStackDnsService.createHostedZone(zone, route53);
+    log.info(`Found zone id ${zoneId} for zone ${zone}`);
     return new LocalStackDnsService(zone, subdomain, zoneId, route53, log);
   }
 

--- a/nilcc-api/src/workload/workload.controllers.ts
+++ b/nilcc-api/src/workload/workload.controllers.ts
@@ -66,6 +66,7 @@ export function create(options: ControllerOptions): void {
         workloadMapper.entityToResponse(
           workload,
           bindings.config.workloadsDnsDomain,
+          bindings.config.metalInstancesDnsDomain,
         ),
       );
     },
@@ -106,6 +107,7 @@ export function list(options: ControllerOptions): void {
           workloadMapper.entityToResponse(
             w,
             bindings.config.workloadsDnsDomain,
+            bindings.config.metalInstancesDnsDomain,
           ),
         ),
       );
@@ -154,6 +156,7 @@ export function read(options: ControllerOptions): void {
         workloadMapper.entityToResponse(
           workload,
           bindings.config.workloadsDnsDomain,
+          bindings.config.metalInstancesDnsDomain,
         ),
       );
     },

--- a/nilcc-api/src/workload/workload.dto.ts
+++ b/nilcc-api/src/workload/workload.dto.ts
@@ -49,6 +49,14 @@ export const CreateWorkloadRequest = z
           },
         ],
       }),
+    domain: z
+      .string()
+      .optional()
+      .openapi({
+        description:
+          "The optional domain to use for this workload. If none is provided, a nilcc-managed domain will be generated.",
+        examples: ["example.com"],
+      }),
     publicContainerName: z
       .string()
       .min(1, "public container name cannot be empty")
@@ -118,6 +126,10 @@ export const CreateWorkloadResponse = CreateWorkloadRequest.extend({
   }),
   accountId: z.string().openapi({
     description: "The account this workload belongs to.",
+  }),
+  metalInstanceDomain: z.string().openapi({
+    description:
+      "The domain for the metal instance host that is running this workload. This can be used when using a custom domain for a workload as the target for a CNAME record.",
   }),
 }).openapi({ ref: "CreateWorkloadResponse" });
 export type CreateWorkloadResponse = z.infer<typeof CreateWorkloadResponse>;

--- a/nilcc-api/src/workload/workload.entity.ts
+++ b/nilcc-api/src/workload/workload.entity.ts
@@ -54,6 +54,9 @@ export class WorkloadEntity {
   })
   files?: Record<string, string>;
 
+  @Column({ type: "varchar", nullable: true })
+  domain?: string;
+
   @Column({ type: "varchar" })
   serviceToExpose: string;
 

--- a/nilcc-api/src/workload/workload.mapper.ts
+++ b/nilcc-api/src/workload/workload.mapper.ts
@@ -5,7 +5,9 @@ export const workloadMapper = {
   entityToResponse(
     workload: WorkloadEntity,
     workloadsDomain: string,
+    metalInstancesDomain: string,
   ): CreateWorkloadResponse {
+    const domain = workload.domain || `${workload.id}.${workloadsDomain}`;
     return {
       workloadId: workload.id,
       name: workload.name,
@@ -18,7 +20,8 @@ export const workloadMapper = {
       gpus: workload.gpus,
       disk: workload.disk,
       status: workload.status,
-      domain: `${workload.id}.${workloadsDomain}`,
+      domain,
+      metalInstanceDomain: `${workload.metalInstance.id}.${metalInstancesDomain}`,
       accountId: workload.account.id,
       createdAt: workload.createdAt.toISOString(),
       updatedAt: workload.updatedAt.toISOString(),

--- a/nilcc-api/tests/workload.test.ts
+++ b/nilcc-api/tests/workload.test.ts
@@ -78,6 +78,9 @@ services:
     expect(workload.domain).equals(
       `${workload.workloadId}.workloads.public.localhost`,
     );
+    expect(workload.metalInstanceDomain).equals(
+      `${myMetalInstance.metalInstanceId}.agents.private.localhost`,
+    );
     // store it for other tests to re-use it
     myWorkload = workload;
   });
@@ -143,6 +146,34 @@ services:
     expect(eventsBody.events).toHaveLength(2);
     const eventKinds = eventsBody.events.map((e) => e.details.kind);
     expect(eventKinds).toEqual(["created", "starting"]);
+  });
+
+  it("should allow creating a workload using a custom domain", async ({
+    expect,
+    clients,
+  }) => {
+    const createWorkloadRequest: CreateWorkloadRequest = {
+      name: "some",
+      dockerCompose: `
+services:
+  app:
+    image: nginx
+    ports:
+      - '80'
+`,
+      domain: "foo.com",
+      publicContainerName: "app",
+      publicContainerPort: 80,
+      memory: 4,
+      cpus: 2,
+      disk: 40,
+      gpus: 0,
+    };
+    const workload = await clients.user
+      .createWorkload(createWorkloadRequest)
+      .submit();
+    expect(workload.domain).toBe("foo.com");
+    await clients.user.deleteWorkload(workload.workloadId).submit();
   });
 
   it("should now allow cross account operations", async ({


### PR DESCRIPTION
This adds a new `domain` parameter in `/workloads/create` that allows the user to specify the domain to be used. nilcc-agent doesn't need any changes to support this since it already accepts whatever domain is being sent and uses it.

Note on the security aspect of this: a nilcc-agent instance doesn't allow 2 workloads with the same domain, so I can't try to impersonate someone else's workload. I _am_ able to launch a workload on a different baremetal host using the same domain but since the record only points to the original baremetal host, this doesn't allow me to do anything.

Closes #280