### PR TITLE
feat: add `/accounts/me` endpoint

### DIFF
--- a/nilcc-api/src/account/account.dto.ts
+++ b/nilcc-api/src/account/account.dto.ts
@@ -20,6 +20,11 @@ export const Account = z
   });
 export type Account = z.infer<typeof Account>;
 
+export const TrimmedAccount = Account.omit({ apiToken: true }).openapi({
+  ref: "TrimmedAccount",
+});
+export type TrimmedAccount = z.infer<typeof TrimmedAccount>;
+
 export const CreateAccountRequest = z
   .object({
     name: z.string(),
@@ -39,3 +44,13 @@ export const AddCreditsRequest = z
     ref: "AddCreditsRequest",
   });
 export type AddCreditsRequest = z.infer<typeof AddCreditsRequest>;
+
+export const AccountCreditsResponse = z
+  .object({
+    accountId: z.string(),
+    credits: z.number(),
+  })
+  .openapi({
+    ref: "AccountCreditsResponse",
+  });
+export type AccountCreditsResponse = z.infer<typeof AccountCreditsResponse>;

--- a/nilcc-api/src/account/account.router.ts
+++ b/nilcc-api/src/account/account.router.ts
@@ -4,6 +4,7 @@ import * as AccountController from "./account.controller";
 export function buildAccountRouter(options: ControllerOptions): void {
   AccountController.create(options);
   AccountController.list(options);
+  AccountController.me(options);
   AccountController.read(options);
   AccountController.addCredits(options);
 }

--- a/nilcc-api/src/common/auth.ts
+++ b/nilcc-api/src/common/auth.ts
@@ -17,6 +17,7 @@ export function metalInstanceAuthentication(bindings: AppBindings) {
 
 export function userAuthentication(bindings: AppBindings) {
   return async (c: Context, next: Next) => {
+    console.error(c.req.url);
     const apiToken = c.req.header("x-api-key");
     if (!apiToken) {
       return c.json(authError("no x-api-key header provided"), 401);

--- a/nilcc-api/src/common/paths.ts
+++ b/nilcc-api/src/common/paths.ts
@@ -16,6 +16,7 @@ export const PathsV1 = {
     create: PathSchema.parse("/api/v1/accounts/create"),
     list: PathSchema.parse("/api/v1/accounts/list"),
     read: PathSchema.parse("/api/v1/accounts/:id"),
+    me: PathSchema.parse("/api/v1/accounts/me"),
     addCredits: PathSchema.parse("/api/v1/accounts/add-credits"),
   },
   workload: {

--- a/nilcc-api/tests/account.test.ts
+++ b/nilcc-api/tests/account.test.ts
@@ -39,4 +39,13 @@ describe("Account", () => {
     const details = await clients.admin.getAccount(account.accountId).submit();
     expect(details).toEqual(account);
   });
+
+  it("should allow self lookups", async ({ expect, clients }) => {
+    const me = await clients.user.myAccount().submit();
+    const account = await clients.admin.getAccount(me.accountId).submit();
+
+    const expected: Record<string, unknown> = { ...account };
+    delete expected.apiToken;
+    expect(me).toEqual(expected);
+  });
 });

--- a/nilcc-api/tests/fixture/test-client.ts
+++ b/nilcc-api/tests/fixture/test-client.ts
@@ -1,5 +1,9 @@
 import { type ZodType, z } from "zod";
-import { Account, type CreateAccountRequest } from "#/account/account.dto";
+import {
+  Account,
+  type CreateAccountRequest,
+  TrimmedAccount,
+} from "#/account/account.dto";
 import type { App } from "#/app";
 import { PathsV1 } from "#/common/paths";
 import type { AppBindings } from "#/env";
@@ -246,6 +250,13 @@ export class UserClient extends TestClient {
       method: "GET",
     });
     return new RequestPromise(promise, WorkloadTier.array());
+  }
+
+  myAccount(): RequestPromise<TrimmedAccount> {
+    const promise = this.request(PathsV1.account.me, {
+      method: "GET",
+    });
+    return new RequestPromise(promise, TrimmedAccount);
   }
 }
 


### PR DESCRIPTION
This adds `/api/v1/accounts/me` that returns the current account information, based on the api token, without the token (for... security? I dunno)

Closes #309