### PR TITLE
feat: set a credit rate on workloads

### DIFF
--- a/nilcc-api/migrations/1756151064011-WorkloadTier.ts
+++ b/nilcc-api/migrations/1756151064011-WorkloadTier.ts
@@ -1,0 +1,17 @@
+import type { MigrationInterface, QueryRunner } from "typeorm";
+
+export class WorkloadCreditRate1756151064011 implements MigrationInterface {
+  name = "WorkloadCreditRate1756151064011";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "workload_entity" ADD COLUMN "creditRate" integer NOT NULL DEFAULT 0`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "workload_entity" DROP COLUMN "creditRate"`,
+    );
+  }
+}

--- a/nilcc-api/src/common/errors.ts
+++ b/nilcc-api/src/common/errors.ts
@@ -35,6 +35,16 @@ export class InvalidDockerCompose extends AppError {
   override statusCode: ContentfulStatusCode = StatusCodes.BAD_REQUEST;
 }
 
+export class InvalidWorkloadTier extends AppError {
+  override kind = "INVALID_WORKLOAD_TIER";
+  override statusCode: ContentfulStatusCode = StatusCodes.BAD_REQUEST;
+}
+
+export class NotEnoughCredits extends AppError {
+  override kind = "NOT_ENOUGH_CREDITS";
+  override statusCode: ContentfulStatusCode = StatusCodes.PRECONDITION_FAILED;
+}
+
 export class AgentRequestError extends AppError {
   override kind = "AGENT_COMMUNICATION";
   agentErrorKind: string;

--- a/nilcc-api/src/data-source.ts
+++ b/nilcc-api/src/data-source.ts
@@ -14,6 +14,7 @@ import { WorkloadDomain1755621623214 } from "migrations/1755621623214-WorkloadDo
 import { DockerCredentials1755638110882 } from "migrations/1755638110882-DockerCredentials";
 import { Tiers1756136984989 } from "migrations/1756136984989-Tiers";
 import { AccountCredits1756146720184 } from "migrations/1756146720184-AccountCredits";
+import { WorkloadCreditRate1756151064011 } from "migrations/1756151064011-WorkloadTier";
 import { DataSource } from "typeorm";
 import type { EnvVars } from "#/env";
 import { MetalInstanceEntity } from "#/metal-instance/metal-instance.entity";
@@ -45,6 +46,7 @@ export async function buildDataSource(config: EnvVars): Promise<DataSource> {
       DockerCredentials1755638110882,
       Tiers1756136984989,
       AccountCredits1756146720184,
+      WorkloadCreditRate1756151064011,
     ],
     synchronize: false,
     logging: false,

--- a/nilcc-api/src/workload/workload.dto.ts
+++ b/nilcc-api/src/workload/workload.dto.ts
@@ -132,6 +132,9 @@ export const CreateWorkloadResponse = CreateWorkloadRequest.extend({
   workloadId: Uuid.openapi({
     description: "The identifier for this workload.",
   }),
+  creditRate: z.number().openapi({
+    description: "The rate of credits burned by this workload per minute.",
+  }),
   status: z
     .enum(["scheduled", "starting", "running", "stopped", "error"])
     .openapi({ description: "The status of the workload." }),

--- a/nilcc-api/src/workload/workload.entity.ts
+++ b/nilcc-api/src/workload/workload.entity.ts
@@ -87,6 +87,9 @@ export class WorkloadEntity {
   @Column({ type: "int" })
   disk: number;
 
+  @Column({ type: "int" })
+  creditRate: number;
+
   @Column({ type: "varchar", default: "scheduled" })
   status: "scheduled" | "starting" | "running" | "stopped" | "error";
 

--- a/nilcc-api/src/workload/workload.mapper.ts
+++ b/nilcc-api/src/workload/workload.mapper.ts
@@ -21,6 +21,7 @@ export const workloadMapper = {
       cpus: workload.cpus,
       gpus: workload.gpus,
       disk: workload.disk,
+      creditRate: workload.creditRate,
       status: workload.status,
       domain,
       metalInstanceDomain: `${workload.metalInstance.id}.${metalInstancesDomain}`,

--- a/nilcc-api/tests/metal-instance.test.ts
+++ b/nilcc-api/tests/metal-instance.test.ts
@@ -129,6 +129,16 @@ services:
       disk: 40,
       gpus: 0,
     };
+    await clients.admin
+      .createTier({
+        name: "tiny",
+        cost: 1,
+        cpus: 2,
+        gpus: 0,
+        memoryMb: 4,
+        diskGb: 40,
+      })
+      .submit();
     const workload = await clients.user
       .createWorkload(createWorkloadRequest)
       .submit();


### PR DESCRIPTION
This PR:

* Ensures every workload matches a specific tier in terms of the parameters (cpus, gpus, etc) it is set to on creation.
* Adds a `creditRate` column for workloads that specifies the number of credits burnt per minute.
* Ensures when creating a workload, the total number of credits that the account has covers all the workloads it has, including the new one, for 5 minutes. That is, if you're running N workloads, currently burning a total of X credits per minute, and try to add a new workload that burns Y credits per minute, then the account must have at least `(X + Y) * 5` credits.

Closes #307