### PR TITLE
feat: add an `awaitingCert` event/vm state

### DIFF
--- a/nilcc-agent/src/clients/nilcc_api.rs
+++ b/nilcc-agent/src/clients/nilcc_api.rs
@@ -31,6 +31,7 @@ pub trait NilccApiClient: Send + Sync {
 #[serde(tag = "kind", rename_all = "camelCase")]
 pub enum VmEvent {
     Starting,
+    AwaitingCert,
     Running,
     Stopped,
     ForcedRestart,

--- a/nilcc-agent/src/workers/vm.rs
+++ b/nilcc-agent/src/workers/vm.rs
@@ -205,6 +205,7 @@ impl VmWorker {
                             warn!("Failed to bootstrap agent: {e:#}");
                             return;
                         }
+                        self.submit_event(VmEvent::AwaitingCert).await;
                         info!("CVM agent is bootstrapped");
                     }
                     if response.https {

--- a/nilcc-api/src/metal-instance/metal-instance.dto.ts
+++ b/nilcc-api/src/metal-instance/metal-instance.dto.ts
@@ -76,6 +76,7 @@ export const WorkloadEventKind = z.discriminatedUnion("kind", [
   z.object({ kind: z.literal("stopped") }),
   z.object({ kind: z.literal("vmRestarted") }),
   z.object({ kind: z.literal("forcedRestart") }),
+  z.object({ kind: z.literal("awaitingCert") }),
   z.object({ kind: z.literal("running") }),
   z.object({ kind: z.literal("failedToStart"), error: z.string() }),
 ]);

--- a/nilcc-api/src/workload/workload.dto.ts
+++ b/nilcc-api/src/workload/workload.dto.ts
@@ -136,7 +136,14 @@ export const CreateWorkloadResponse = CreateWorkloadRequest.extend({
     description: "The rate of credits burned by this workload per minute.",
   }),
   status: z
-    .enum(["scheduled", "starting", "running", "stopped", "error"])
+    .enum([
+      "scheduled",
+      "starting",
+      "awaitingCert",
+      "running",
+      "stopped",
+      "error",
+    ])
     .openapi({ description: "The status of the workload." }),
   createdAt: z.string().datetime().openapi({
     description: "The timestamp at which this workload was created.",

--- a/nilcc-api/src/workload/workload.entity.ts
+++ b/nilcc-api/src/workload/workload.entity.ts
@@ -91,7 +91,13 @@ export class WorkloadEntity {
   creditRate: number;
 
   @Column({ type: "varchar", default: "scheduled" })
-  status: "scheduled" | "starting" | "running" | "stopped" | "error";
+  status:
+    | "scheduled"
+    | "starting"
+    | "awaitingCert"
+    | "running"
+    | "stopped"
+    | "error";
 
   @ManyToOne(
     () => MetalInstanceEntity,
@@ -128,6 +134,7 @@ export class WorkloadEventEntity {
   event:
     | "created"
     | "starting"
+    | "awaitingCert"
     | "running"
     | "stopped"
     | "vmRestarted"

--- a/nilcc-api/src/workload/workload.service.ts
+++ b/nilcc-api/src/workload/workload.service.ts
@@ -268,6 +268,9 @@ export class WorkloadService {
       case "forcedRestart":
         workload.status = "starting";
         break;
+      case "awaitingCert":
+        workload.status = "awaitingCert";
+        break;
       case "running":
         workload.status = "running";
         break;
@@ -311,28 +314,10 @@ export class WorkloadService {
     }
     return workload.events.map((event) => {
       let details: WorkloadEventKind;
-      switch (event.event) {
-        case "created":
-          details = { kind: "created" };
-          break;
-        case "starting":
-          details = { kind: "starting" };
-          break;
-        case "running":
-          details = { kind: "running" };
-          break;
-        case "stopped":
-          details = { kind: "stopped" };
-          break;
-        case "vmRestarted":
-          details = { kind: "vmRestarted" };
-          break;
-        case "forcedRestart":
-          details = { kind: "forcedRestart" };
-          break;
-        case "failedToStart":
-          details = { kind: "failedToStart", error: event.details || "" };
-          break;
+      if (event.event === "failedToStart") {
+        details = { kind: "failedToStart", error: event.details || "" };
+      } else {
+        details = { kind: event.event };
       }
       return {
         eventId: event.id,


### PR DESCRIPTION
This adds a new `awaitingCert` event and vm state in nilcc-api that represents "the VM is up but has not yet created the tls certificate needed for a client to talk to the workload via https".