### PR TITLE
feat: validate workload domain is not agent's

### DIFF
--- a/nilcc-agent/src/main.rs
+++ b/nilcc-agent/src/main.rs
@@ -235,6 +235,7 @@ async fn run_daemon(config: AgentConfig) -> Result<()> {
         services: Services { workload: workload_service.clone() },
         clients: Clients { cvm_agent: cvm_agent_client },
         resource_limits: config.resources.limits,
+        agent_domain: config.api.domain.clone(),
     };
     let router = build_router(state, config.api.token);
     let handle = Handle::new();

--- a/nilcc-agent/src/routes/mod.rs
+++ b/nilcc-agent/src/routes/mod.rs
@@ -36,6 +36,7 @@ pub struct AppState {
     pub services: Services,
     pub clients: Clients,
     pub resource_limits: ResourceLimitsConfig,
+    pub agent_domain: String,
 }
 
 pub fn build_router(state: AppState, token: String) -> Router {


### PR DESCRIPTION
This can otherwise allow someone to redirect the agent's traffic to their own workload.