### PR TITLE
feat: don't require GPU artifacts

### DIFF
--- a/nilcc-agent/src/clients/qemu.rs
+++ b/nilcc-agent/src/clients/qemu.rs
@@ -384,9 +384,11 @@ impl VmClient for QemuClient {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
     use crate::services::disk::{DefaultDiskService, DiskService};
-    use tokio::fs;
+    use tokio::{fs, time::sleep};
     use tracing_test::traced_test;
 
     fn make_client() -> QemuClient {
@@ -532,6 +534,11 @@ mod tests {
 
         // Start it and make sure it's running
         client.start_vm(&socket_path, spec).await.unwrap();
+        for _ in 0..50 {
+            if !socket_path.exists() {
+                sleep(Duration::from_millis(100)).await;
+            }
+        }
         assert!(client.is_vm_running(&socket_path).await);
 
         // Stop is and make sure it's not running anymore.

--- a/nilcc-agent/src/config.rs
+++ b/nilcc-agent/src/config.rs
@@ -81,7 +81,7 @@ impl TryInto<CvmConfig> for CvmConfigs {
                     initrd: path.join("initramfs/initramfs.cpio.gz"),
                     bios: path.join("vm_images/ovmf/OVMF.fd"),
                     cpu: build_cvm_files("cpu")?,
-                    gpu: build_cvm_files("gpu")?,
+                    gpu: build_cvm_files("gpu").ok(),
                 })
             }
         }
@@ -100,7 +100,7 @@ pub struct CvmConfig {
     pub cpu: CvmFiles,
 
     /// The disk, kernel and verity files for the gpu cvm.
-    pub gpu: CvmFiles,
+    pub gpu: Option<CvmFiles>,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/nilcc-agent/src/services/vm.rs
+++ b/nilcc-agent/src/services/vm.rs
@@ -231,7 +231,11 @@ impl VmService for DefaultVmService {
     }
 
     async fn create_workload_spec(&self, workload: &Workload) -> Result<VmSpec, StartVmError> {
-        let cvm_files = if workload.gpus.is_empty() { &self.cvm_config.cpu } else { &self.cvm_config.gpu };
+        let cvm_files = if workload.gpus.is_empty() {
+            &self.cvm_config.cpu
+        } else {
+            self.cvm_config.gpu.as_ref().expect("no gpu files")
+        };
         let (iso_path, docker_compose_hash) = self.create_application_iso(workload).await?;
         let state_disk = self.create_state_disk(workload).await?;
         let base_disk =
@@ -364,12 +368,7 @@ mod tests {
                         verity_disk: base_path.join("cpu-verity-disk"),
                         verity_root_hash: "cpu-root-hash".into(),
                     },
-                    gpu: CvmFiles {
-                        base_disk: base_path.join("gpu-base-disk"),
-                        kernel: base_path.join("gpu-kernel"),
-                        verity_disk: base_path.join("gpu-verity-disk"),
-                        verity_root_hash: "gpu-root-hash".into(),
-                    },
+                    gpu: None,
                 },
                 zerossl_config: ZeroSslConfig { eab_key_id: "key".into(), eab_mac_key: "mac".into() },
                 docker_config: DockerConfig { username: "user".into(), password: "pass".into() },


### PR DESCRIPTION
This causes nilcc-agent to not require GPU artifacts on non GPU machines when using the `cvm.base_path` config parameter.