### PR TITLE
feat: send VM events asynchronously

### DIFF
--- a/nilcc-agent/src/workers/events.rs
+++ b/nilcc-agent/src/workers/events.rs
@@ -1,0 +1,62 @@
+use crate::clients::nilcc_api::{NilccApiClient, VmEvent};
+use std::{sync::Arc, time::Duration};
+use tokio::{
+    sync::mpsc::{channel, Receiver, Sender},
+    time::sleep,
+};
+use tracing::{error, info};
+use uuid::Uuid;
+
+const RETRY_INTERVAL: Duration = Duration::from_secs(1);
+
+pub(crate) struct WorkloadEvent {
+    workload_id: Uuid,
+    event: VmEvent,
+}
+
+pub struct EventWorker {
+    client: Arc<dyn NilccApiClient>,
+    receiver: Receiver<WorkloadEvent>,
+}
+
+impl EventWorker {
+    pub fn spawn(client: Arc<dyn NilccApiClient>) -> EventSender {
+        let (sender, receiver) = channel(1024);
+        tokio::spawn(async move {
+            let worker = EventWorker { client, receiver };
+            worker.run().await;
+        });
+        EventSender(sender)
+    }
+
+    async fn run(mut self) {
+        while let Some(event) = self.receiver.recv().await {
+            self.send_event(event).await;
+        }
+    }
+
+    async fn send_event(&self, event: WorkloadEvent) {
+        let WorkloadEvent { workload_id, event } = event;
+        loop {
+            info!("Sending event for workload {workload_id}");
+            match self.client.report_vm_event(workload_id, event.clone()).await {
+                Ok(_) => return,
+                Err(e) => {
+                    error!("Failed to report event for workload {workload_id}: {e:#}");
+                    sleep(RETRY_INTERVAL).await;
+                }
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct EventSender(pub(crate) Sender<WorkloadEvent>);
+
+impl EventSender {
+    pub(crate) async fn send_event(&self, workload_id: Uuid, event: VmEvent) {
+        if self.0.send(WorkloadEvent { workload_id, event }).await.is_err() {
+            error!("Sender dropped");
+        }
+    }
+}

--- a/nilcc-agent/src/workers/mod.rs
+++ b/nilcc-agent/src/workers/mod.rs
@@ -1,2 +1,3 @@
+pub mod events;
 pub mod heartbeat;
 pub(crate) mod vm;


### PR DESCRIPTION
nilcc-agent VM event submission is now async so the worker won't hang waiting to send them and we will also retry until we can successfully send them.