### PR TITLE
feat: add initial tiers support

### DIFF
--- a/nilcc-api/migrations/1756136984989-Tiers.ts
+++ b/nilcc-api/migrations/1756136984989-Tiers.ts
@@ -1,0 +1,15 @@
+import type { MigrationInterface, QueryRunner } from "typeorm";
+
+export class Tiers1756136984989 implements MigrationInterface {
+  name = "Tiers1756136984989";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "workload_tier_entity" (id uuid NOT NULL, name character varying NOT NULL UNIQUE, cpus integer NOT NULL, gpus integer NOT NULL, memory integer NOT NULL, disk integer NOT NULL, cost integer NOT NULL, CONSTRAINT "PK_f62514bb6858ae5056e76107b8de58e7" PRIMARY KEY ("id"))`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "workload_tier_entity"`);
+  }
+}

--- a/nilcc-api/src/account/account.controller.ts
+++ b/nilcc-api/src/account/account.controller.ts
@@ -1,4 +1,5 @@
 import { describeRoute } from "hono-openapi";
+import { resolver } from "hono-openapi/zod";
 import { z } from "zod";
 import { adminAuthentication } from "#/common/auth";
 import { EntityNotFound } from "#/common/errors";
@@ -6,7 +7,7 @@ import { OpenApiSpecCommonErrorResponses } from "#/common/openapi";
 import { PathsV1 } from "#/common/paths";
 import type { ControllerOptions } from "#/common/types";
 import { pathValidator, payloadValidator } from "#/common/zod-utils";
-import { CreateAccountRequest } from "./account.dto";
+import { Account, CreateAccountRequest } from "./account.dto";
 import { accountMapper } from "./account.mapper";
 
 const idParamSchema = z.object({ id: z.string().uuid() });
