### PR TITLE
chore: add explicit `restart` VM events/states

### DIFF
--- a/nilcc-agent/src/clients/nilcc_api.rs
+++ b/nilcc-agent/src/clients/nilcc_api.rs
@@ -33,6 +33,8 @@ pub enum VmEvent {
     Starting,
     Running,
     Stopped,
+    ForcedRestart,
+    VmRestarted,
     FailedToStart { error: String },
 }
 

--- a/nilcc-api/src/metal-instance/metal-instance.dto.ts
+++ b/nilcc-api/src/metal-instance/metal-instance.dto.ts
@@ -74,6 +74,8 @@ export const WorkloadEventKind = z.discriminatedUnion("kind", [
   z.object({ kind: z.literal("created") }),
   z.object({ kind: z.literal("starting") }),
   z.object({ kind: z.literal("stopped") }),
+  z.object({ kind: z.literal("vmRestarted") }),
+  z.object({ kind: z.literal("forcedRestart") }),
   z.object({ kind: z.literal("running") }),
   z.object({ kind: z.literal("failedToStart"), error: z.string() }),
 ]);

--- a/nilcc-api/src/workload/workload.entity.ts
+++ b/nilcc-api/src/workload/workload.entity.ts
@@ -125,7 +125,14 @@ export class WorkloadEventEntity {
   workload: WorkloadEntity;
 
   @Column({ type: "varchar" })
-  event: "created" | "starting" | "running" | "stopped" | "failedToStart";
+  event:
+    | "created"
+    | "starting"
+    | "running"
+    | "stopped"
+    | "vmRestarted"
+    | "forcedRestart"
+    | "failedToStart";
 
   @Column({ type: "varchar", nullable: true })
   details?: string;

--- a/nilcc-api/src/workload/workload.service.ts
+++ b/nilcc-api/src/workload/workload.service.ts
@@ -256,6 +256,8 @@ export class WorkloadService {
     }
     switch (request.event.kind) {
       case "starting":
+      case "vmRestarted":
+      case "forcedRestart":
         workload.status = "starting";
         break;
       case "running":
@@ -313,6 +315,12 @@ export class WorkloadService {
           break;
         case "stopped":
           details = { kind: "stopped" };
+          break;
+        case "vmRestarted":
+          details = { kind: "vmRestarted" };
+          break;
+        case "forcedRestart":
+          details = { kind: "forcedRestart" };
           break;
         case "failedToStart":
           details = { kind: "failedToStart", error: event.details || "" };


### PR DESCRIPTION
This adds an explicit "vmRestarted" event when a VM is restarted on its own (e.g. the VM shuts down) and a "forcedRestart" event when a VM is restarted explicitly by the user.