### PR TITLE
feat: download and tag workloads with artifact version

### DIFF
--- a/nilcc-agent/migrations/20250828201802_add_artifacts_version.sql
+++ b/nilcc-agent/migrations/20250828201802_add_artifacts_version.sql
@@ -1,0 +1,8 @@
+-- Add artifacts version table.
+
+CREATE TABLE artifacts_version(
+  version VARCHAR(64) NOT NULL,
+  updated_at DATETIME WITH TIMEZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+ALTER TABLE workloads ADD COLUMN artifacts_version TEXT NOT NULL;

--- a/nilcc-agent/src/config.rs
+++ b/nilcc-agent/src/config.rs
@@ -47,60 +47,12 @@ pub struct AgentConfig {
 }
 
 #[derive(Clone, Debug, Deserialize)]
-#[serde(untagged)]
-#[allow(clippy::large_enum_variant)]
-pub enum CvmConfigs {
-    Explicit(CvmConfig),
-    BasePath {
-        // The base path where all configs are.
-        base_path: PathBuf,
-    },
-}
+pub struct CvmConfigs {
+    // The base path where all configs are.
+    pub base_path: PathBuf,
 
-impl TryInto<CvmConfig> for CvmConfigs {
-    type Error = anyhow::Error;
-
-    fn try_into(self) -> Result<CvmConfig, Self::Error> {
-        match self {
-            Self::Explicit(config) => Ok(config),
-            Self::BasePath { base_path: path } => {
-                let build_cvm_files = |vm_type: &str| -> anyhow::Result<CvmFiles> {
-                    let verity_root_hash_path = path.join(format!("vm_images/cvm-{vm_type}-verity/root-hash"));
-                    let verity_root_hash = std::fs::read_to_string(&verity_root_hash_path)
-                        .context("Could not read verity hash")?
-                        .trim()
-                        .into();
-                    Ok(CvmFiles {
-                        kernel: path.join(format!("vm_images/kernel/{vm_type}-vmlinuz")),
-                        base_disk: path.join(format!("vm_images/cvm-{vm_type}.qcow2")),
-                        verity_disk: path.join(format!("vm_images/cvm-{vm_type}-verity/verity-hash-dev")),
-                        verity_root_hash,
-                    })
-                };
-                Ok(CvmConfig {
-                    initrd: path.join("initramfs/initramfs.cpio.gz"),
-                    bios: path.join("vm_images/ovmf/OVMF.fd"),
-                    cpu: build_cvm_files("cpu")?,
-                    gpu: build_cvm_files("gpu").ok(),
-                })
-            }
-        }
-    }
-}
-
-#[derive(Clone, Debug, Deserialize)]
-pub struct CvmConfig {
-    /// The path to the initrd file.
-    pub initrd: PathBuf,
-
-    /// The path to the bios file.
-    pub bios: PathBuf,
-
-    /// The disk, kernel and verity files for the cpu cvm.
-    pub cpu: CvmFiles,
-
-    /// The disk, kernel and verity files for the gpu cvm.
-    pub gpu: Option<CvmFiles>,
+    /// The initial version to use.
+    pub initial_version: String,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/nilcc-agent/src/repositories/artifacts.rs
+++ b/nilcc-agent/src/repositories/artifacts.rs
@@ -1,0 +1,70 @@
+use crate::repositories::sqlite::SqliteTransactionContext;
+use async_trait::async_trait;
+
+#[cfg_attr(test, mockall::automock)]
+#[async_trait]
+pub trait ArtifactsVersionRepository: Send + Sync {
+    /// Set the current artifacts version.
+    async fn set(&mut self, version: &str) -> Result<(), ArtifactsVersionRepositoryError>;
+
+    /// Get the current artifacts version, if any
+    async fn get(&mut self) -> Result<Option<String>, ArtifactsVersionRepositoryError>;
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ArtifactsVersionRepositoryError {
+    #[error("database error: {0}")]
+    Database(#[from] sqlx::Error),
+}
+
+pub struct SqliteArtifactsVersionRepository<'a> {
+    ctx: SqliteTransactionContext<'a>,
+}
+
+impl<'a> SqliteArtifactsVersionRepository<'a> {
+    pub fn new(ctx: SqliteTransactionContext<'a>) -> Self {
+        Self { ctx }
+    }
+}
+
+#[async_trait]
+impl<'a> ArtifactsVersionRepository for SqliteArtifactsVersionRepository<'a> {
+    async fn set(&mut self, version: &str) -> Result<(), ArtifactsVersionRepositoryError> {
+        let query = "UPDATE artifacts_version SET version = ?";
+        let result = sqlx::query(query).bind(version).execute(&mut *self.ctx).await?;
+        if result.rows_affected() == 1 {
+            return Ok(());
+        }
+        let query = "INSERT INTO artifacts_version (version) VALUES (?)";
+        sqlx::query(query).bind(version).execute(&mut *self.ctx).await?;
+        Ok(())
+    }
+
+    async fn get(&mut self) -> Result<Option<String>, ArtifactsVersionRepositoryError> {
+        let query = "SELECT version FROM artifacts_version";
+        let version: Option<(String,)> = sqlx::query_as(query).fetch_optional(&mut *self.ctx).await?;
+        Ok(version.map(|v| v.0))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::repositories::sqlite::{SqliteDb, SqliteTransactionContextInner};
+
+    #[tokio::test]
+    async fn crud() {
+        let db = SqliteDb::connect("sqlite://:memory:").await.expect("failed to create db");
+        let connection = db.0.acquire().await.expect("failed to acquire");
+        let mut repo =
+            SqliteArtifactsVersionRepository::new(SqliteTransactionContextInner::Connection(connection).into());
+
+        assert!(repo.get().await.expect("failed to get").is_none());
+
+        repo.set("aaa").await.expect("failed to set");
+        assert_eq!(repo.get().await.expect("failed to get").as_deref(), Some("aaa"));
+
+        repo.set("bbb").await.expect("failed to set");
+        assert_eq!(repo.get().await.expect("failed to get").as_deref(), Some("bbb"));
+    }
+}

--- a/nilcc-agent/src/repositories/mod.rs
+++ b/nilcc-agent/src/repositories/mod.rs
@@ -1,2 +1,3 @@
+pub mod artifacts;
 pub mod sqlite;
 pub mod workload;

--- a/nilcc-agent/src/repositories/workload.rs
+++ b/nilcc-agent/src/repositories/workload.rs
@@ -14,6 +14,7 @@ use uuid::Uuid;
 pub struct Workload {
     pub id: Uuid,
     pub docker_compose: String,
+    pub artifacts_version: String,
     #[sqlx(json)]
     pub env_vars: HashMap<String, String>,
     #[sqlx(json)]
@@ -52,6 +53,7 @@ impl fmt::Debug for Workload {
         let Self {
             id,
             docker_compose,
+            artifacts_version,
             env_vars,
             files,
             public_container_name,
@@ -70,6 +72,7 @@ impl fmt::Debug for Workload {
         f.debug_struct("Workload")
             .field("id", id)
             .field("docker_compose", docker_compose)
+            .field("artifacts_version", artifacts_version)
             .field("env_vars", &environment_variables)
             .field("files", &files)
             .field("public_container_name", public_container_name)
@@ -169,6 +172,7 @@ impl<'a> WorkloadRepository for SqliteWorkloadRepository<'a> {
 INSERT INTO workloads (
     id,
     docker_compose,
+    artifacts_version,
     env_vars,
     files,
     docker_credentials,
@@ -183,11 +187,12 @@ INSERT INTO workloads (
     enabled,
     created_at
 )
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
 ";
         let Workload {
             id,
             docker_compose,
+            artifacts_version,
             env_vars,
             files,
             docker_credentials,
@@ -205,6 +210,7 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
         sqlx::query(query)
             .bind(id)
             .bind(docker_compose)
+            .bind(artifacts_version)
             .bind(sqlx::types::Json(env_vars))
             .bind(sqlx::types::Json(files))
             .bind(sqlx::types::Json(docker_credentials))
@@ -275,6 +281,7 @@ mod tests {
         let mut repo = SqliteWorkloadRepository::new(SqliteTransactionContextInner::Connection(connection).into());
         let workload = Workload {
             id: Uuid::new_v4(),
+            artifacts_version: "default".into(),
             docker_compose: "hi".into(),
             env_vars: HashMap::from([("FOO".into(), "value".into())]),
             files: HashMap::from([("foo.txt".into(), vec![1, 2, 3])]),

--- a/nilcc-agent/src/resources.rs
+++ b/nilcc-agent/src/resources.rs
@@ -304,6 +304,7 @@ mod tests {
         Workload {
             id: Uuid::new_v4(),
             docker_compose: Default::default(),
+            artifacts_version: "default".into(),
             env_vars: Default::default(),
             files: Default::default(),
             docker_credentials: Default::default(),


### PR DESCRIPTION
This:
* Changes the config file structure around `cvm` to always include only a base path and an initial version.
* The agent now keeps track of the current version to be used for any workloads that are created in its sqlite db.
* The initial version must be a valid public artifact version which will be downloaded from s3 if we don't have a version stored in sqlite.
* When creating a workload, it is associated with the current version and the artifacts for that version are used.
* In the future we will support updating the version, but workloads will always use the version they were started with.

This is the first half of #328