### PR TITLE
fix: don't report repeated workload events

### DIFF
--- a/nilcc-agent/migrations/20250902180758_add_last_reported_state.sql
+++ b/nilcc-agent/migrations/20250902180758_add_last_reported_state.sql
@@ -1,0 +1,3 @@
+-- Add `last_reported_event` to workloads table.
+
+ALTER TABLE workloads ADD COLUMN last_reported_event VARCHAR(64) DEFAULT NULL;

--- a/nilcc-agent/src/clients/nilcc_api.rs
+++ b/nilcc-agent/src/clients/nilcc_api.rs
@@ -6,6 +6,7 @@ use axum::http::{HeaderMap, HeaderName, HeaderValue};
 use reqwest::{Client, Method, StatusCode};
 use serde::Serialize;
 use std::net::Ipv4Addr;
+use strum::EnumDiscriminants;
 use tracing::info;
 use uuid::Uuid;
 
@@ -27,7 +28,7 @@ pub trait NilccApiClient: Send + Sync {
     async fn heartbeat(&self) -> Result<(), NilccApiError>;
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, PartialEq, EnumDiscriminants)]
 #[serde(tag = "kind", rename_all = "camelCase")]
 pub enum VmEvent {
     Starting,

--- a/nilcc-agent/src/resources.rs
+++ b/nilcc-agent/src/resources.rs
@@ -316,6 +316,7 @@ mod tests {
             gpus: gpus.iter().cloned().collect(),
             ports: [150, 151, 152],
             domain: domain.into(),
+            last_reported_event: None,
             enabled: true,
         }
     }

--- a/nilcc-agent/src/services/vm.rs
+++ b/nilcc-agent/src/services/vm.rs
@@ -416,6 +416,7 @@ mod tests {
             disk_space_gb: 1.try_into().unwrap(),
             ports: [1000, 1001, 1002],
             domain: "example.com".into(),
+            last_reported_event: None,
             enabled: true,
         };
         let mut builder = Builder::default();

--- a/nilcc-agent/src/services/workload.rs
+++ b/nilcc-agent/src/services/workload.rs
@@ -233,6 +233,7 @@ impl DefaultWorkloadService {
             disk_space_gb,
             ports,
             domain,
+            last_reported_event: None,
             enabled: true,
         }
     }
@@ -482,6 +483,7 @@ mod tests {
             gpus: Default::default(),
             ports: [150, 151, 152],
             domain: "example.com".into(),
+            last_reported_event: None,
             enabled: true,
         }
     }
@@ -598,6 +600,7 @@ mod tests {
             disk_space_gb: request.disk_space_gb,
             ports: [100, 101, 102],
             domain: request.domain.clone(),
+            last_reported_event: None,
             enabled: true,
         };
         let mut builder = Builder::default();

--- a/nilcc-agent/src/workers/events.rs
+++ b/nilcc-agent/src/workers/events.rs
@@ -1,6 +1,10 @@
-use crate::clients::nilcc_api::{NilccApiClient, NilccApiError, VmEvent};
+use crate::{
+    clients::nilcc_api::{NilccApiClient, NilccApiError, VmEvent, VmEventDiscriminants},
+    repositories::{sqlite::RepositoryProvider, workload::WorkloadRepositoryError},
+};
+use anyhow::Context;
 use reqwest::StatusCode;
-use std::{sync::Arc, time::Duration};
+use std::{collections::HashSet, sync::Arc, time::Duration};
 use tokio::{
     sync::mpsc::{channel, Receiver, Sender},
     time::sleep,
@@ -15,16 +19,25 @@ pub(crate) struct WorkloadEvent {
     event: VmEvent,
 }
 
+pub struct EventWorkerArgs {
+    pub api_client: Arc<dyn NilccApiClient>,
+    pub repository_provider: Arc<dyn RepositoryProvider>,
+}
+
 pub struct EventWorker {
     client: Arc<dyn NilccApiClient>,
     receiver: Receiver<WorkloadEvent>,
+    repository_provider: Arc<dyn RepositoryProvider>,
+    seen_workloads: HashSet<Uuid>,
 }
 
 impl EventWorker {
-    pub fn spawn(client: Arc<dyn NilccApiClient>) -> EventSender {
+    pub fn spawn(args: EventWorkerArgs) -> EventSender {
+        let EventWorkerArgs { api_client, repository_provider } = args;
         let (sender, receiver) = channel(1024);
         tokio::spawn(async move {
-            let worker = EventWorker { client, receiver };
+            let worker =
+                EventWorker { client: api_client, repository_provider, receiver, seen_workloads: Default::default() };
             worker.run().await;
         });
         EventSender(sender)
@@ -32,22 +45,56 @@ impl EventWorker {
 
     async fn run(mut self) {
         while let Some(event) = self.receiver.recv().await {
-            self.send_event(event).await;
+            while let Err(e) = self.send_event(&event).await {
+                error!("Failed to send event: {e:#}");
+                sleep(RETRY_INTERVAL).await;
+            }
         }
     }
 
-    async fn send_event(&self, event: WorkloadEvent) {
+    async fn send_event(&mut self, event: &WorkloadEvent) -> anyhow::Result<()> {
         let WorkloadEvent { workload_id, event } = event;
-        loop {
-            info!("Sending event for workload {workload_id}");
-            match self.client.report_vm_event(workload_id, event.clone()).await {
-                Ok(_) => return,
-                Err(NilccApiError::Api { status, .. }) if status == StatusCode::NOT_FOUND => {
-                    warn!("API returned 404 for workload {workload_id} event, ignoring");
-                    return;
+        let event_type = format!("{:?}", VmEventDiscriminants::from(event));
+        let mut repo =
+            self.repository_provider.workloads(Default::default()).await.context("Failed to get repository")?;
+        if !self.seen_workloads.contains(workload_id) {
+            let workload = match repo.find(*workload_id).await {
+                Ok(workload) => workload,
+                Err(WorkloadRepositoryError::WorkloadNotFound) => {
+                    warn!("Ignoring event {event_type} since workload {workload_id} does not exist anymore");
+                    return Ok(());
                 }
                 Err(e) => {
-                    error!("Failed to report event for workload {workload_id}: {e:#}");
+                    return Err(e).context("Failed to lookup workload");
+                }
+            };
+            if workload.last_reported_event.as_ref() == Some(&event_type) {
+                info!("Already reported event {event_type} for workload {workload_id}, ignoring");
+                self.seen_workloads.insert(*workload_id);
+                return Ok(());
+            }
+        }
+
+        info!("Sending event {event_type} for workload {workload_id}");
+        match self.client.report_vm_event(*workload_id, event.clone()).await {
+            Ok(_) => (),
+            Err(NilccApiError::Api { status, .. }) if status == StatusCode::NOT_FOUND => {
+                warn!("API returned 404 for workload {workload_id} event, ignoring");
+                return Ok(());
+            }
+            Err(e) => {
+                return Err(e).context("Failed to send event to API");
+            }
+        };
+
+        loop {
+            match repo.set_last_reported_event(*workload_id, event_type.clone()).await {
+                Ok(_) => {
+                    self.seen_workloads.insert(*workload_id);
+                    return Ok(());
+                }
+                Err(e) => {
+                    warn!("Failed to update workload last reported event: {e}");
                     sleep(RETRY_INTERVAL).await;
                 }
             }


### PR DESCRIPTION
This prevents the workload's state to be re-reported on nilcc-agent restart when it hasn't changed. e.g. if the VM is running and you restart, now you won't get another `Running` event.