@@ -23,6 +24,11 @@ export function create(options: ControllerOptions) {
       responses: {
         200: {
           description: "Account created successfully",
+          content: {
+            "application/json": {
+              schema: resolver(Account),
+            },
+          },
         },
         ...OpenApiSpecCommonErrorResponses,
       },

--- a/nilcc-api/src/account/account.service.ts
+++ b/nilcc-api/src/account/account.service.ts
@@ -1,7 +1,7 @@
 import * as crypto from "node:crypto";
-import { QueryFailedError, type QueryRunner, type Repository } from "typeorm";
+import type { QueryRunner, Repository } from "typeorm";
 import { v4 as uuidv4 } from "uuid";
-import { AccountAlreadyExists } from "#/common/errors";
+import { EntityAlreadyExists, isUniqueConstraint } from "#/common/errors";
 import type { AppBindings } from "#/env";
 import { AccountEntity } from "./account.entity";
 
@@ -28,8 +28,8 @@ export class AccountService {
         createdAt: new Date(),
       });
     } catch (e: unknown) {
-      if (e instanceof QueryFailedError && e.driverError.code === "23505") {
-        throw new AccountAlreadyExists();
+      if (isUniqueConstraint(e)) {
+        throw new EntityAlreadyExists("account");
       }
       throw e;
     }

--- a/nilcc-api/src/app.ts
+++ b/nilcc-api/src/app.ts
@@ -19,6 +19,7 @@ import { buildSystemRouter } from "./system/system.router";
 import { buildWorkloadRouter } from "./workload/workload.router";
 import { buildWorkloadContainerRouter } from "./workload-container/workload-container.router";
 import { buildWorkloadEventRouter } from "./workload-event/workload-event.router";
+import { buildWorkloadTierRouter } from "./workload-tier/workload-tier.router";
 
 export type App = Hono<AppEnv>;
 
@@ -47,6 +48,7 @@ export async function buildApp(
   buildWorkloadRouter({ app, bindings });
   buildWorkloadContainerRouter({ app, bindings });
   buildWorkloadEventRouter({ app, bindings });
+  buildWorkloadTierRouter({ app, bindings });
   buildMetalInstanceRouter({ app, bindings });
   buildSystemRouter({ app, bindings });
 

--- a/nilcc-api/src/common/auth.ts
+++ b/nilcc-api/src/common/auth.ts
@@ -3,6 +3,10 @@ import { Temporal } from "temporal-polyfill";
 import type { AppBindings } from "#/env";
 import type { ApiErrorResponse } from "./handler";
 
+export function adminOrUserAuthentication(bindings: AppBindings) {
+  return requireApiKey(bindings.config.adminApiKey);
+}
+
 export function adminAuthentication(bindings: AppBindings) {
   return requireApiKey(bindings.config.adminApiKey);
 }

--- a/nilcc-api/src/common/errors.ts
+++ b/nilcc-api/src/common/errors.ts
@@ -1,5 +1,6 @@
 import type { ContentfulStatusCode } from "hono/dist/types/utils/http-status";
 import { StatusCodes } from "http-status-codes";
+import { QueryFailedError } from "typeorm";
 
 export abstract class AppError extends Error {
   kind = "INTERNAL";
@@ -67,13 +68,13 @@ export class EntityNotFound extends AppError {
   }
 }
 
-export class AccountAlreadyExists extends AppError {
-  override kind = "ACCOUNT_ALREADY_EXISTS";
+export class EntityAlreadyExists extends AppError {
+  override kind = "ALREADY_EXISTS";
   override statusCode: ContentfulStatusCode = StatusCodes.CONFLICT;
 
-  constructor() {
+  constructor(entity: string) {
     super();
-    this.description = "account already exists";
+    this.description = `${entity} already exists`;
   }
 }
 
@@ -85,4 +86,8 @@ export class AccessDenied extends AppError {
     super();
     this.description = "access denied";
   }
+}
+
+export function isUniqueConstraint(e: unknown): boolean {
+  return e instanceof QueryFailedError && e.driverError.code === "23505";
 }

--- a/nilcc-api/src/common/openapi.ts
+++ b/nilcc-api/src/common/openapi.ts
@@ -19,9 +19,19 @@ export const OpenApiSpecCommonErrorResponses = {
   },
   401: {
     description: ReasonPhrases.UNAUTHORIZED,
+    content: {
+      "application/json": {
+        schema: resolver(ApiErrorResponse),
+      },
+    },
   },
   403: {
     description: ReasonPhrases.FORBIDDEN,
+    content: {
+      "application/json": {
+        schema: resolver(ApiErrorResponse),
+      },
+    },
   },
   404: {
     description: ReasonPhrases.NOT_FOUND,

--- a/nilcc-api/src/common/paths.ts
+++ b/nilcc-api/src/common/paths.ts
@@ -32,6 +32,10 @@ export const PathsV1 = {
     submit: PathSchema.parse("/api/v1/workload-events/submit"),
     list: PathSchema.parse("/api/v1/workload-events/list"),
   },
+  workloadTiers: {
+    create: PathSchema.parse("/api/v1/workload-tiers/create"),
+    list: PathSchema.parse("/api/v1/workload-tiers/list"),
+  },
   metalInstance: {
     register: PathSchema.parse("/api/v1/metal-instances/register"),
     heartbeat: PathSchema.parse("/api/v1/metal-instances/heartbeat"),

--- a/nilcc-api/src/data-source.ts
+++ b/nilcc-api/src/data-source.ts
@@ -12,6 +12,7 @@ import { Account1755033746208 } from "migrations/1755033746208-Account";
 import { WorkloadAccount1755195024670 } from "migrations/1755195024670-WorkloadAccount";
 import { WorkloadDomain1755621623214 } from "migrations/1755621623214-WorkloadDomain";
 import { DockerCredentials1755638110882 } from "migrations/1755638110882-DockerCredentials";
+import { Tiers1756136984989 } from "migrations/1756136984989-Tiers";
 import { DataSource } from "typeorm";
 import type { EnvVars } from "#/env";
 import { MetalInstanceEntity } from "#/metal-instance/metal-instance.entity";
@@ -20,6 +21,7 @@ import {
   WorkloadEventEntity,
 } from "#/workload/workload.entity";
 import { AccountEntity } from "./account/account.entity";
+import { WorkloadTierEntity } from "./workload-tier/workload-tier.entity";
 
 export async function buildDataSource(config: EnvVars): Promise<DataSource> {
   const dataSource = new DataSource({
@@ -30,6 +32,7 @@ export async function buildDataSource(config: EnvVars): Promise<DataSource> {
       WorkloadEntity,
       MetalInstanceEntity,
       WorkloadEventEntity,
+      WorkloadTierEntity,
     ],
     subscribers: [NullToUndefinedSubscriber],
     // We can't use globs (e.g. `migrations/*.ts`) here because of some very reasonable problem with typescript
@@ -39,6 +42,7 @@ export async function buildDataSource(config: EnvVars): Promise<DataSource> {
       WorkloadAccount1755195024670,
       WorkloadDomain1755621623214,
       DockerCredentials1755638110882,
+      Tiers1756136984989,
     ],
     synchronize: false,
     logging: false,

--- a/nilcc-api/src/env.ts
+++ b/nilcc-api/src/env.ts
@@ -16,6 +16,7 @@ import {
   LocalStackDnsService,
   Route53DnsService,
 } from "./dns/dns.service";
+import { WorkloadTierService } from "./workload-tier/workload-tier.service";
 export const LOG_LEVELS = ["debug", "info", "warn", "error"] as const;
 
 export const FeatureFlag = {
@@ -54,6 +55,7 @@ export type DnsServices = {
 export type AppServices = {
   metalInstance: MetalInstanceService;
   workload: WorkloadService;
+  workloadTier: WorkloadTierService;
   account: AccountService;
   dns: DnsServices;
   nilccAgentClient: NilccAgentClient;
@@ -154,6 +156,7 @@ async function buildServices(
 
   const metalInstanceService = new MetalInstanceService();
   const workloadService = new WorkloadService();
+  const workloadTierService = new WorkloadTierService();
   const accountService = new AccountService();
   const nilccAgentClient = new DefaultNilccAgentClient(
     config.metalInstancesEndpointScheme,
@@ -165,6 +168,7 @@ async function buildServices(
   return {
     metalInstance: metalInstanceService,
     workload: workloadService,
+    workloadTier: workloadTierService,
     account: accountService,
     dns,
     nilccAgentClient,

--- a/nilcc-api/src/workload-tier/workload-tier.controllers.ts
+++ b/nilcc-api/src/workload-tier/workload-tier.controllers.ts
@@ -1,0 +1,70 @@
+import { describeRoute } from "hono-openapi";
+import { resolver } from "hono-openapi/zod";
+import { adminAuthentication, userAuthentication } from "#/common/auth";
+import { OpenApiSpecCommonErrorResponses } from "#/common/openapi";
+import { PathsV1 } from "#/common/paths";
+import type { ControllerOptions } from "#/common/types";
+import { payloadValidator } from "#/common/zod-utils";
+import { CreateWorkloadTierRequest, WorkloadTier } from "./workload-tier.dto";
+import { workloadTierMapper } from "./workload-tier.mapper";
+
+export function create(options: ControllerOptions) {
+  const { app, bindings } = options;
+  app.post(
+    PathsV1.workloadTiers.create,
+    describeRoute({
+      tags: ["workload-tier"],
+      summary: "Create a workload tier",
+      description: "This creates a workload tier.",
+      responses: {
+        200: {
+          description: "The workload tier was created successfully",
+          content: {
+            "application/json": {
+              schema: resolver(WorkloadTier),
+            },
+          },
+        },
+        ...OpenApiSpecCommonErrorResponses,
+      },
+    }),
+    adminAuthentication(bindings),
+    payloadValidator(CreateWorkloadTierRequest),
+    async (c) => {
+      const payload = c.req.valid("json");
+      const tier = await bindings.services.workloadTier.create(
+        bindings,
+        payload,
+      );
+      return c.json(workloadTierMapper.entityToResponse(tier));
+    },
+  );
+}
+
+export function list(options: ControllerOptions) {
+  const { app, bindings } = options;
+  app.get(
+    PathsV1.workloadTiers.list,
+    describeRoute({
+      tags: ["workload-tier"],
+      summary: "List workload tiers.",
+      description: "This endpoint lists all existing workload tiers.",
+      responses: {
+        200: {
+          description: "The workload tiers.",
+          content: {
+            "application/json": {
+              schema: resolver(WorkloadTier.array()),
+            },
+          },
+        },
+        ...OpenApiSpecCommonErrorResponses,
+      },
+    }),
+    userAuthentication(bindings),
+    async (c) => {
+      const tiers = await bindings.services.workloadTier.list(bindings);
+      return c.json(tiers.map(workloadTierMapper.entityToResponse));
+    },
+  );
+}

--- a/nilcc-api/src/workload-tier/workload-tier.dto.ts
+++ b/nilcc-api/src/workload-tier/workload-tier.dto.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+import { Uuid } from "#/common/types";
+
+export const WorkloadTier = z
+  .object({
+    id: Uuid.openapi({ description: "The identifier for this tier." }),
+    name: z.string().openapi({ description: "The name of this tier." }),
+    cpus: z
+      .number()
+      .openapi({ description: "The number of CPUs included in this tier." }),
+    gpus: z
+      .number()
+      .openapi({ description: "The number of GPUs included in this tier." }),
+    memoryMb: z.number().openapi({
+      description: "The amount of MB of RAM included in this tier.",
+    }),
+    diskGb: z.number().openapi({
+      description: "The amount of GB of disk included in this tier.",
+    }),
+    cost: z.number().openapi({
+      description: "The cost per minute in credits for this tier.",
+    }),
+  })
+  .openapi({ description: "A workload tier." });
+export type WorkloadTier = z.infer<typeof WorkloadTier>;
+
+export const CreateWorkloadTierRequest = z
+  .object({
+    name: z.string().openapi({ description: "The name of the tier." }),
+    cpus: z
+      .number()
+      .openapi({ description: "The number of CPUs included in the tier." }),
+    gpus: z
+      .number()
+      .openapi({ description: "The number of GPUs included in the tier." }),
+    memoryMb: z.number().openapi({
+      description: "The amount of MB of RAM included in the tier.",
+    }),
+    diskGb: z.number().openapi({
+      description: "The amount of GB of disk included in the tier.",
+    }),
+    cost: z
+      .number()
+      .positive()
+      .openapi({ description: "The cost per minute in credits for the tier." }),
+  })
+  .openapi({ description: "A request to create a tier." });
+export type CreateWorkloadTierRequest = z.infer<
+  typeof CreateWorkloadTierRequest
+>;

--- a/nilcc-api/src/workload-tier/workload-tier.entity.ts
+++ b/nilcc-api/src/workload-tier/workload-tier.entity.ts
@@ -1,0 +1,25 @@
+import { Column, Entity, PrimaryColumn } from "typeorm";
+
+@Entity()
+export class WorkloadTierEntity {
+  @PrimaryColumn({ type: "uuid" })
+  id: string;
+
+  @Column({ type: "varchar", unique: true })
+  name: string;
+
+  @Column({ type: "int" })
+  memory: number;
+
+  @Column({ type: "int" })
+  cpus: number;
+
+  @Column({ type: "int" })
+  gpus: number;
+
+  @Column({ type: "int" })
+  disk: number;
+
+  @Column({ type: "int" })
+  cost: number;
+}

--- a/nilcc-api/src/workload-tier/workload-tier.mapper.ts
+++ b/nilcc-api/src/workload-tier/workload-tier.mapper.ts
@@ -1,0 +1,16 @@
+import type { WorkloadTier } from "./workload-tier.dto";
+import type { WorkloadTierEntity } from "./workload-tier.entity";
+
+export const workloadTierMapper = {
+  entityToResponse(tier: WorkloadTierEntity): WorkloadTier {
+    return {
+      id: tier.id,
+      name: tier.name,
+      cpus: tier.cpus,
+      gpus: tier.gpus,
+      memoryMb: tier.memory,
+      diskGb: tier.disk,
+      cost: tier.cost,
+    };
+  },
+};

--- a/nilcc-api/src/workload-tier/workload-tier.router.ts
+++ b/nilcc-api/src/workload-tier/workload-tier.router.ts
@@ -1,0 +1,7 @@
+import type { ControllerOptions } from "#/common/types";
+import * as WorkloadTierController from "./workload-tier.controllers";
+
+export function buildWorkloadTierRouter(options: ControllerOptions): void {
+  WorkloadTierController.create(options);
+  WorkloadTierController.list(options);
+}

--- a/nilcc-api/src/workload-tier/workload-tier.service.ts
+++ b/nilcc-api/src/workload-tier/workload-tier.service.ts
@@ -1,0 +1,46 @@
+import type { QueryRunner, Repository } from "typeorm";
+import { v4 as uuidv4 } from "uuid";
+import { EntityAlreadyExists, isUniqueConstraint } from "#/common/errors";
+import type { AppBindings } from "#/env";
+import type { CreateWorkloadTierRequest } from "./workload-tier.dto";
+import { WorkloadTierEntity } from "./workload-tier.entity";
+
+export class WorkloadTierService {
+  getRepository(
+    bindings: AppBindings,
+    tx?: QueryRunner,
+  ): Repository<WorkloadTierEntity> {
+    if (tx) {
+      return tx.manager.getRepository(WorkloadTierEntity);
+    }
+    return bindings.dataSource.getRepository(WorkloadTierEntity);
+  }
+
+  async create(
+    bindings: AppBindings,
+    request: CreateWorkloadTierRequest,
+  ): Promise<WorkloadTierEntity> {
+    const repository = this.getRepository(bindings);
+    try {
+      return await repository.save({
+        id: uuidv4(),
+        name: request.name,
+        cpus: request.cpus,
+        gpus: request.gpus,
+        memory: request.memoryMb,
+        disk: request.diskGb,
+        cost: request.cost,
+      });
+    } catch (e: unknown) {
+      if (isUniqueConstraint(e)) {
+        throw new EntityAlreadyExists("workload tier");
+      }
+      throw e;
+    }
+  }
+
+  async list(bindings: AppBindings): Promise<WorkloadTierEntity[]> {
+    const repository = this.getRepository(bindings);
+    return await repository.find();
+  }
+}

--- a/nilcc-api/tests/fixture/test-client.ts
+++ b/nilcc-api/tests/fixture/test-client.ts
@@ -26,6 +26,10 @@ import {
   type ListWorkloadEventsRequest,
   ListWorkloadEventsResponse,
 } from "#/workload-event/workload-event.dto";
+import {
+  type CreateWorkloadTierRequest,
+  WorkloadTier,
+} from "#/workload-tier/workload-tier.dto";
 
 export type TestClientOptions = {
   app: App;
@@ -86,12 +90,13 @@ export class RequestPromise<T> {
 
   async submit(): Promise<T> {
     const response = await this.promise;
-    const body = await response.json();
     if (response.status !== 200) {
+      const body = await response.text();
       throw new Error(
-        `Request failed with status: ${response.status}: ${JSON.stringify(body)}`,
+        `Request failed with status: ${response.status}: ${body}`,
       );
     }
+    const body = await response.json();
     return this.schema.parse(body);
   }
 
@@ -140,6 +145,14 @@ export class AdminClient extends TestClient {
       method: "GET",
     });
     return new RequestPromise(promise, Account);
+  }
+
+  createTier(request: CreateWorkloadTierRequest): RequestPromise<WorkloadTier> {
+    const promise = this.request(PathsV1.workloadTiers.create, {
+      method: "POST",
+      body: request,
+    });
+    return new RequestPromise(promise, WorkloadTier);
   }
 }
 
@@ -226,6 +239,13 @@ export class UserClient extends TestClient {
       body,
     });
     return new RequestPromise(promise, WorkloadSystemLogsResponse);
+  }
+
+  listTiers(): RequestPromise<WorkloadTier[]> {
+    const promise = this.request(PathsV1.workloadTiers.list, {
+      method: "GET",
+    });
+    return new RequestPromise(promise, WorkloadTier.array());
   }
 }
 

--- a/nilcc-api/tests/workload-tier.test.ts
+++ b/nilcc-api/tests/workload-tier.test.ts
@@ -1,0 +1,38 @@
+import { describe } from "vitest";
+import type { CreateWorkloadTierRequest } from "#/workload-tier/workload-tier.dto";
+import { createTestFixtureExtension } from "./fixture/it";
+
+describe("WorkloadTier", () => {
+  const { it, beforeAll, afterAll } = createTestFixtureExtension();
+
+  beforeAll(async (_ctx) => {});
+  afterAll(async (_ctx) => {});
+
+  it("should create a workload tier that hasn't been created", async ({
+    expect,
+    clients,
+  }) => {
+    const request: CreateWorkloadTierRequest = {
+      name: "my favorite tier",
+      cpus: 1,
+      memoryMb: 1024,
+      gpus: 2,
+      diskGb: 12,
+      cost: 10,
+    };
+
+    const tier = await clients.admin.createTier(request).submit();
+    expect(tier.name).toBe(request.name);
+    expect(tier.cpus).toBe(request.cpus);
+    expect(tier.gpus).toBe(request.gpus);
+    expect(tier.memoryMb).toBe(request.memoryMb);
+    expect(tier.diskGb).toBe(request.diskGb);
+    expect(tier.cost).toBe(request.cost);
+
+    // Creating it again should fail
+    expect(await clients.admin.createTier(request).status()).toBe(409);
+
+    const tiers = await clients.user.listTiers().submit();
+    expect(tiers).toEqual([tier]);
+  });
+});


### PR DESCRIPTION
This adds the initial tier support:
* Creates the table to keep track of them.
* Adds a `/tiers/create` endpoint.
* Adds a `/tiers/list` endpoint.

Closes #305