### PR TITLE
chore: use predictable kernel artifact names

### DIFF
--- a/artifacts/initramfs/build.sh
+++ b/artifacts/initramfs/build.sh
@@ -14,9 +14,8 @@ KERNEL_DIR=$BUILD_DIR/kernel
 
 mkdir -p $INITRD_DIR $KERNEL_DIR
 
-KERNEL_DEB=$(ls $SCRIPT_PATH/../kernel/build/guest/linux-image-6.11.0-snp-guest-*.deb | grep -v 'dbg_6.11')
-[[ ${#KERNEL_DEB[@]} == 0 ]] && echo "Kernel not found, run 'kernel/build.sh guest' first" && exit 1
-[[ ${#KERNEL_DEB[@]} > 1 ]] && echo "More than one kernel package found, only one can be used" && exit 1
+KERNEL_DEB=$SCRIPT_PATH/../kernel/build/guest/linux-image.deb
+[[ ! -f "$KERNEL_DEB" ]] && echo "Kernel not found, run 'kernel/build.sh guest' first" && exit 1
 
 cp "$KERNEL_DEB" $KERNEL_DIR/kernel.deb
 

--- a/artifacts/kernel/build.sh
+++ b/artifacts/kernel/build.sh
@@ -30,8 +30,12 @@ fi
 docker run --rm -v "$SCRIPT_PATH:/kernel" ubuntu:24.04 bash /kernel/docker_build.sh $1
 sudo chown -R $(whoami) $SCRIPT_PATH/build/
 
-cp $SCRIPT_PATH/build/$1/AMDSEV/linux/*.deb $SCRIPT_PATH/build/$1
+mv $SCRIPT_PATH/build/$1/AMDSEV/linux/linux-headers-* $SCRIPT_PATH/build/$1/linux-headers.deb
+mv $SCRIPT_PATH/build/$1/AMDSEV/linux/linux-image-*-dbg_* $SCRIPT_PATH/build/$1/linux-image-dbg.deb
+mv $SCRIPT_PATH/build/$1/AMDSEV/linux/linux-image-*_*.deb $SCRIPT_PATH/build/$1/linux-image.deb
+mv $SCRIPT_PATH/build/$1/AMDSEV/linux/linux-libc-dev* $SCRIPT_PATH/build/$1/linux-libc-dev.deb
+
 echo "Build finished, artifacts in build/$1"
 
 [[ ! -d $SCRIPT_PATH/../dist/kernel/$1 ]] && mkdir -p $SCRIPT_PATH/../dist/kernel/$1
-cp $SCRIPT_PATH/build/$1/AMDSEV/linux/*.deb "$SCRIPT_PATH/../dist/kernel/$1"
+cp $SCRIPT_PATH/build/$1/*.deb "$SCRIPT_PATH/../dist/kernel/$1"

--- a/artifacts/kernel/docker_build.sh
+++ b/artifacts/kernel/docker_build.sh
@@ -7,7 +7,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 apt update
 apt install -y python3-venv ninja-build libglib2.0-dev python-is-python3 nasm iasl flex bison libelf-dev debhelper \
-ninja-build iasl nasm flex bison openssl dkms autoconf bc python3-pip git-lfs openssl libssl-dev cpio zstd rsync
+  ninja-build iasl nasm flex bison openssl dkms autoconf bc python3-pip git-lfs openssl libssl-dev cpio zstd rsync
 
 cp /kernel/config-6.8.0-57-generic /boot/config
 


### PR DESCRIPTION
This changes the kernel artifacts so they look like "linux-image.deb" rather than an unpredictable name that we need to lookup in s3 to know what it is.