### PR TITLE
feat: re-assign GPUs on start if addresses changed

### DIFF
--- a/nilcc-agent/src/main.rs
+++ b/nilcc-agent/src/main.rs
@@ -308,6 +308,7 @@ async fn run_daemon(config: AgentConfig) -> Result<()> {
     HeartbeatWorker::spawn(nilcc_api_client.clone());
 
     let vm_client = Arc::new(QemuClient::new(config.qemu.system_bin));
+    system_resources.adjust_gpu_assignment(&repository_provider).await.context("Failed to adjust GPU configs")?;
     let cvm_agent_client = Arc::new(DefaultCvmAgentClient::new().context("Failed to create cvm-agent client")?);
     let vm_service = DefaultVmService::new(VmServiceArgs {
         vm_client,


### PR DESCRIPTION
Since GPU addresses can change, we now check the GPU assignment for workloads on start to make sure it matches the addresses we currently see. If those don't match, we re-assign workloads to GPUs.

Note that we're assuming workloads won't be running here since this can only really happen after a reboot so we don't do anything to actively running VMs (since there shouldn't be any).