### PR TITLE
feat: allow upgrading artifact versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2256,6 +2256,7 @@ dependencies = [
 name = "nilcc-agent-models"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "convert_case",
  "regex",
  "serde",

--- a/crates/nilcc-agent-models/Cargo.toml
+++ b/crates/nilcc-agent-models/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 convert_case = "0.8"
+chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 regex = "1.11"
 serde_with = { version = "3.14", features = ["base64"] }

--- a/crates/nilcc-artifacts/src/lib.rs
+++ b/crates/nilcc-artifacts/src/lib.rs
@@ -43,6 +43,13 @@ impl ArtifactsDownloader {
         self
     }
 
+    pub async fn validate_exists(&self) -> anyhow::Result<()> {
+        let Self { version, artifacts_url, .. } = self;
+        let url = format!("{artifacts_url}/{version}/metadata.json");
+        reqwest::get(url).await?.error_for_status()?;
+        Ok(())
+    }
+
     pub async fn download(&self, target_dir: &Path) -> anyhow::Result<Artifacts> {
         info!("Downloading artifacts to {}", target_dir.display());
 

--- a/nilcc-agent/src/routes/mod.rs
+++ b/nilcc-agent/src/routes/mod.rs
@@ -3,6 +3,7 @@
 use crate::auth::AuthLayer;
 use crate::clients::cvm_agent::CvmAgentClient;
 use crate::config::ResourceLimitsConfig;
+use crate::services::upgrade::UpgradeService;
 use crate::services::workload::WorkloadService;
 use axum::extract::rejection::QueryRejection;
 use axum::extract::{rejection::JsonRejection, FromRequest};
@@ -13,17 +14,21 @@ use axum::response::IntoResponse;
 use axum::routing::{get, post};
 use axum::Router;
 use nilcc_agent_models::errors::RequestHandlerError;
+use nilcc_artifacts::VmType;
 use serde::Serialize;
 use std::ops::Deref;
+use std::path::PathBuf;
 use std::sync::Arc;
 use tower::ServiceBuilder;
 use validator::Validate;
 
+pub(crate) mod system;
 pub(crate) mod workloads;
 
 #[derive(Clone)]
 pub struct Services {
     pub workload: Arc<dyn WorkloadService>,
+    pub upgrade: Arc<dyn UpgradeService>,
 }
 
 #[derive(Clone)]
@@ -37,23 +42,31 @@ pub struct AppState {
     pub clients: Clients,
     pub resource_limits: ResourceLimitsConfig,
     pub agent_domain: String,
+    pub vm_types: Vec<VmType>,
+    pub cvm_artifacts_path: PathBuf,
 }
 
 pub fn build_router(state: AppState, token: String) -> Router {
     Router::new().route("/health", get(health)).nest(
-        "/api/v1/workloads",
+        "/api/v1",
         Router::new()
-            .route("/create", post(workloads::create::handler))
-            .route("/delete", post(workloads::delete::handler))
-            .route("/restart", post(workloads::restart::handler))
-            .route("/stop", post(workloads::stop::handler))
-            .route("/start", post(workloads::start::handler))
-            .route("/list", get(workloads::list::handler))
-            .route("/{workload_id}/health", get(workloads::health::handler))
-            .route("/{workload_id}/containers/list", get(workloads::containers::list::handler))
-            .route("/{workload_id}/containers/logs", get(workloads::containers::logs::handler))
-            .route("/{workload_id}/system/logs", get(workloads::system::logs::handler))
-            .route("/{workload_id}/system/stats", get(workloads::system::stats::handler))
+            .route("/system/artifacts/upgrade", post(system::artifacts::upgrade::handler))
+            .route("/system/artifacts/version", get(system::artifacts::version::handler))
+            .nest(
+                "/workloads",
+                Router::new()
+                    .route("/create", post(workloads::create::handler))
+                    .route("/delete", post(workloads::delete::handler))
+                    .route("/restart", post(workloads::restart::handler))
+                    .route("/stop", post(workloads::stop::handler))
+                    .route("/start", post(workloads::start::handler))
+                    .route("/list", get(workloads::list::handler))
+                    .route("/{workload_id}/health", get(workloads::health::handler))
+                    .route("/{workload_id}/containers/list", get(workloads::containers::list::handler))
+                    .route("/{workload_id}/containers/logs", get(workloads::containers::logs::handler))
+                    .route("/{workload_id}/system/logs", get(workloads::system::logs::handler))
+                    .route("/{workload_id}/system/stats", get(workloads::system::stats::handler)),
+            )
             .with_state(state)
             .layer(ServiceBuilder::new().layer(AuthLayer::new(token))),
     )

--- a/nilcc-agent/src/routes/system/artifacts/mod.rs
+++ b/nilcc-agent/src/routes/system/artifacts/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod upgrade;
+pub(crate) mod version;

--- a/nilcc-agent/src/routes/system/artifacts/upgrade.rs
+++ b/nilcc-agent/src/routes/system/artifacts/upgrade.rs
@@ -1,0 +1,32 @@
+use crate::{
+    routes::{AppState, Json},
+    services::upgrade::{UpgradeError, UpgradeErrorDiscriminants},
+};
+use axum::{
+    extract::State,
+    response::{IntoResponse, Response},
+};
+use nilcc_agent_models::{errors::RequestHandlerError, system::UpgradeArtifactsRequest};
+use reqwest::StatusCode;
+
+pub(crate) async fn handler(
+    state: State<AppState>,
+    request: Json<UpgradeArtifactsRequest>,
+) -> Result<Json<()>, UpgradeError> {
+    let UpgradeArtifactsRequest { version } = request.0;
+    let path = state.cvm_artifacts_path.join(&version);
+    state.services.upgrade.upgrade_artifacts(version, state.vm_types.clone(), path).await?;
+    Ok(Json(()))
+}
+
+impl IntoResponse for UpgradeError {
+    fn into_response(self) -> Response {
+        let discriminant = UpgradeErrorDiscriminants::from(&self);
+        let (code, message) = match self {
+            Self::InvalidVersion => (StatusCode::BAD_REQUEST, self.to_string()),
+            Self::ActiveUpgrade(_) => (StatusCode::PRECONDITION_FAILED, self.to_string()),
+        };
+        let response = RequestHandlerError::new(message, format!("{discriminant:?}"));
+        (code, Json(response)).into_response()
+    }
+}

--- a/nilcc-agent/src/routes/system/artifacts/version.rs
+++ b/nilcc-agent/src/routes/system/artifacts/version.rs
@@ -1,0 +1,35 @@
+use crate::{
+    routes::AppState,
+    services::upgrade::{UpgradeMetadata, UpgradeState},
+};
+use axum::{extract::State, response::IntoResponse, Json};
+use axum::{http::StatusCode, response::Response};
+use nilcc_agent_models::{
+    errors::RequestHandlerError,
+    system::{ArtifactUpgrade, ArtifactsVersionResponse},
+};
+use tracing::error;
+
+pub(crate) async fn handler(state: State<AppState>) -> Result<Json<ArtifactsVersionResponse>, Response> {
+    let version = state.services.upgrade.artifacts_version().await.map_err(|e| {
+        error!("Failed to get current artifacts version: {e:#}");
+        (StatusCode::INTERNAL_SERVER_ERROR, Json(RequestHandlerError::new("internal server error", "INTERNAL")))
+            .into_response()
+    })?;
+    let last_upgrade = match state.services.upgrade.artifacts_upgrade_state().await {
+        UpgradeState::None => None,
+        UpgradeState::Upgrading { metadata } => {
+            let UpgradeMetadata { version, started_at, .. } = metadata;
+            Some(ArtifactUpgrade { version, started_at, state: nilcc_agent_models::system::UpgradeState::InProgress })
+        }
+        UpgradeState::Done { metadata, finished_at, error } => {
+            let UpgradeMetadata { version, started_at, .. } = metadata;
+            let state = match error {
+                Some(error) => nilcc_agent_models::system::UpgradeState::Error { error, finished_at },
+                None => nilcc_agent_models::system::UpgradeState::Success { finished_at },
+            };
+            Some(ArtifactUpgrade { version, started_at, state })
+        }
+    };
+    Ok(Json(ArtifactsVersionResponse { version, last_upgrade }))
+}

--- a/nilcc-agent/src/routes/system/mod.rs
+++ b/nilcc-agent/src/routes/system/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod artifacts;

--- a/nilcc-agent/src/services/mod.rs
+++ b/nilcc-agent/src/services/mod.rs
@@ -1,4 +1,5 @@
 pub mod disk;
 pub mod proxy;
+pub mod upgrade;
 pub mod vm;
 pub mod workload;

--- a/nilcc-agent/src/services/upgrade.rs
+++ b/nilcc-agent/src/services/upgrade.rs
@@ -1,0 +1,157 @@
+use crate::repositories::sqlite::RepositoryProvider;
+use anyhow::anyhow;
+use anyhow::Context;
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use nilcc_artifacts::{ArtifactsDownloader, VmType};
+use std::{path::PathBuf, sync::Arc};
+use strum::EnumDiscriminants;
+use tokio::sync::Mutex;
+use tracing::{error, info};
+
+#[async_trait]
+pub trait UpgradeService: Send + Sync {
+    async fn upgrade_artifacts(
+        &self,
+        version: String,
+        vm_types: Vec<VmType>,
+        target_path: PathBuf,
+    ) -> Result<(), UpgradeError>;
+
+    async fn artifacts_upgrade_state(&self) -> UpgradeState;
+    async fn artifacts_version(&self) -> anyhow::Result<String>;
+}
+
+#[derive(Debug, EnumDiscriminants, thiserror::Error)]
+pub enum UpgradeError {
+    #[error("invalid version")]
+    InvalidVersion,
+
+    #[error("an upgrade to version {0} is already in progress")]
+    ActiveUpgrade(String),
+}
+
+pub struct DefaultUpgradeServiceArgs {
+    pub repository_provider: Arc<dyn RepositoryProvider>,
+}
+
+pub struct DefaultUpgradeService {
+    artifacts: Arc<Mutex<UpgradeState>>,
+    repository_provider: Arc<dyn RepositoryProvider>,
+}
+
+impl DefaultUpgradeService {
+    pub fn new(args: DefaultUpgradeServiceArgs) -> Self {
+        let DefaultUpgradeServiceArgs { repository_provider } = args;
+        Self { artifacts: Default::default(), repository_provider }
+    }
+}
+
+#[async_trait]
+impl UpgradeService for DefaultUpgradeService {
+    async fn upgrade_artifacts(
+        &self,
+        version: String,
+        vm_types: Vec<VmType>,
+        target_path: PathBuf,
+    ) -> Result<(), UpgradeError> {
+        let mut current = self.artifacts.lock().await;
+        match &*current {
+            UpgradeState::Upgrading { metadata, .. } => {
+                return Err(UpgradeError::ActiveUpgrade(metadata.version.clone()))
+            }
+            UpgradeState::None | UpgradeState::Done { .. } => (),
+        };
+        let downloader = ArtifactsDownloader::new(version.clone(), vm_types.clone());
+        downloader.validate_exists().await.map_err(|_| UpgradeError::InvalidVersion)?;
+
+        info!("Initiating upgrade to version {version}");
+        let metadata = UpgradeMetadata { version: version.clone(), started_at: Utc::now(), vm_types };
+        let state = self.artifacts.clone();
+        *current = UpgradeState::Upgrading { metadata };
+
+        let worker = ArtifactUpgradeWorker {
+            downloader,
+            target_path,
+            state,
+            version,
+            repository_provider: self.repository_provider.clone(),
+        };
+        tokio::spawn(async move { worker.run().await });
+        Ok(())
+    }
+
+    async fn artifacts_upgrade_state(&self) -> UpgradeState {
+        self.artifacts.lock().await.clone()
+    }
+
+    async fn artifacts_version(&self) -> anyhow::Result<String> {
+        let mut repo = self.repository_provider.artifacts_version(Default::default()).await?;
+        let version = repo.get().await?;
+        version.ok_or_else(|| anyhow!("no version in db"))
+    }
+}
+
+#[derive(Clone, Default, Debug)]
+pub enum UpgradeState {
+    #[default]
+    None,
+    Upgrading {
+        metadata: UpgradeMetadata,
+    },
+    Done {
+        metadata: UpgradeMetadata,
+        finished_at: DateTime<Utc>,
+        error: Option<String>,
+    },
+}
+
+#[derive(Clone, Debug)]
+pub struct UpgradeMetadata {
+    pub version: String,
+    pub started_at: DateTime<Utc>,
+    pub vm_types: Vec<VmType>,
+}
+
+struct ArtifactUpgradeWorker {
+    downloader: ArtifactsDownloader,
+    target_path: PathBuf,
+    state: Arc<Mutex<UpgradeState>>,
+    version: String,
+    repository_provider: Arc<dyn RepositoryProvider>,
+}
+
+impl ArtifactUpgradeWorker {
+    async fn run(self) {
+        let version = &self.version;
+        let error = match self.perform_upgrade().await {
+            Ok(_) => None,
+            Err(e) => {
+                error!("Failed to upgrade to version {version}: {e}");
+                Some(e.to_string())
+            }
+        };
+        let mut state = self.state.lock().await;
+        match &*state {
+            UpgradeState::None => {
+                error!("Not running any upgrades");
+            }
+            UpgradeState::Done { .. } => {
+                error!("Upgrade is marked as completed already");
+            }
+            UpgradeState::Upgrading { metadata } => {
+                *state = UpgradeState::Done { metadata: metadata.clone(), finished_at: Utc::now(), error }
+            }
+        };
+    }
+
+    async fn perform_upgrade(&self) -> anyhow::Result<()> {
+        let version = &self.version;
+        self.downloader.download(&self.target_path).await?;
+        info!("Upgrade to version {version} successful");
+        let mut repo =
+            self.repository_provider.artifacts_version(Default::default()).await.context("Failed to get repository")?;
+        repo.set(version).await.context("Failed to set version")?;
+        Ok(())
+    }
+}

--- a/nilcc-agent/src/services/workload.rs
+++ b/nilcc-agent/src/services/workload.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use nilcc_agent_models::workloads::create::CreateWorkloadRequest;
-use std::{collections::BTreeSet, io, ops::Range};
+use std::{collections::BTreeSet, io, ops::Range, sync::Arc};
 use strum::EnumDiscriminants;
 use tokio::sync::Mutex;
 use tracing::info;
@@ -107,7 +107,7 @@ impl From<WorkloadRepositoryError> for WorkloadLookupError {
 
 pub struct WorkloadServiceArgs {
     pub vm_service: Box<dyn VmService>,
-    pub repository_provider: Box<dyn RepositoryProvider>,
+    pub repository_provider: Arc<dyn RepositoryProvider>,
     pub proxy_service: Box<dyn ProxyService>,
     pub resources: SystemResources,
     pub open_ports: Range<u16>,
@@ -152,7 +152,7 @@ pub enum CreateServiceError {
 }
 
 pub struct DefaultWorkloadService {
-    repository_provider: Box<dyn RepositoryProvider>,
+    repository_provider: Arc<dyn RepositoryProvider>,
     vm_service: Box<dyn VmService>,
     proxy_service: Box<dyn ProxyService>,
     resources: Mutex<AvailableResources>,
@@ -434,7 +434,7 @@ mod tests {
 
             let args = WorkloadServiceArgs {
                 vm_service: Box::new(vm_service),
-                repository_provider: Box::new(provider),
+                repository_provider: Arc::new(provider),
                 proxy_service: Box::new(proxy_service),
                 resources,
                 open_ports,


### PR DESCRIPTION
This implements an endpoint to upgrade the current artifacts version and another one to get the current version and information about the last executed upgrade. The upgrade runs asynchronously and will download all artifacts and at the end switch to the new version in sqlite. At that point any new workloads will start using this new artifact version, while existing ones will keep using the previous one.

Implements almost all of the remaining #328, just need to make sure you can't upgrade to existing versions but will do that in another PR.