### PR TITLE
feat: add a `debug` mode in nilcc-agent

### DIFF
--- a/nilcc-agent/src/workers/vm.rs
+++ b/nilcc-agent/src/workers/vm.rs
@@ -339,7 +339,7 @@ mod tests {
             initrd_path: None,
             kernel_path: None,
             kernel_args: None,
-            display_gtk: false,
+            display: Default::default(),
             enable_cvm: false,
         }
     }


### PR DESCRIPTION
This adds a new `nilcc-agent debug <workload-id>` command that allows starting a vm in debug mode. This means:

* We copy the disks into a temporary directory (this means we don't care if the VM is already running, we'll start an entirely separate one with the same disk/iso).
* We remove all port forwarding.
* We start the vm with `-nographic` and with `-append "console=ttyS0 ..."` inheriting stdin/out/err. This means the shell you're running nilcc-agent "turns" into the qemu invocation that attaches to the console and lets you debug it.