### PR TITLE
feat: don't allow re-updating to existing version

### DIFF
--- a/nilcc-agent/migrations/20250829190416_add_current_to_artifacts_table.sql
+++ b/nilcc-agent/migrations/20250829190416_add_current_to_artifacts_table.sql
@@ -1,0 +1,13 @@
+-- Add a `current` column to the artifacts version table.
+
+ALTER TABLE artifacts_version RENAME TO artifacts_version_old;
+
+CREATE TABLE artifacts_version(
+  version VARCHAR(64) PRIMARY KEY,
+  updated_at DATETIME WITH TIMEZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  current BOOLEAN DEFAULT false
+);
+
+INSERT INTO artifacts_version(version, updated_at) SELECT * FROM artifacts_version_old;
+
+DROP TABLE artifacts_version_old;

--- a/nilcc-agent/src/routes/system/artifacts/upgrade.rs
+++ b/nilcc-agent/src/routes/system/artifacts/upgrade.rs
@@ -24,7 +24,8 @@ impl IntoResponse for UpgradeError {
         let discriminant = UpgradeErrorDiscriminants::from(&self);
         let (code, message) = match self {
             Self::InvalidVersion => (StatusCode::BAD_REQUEST, self.to_string()),
-            Self::ActiveUpgrade(_) => (StatusCode::PRECONDITION_FAILED, self.to_string()),
+            Self::ActiveUpgrade(_) | Self::ExistingVersion => (StatusCode::PRECONDITION_FAILED, self.to_string()),
+            Self::Internal => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
         };
         let response = RequestHandlerError::new(message, format!("{discriminant:?}"));
         (code, Json(response)).into_response()

--- a/nilcc-agent/src/services/workload.rs
+++ b/nilcc-agent/src/services/workload.rs
@@ -284,13 +284,13 @@ impl WorkloadService for DefaultWorkloadService {
         if resources.ports.len() < TOTAL_PORTS {
             return Err(CreateWorkloadError::InsufficientResources("open ports"));
         }
-        let workload = self.build_workload(request, &resources, artifacts_version);
+        let workload = self.build_workload(request, &resources, artifacts_version.clone());
         let id = workload.id;
         info!("Storing workload {id} in database");
         let mut repo = self.repository_provider.workloads(ProviderMode::Transactional).await?;
         repo.create(workload.clone()).await?;
 
-        info!("Scheduling VM {id}");
+        info!("Scheduling VM {id} using artifacts version {artifacts_version}");
         let proxied_vm = ProxiedVm::from(&workload);
         self.vm_service.create_vm(workload).await?;
         self.proxy_service.start_vm_proxy(proxied_vm).await;


### PR DESCRIPTION
This keeps track of all artifact versions in the db rather than just the latest one. This allows making sure we never allow upgrading to a version we've already used/are currently using, since we assume once a version lands in sqlite it is considered valid. If this situation were ever to happen (e.g. a version shows up then it goes away) then we should manually fix it.

Closes #328