### PR TITLE
feat: perform a single attestation including TLS pubkey on start

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1596,13 +1596,14 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
+ "futures-core",
  "h2",
  "http",
  "http-body",
@@ -1610,6 +1611,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
+ "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -2289,14 +2291,17 @@ dependencies = [
  "hex",
  "num_cpus",
  "rand 0.9.1",
+ "reqwest",
  "serde",
  "serde_with",
  "sev",
+ "sha2",
  "thiserror 2.0.12",
  "tokio",
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "x509-parser 0.18.0",
 ]
 
 [[package]]
@@ -5262,6 +5267,23 @@ dependencies = [
  "nom",
  "oid-registry 0.8.1",
  "ring",
+ "rusticata-macros",
+ "thiserror 2.0.12",
+ "time",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3e137310115a65136898d2079f003ce33331a6c4b0d51f1531d1be082b6425"
+dependencies = [
+ "asn1-rs 0.7.1",
+ "data-encoding",
+ "der-parser 10.0.0",
+ "lazy_static",
+ "nom",
+ "oid-registry 0.8.1",
  "rusticata-macros",
  "thiserror 2.0.12",
  "time",

--- a/crates/cvm-agent-models/src/lib.rs
+++ b/crates/cvm-agent-models/src/lib.rs
@@ -24,6 +24,9 @@ pub mod bootstrap {
 
         /// The docker credentials to use.
         pub docker: Vec<DockerCredentials>,
+
+        /// The public domain the CVM is accessible at.
+        pub domain: String,
     }
 
     /// The ACME credentials.

--- a/cvm-agent/resources/docker-compose.yaml
+++ b/cvm-agent/resources/docker-compose.yaml
@@ -11,6 +11,7 @@ services:
       APP__SERVER__BIND_ENDPOINT: "0.0.0.0:80"
       APP__NILCC_VERSION: ${NILCC_VERSION}
       APP__VM_TYPE: ${NILCC_VM_TYPE}
+      APP__ATTESTATION_DOMAIN: ${NILCC_DOMAIN}
       NO_COLOR: 1
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost/health"]

--- a/cvm-agent/src/monitors/compose.rs
+++ b/cvm-agent/src/monitors/compose.rs
@@ -17,11 +17,12 @@ pub(crate) struct ComposeMonitor {
     ctx: BootstrapContext,
     acme: AcmeCredentials,
     docker: Vec<DockerCredentials>,
+    domain: String,
 }
 
 impl ComposeMonitor {
-    pub(crate) fn spawn(ctx: BootstrapContext, acme: AcmeCredentials, docker: Vec<DockerCredentials>) {
-        let monitor = ComposeMonitor { ctx, acme, docker };
+    pub(crate) fn spawn(ctx: BootstrapContext, acme: AcmeCredentials, docker: Vec<DockerCredentials>, domain: String) {
+        let monitor = ComposeMonitor { ctx, acme, docker, domain };
         info!("Spawning docker compose monitor");
         tokio::spawn(async move {
             monitor.run().await;
@@ -132,6 +133,7 @@ impl ComposeMonitor {
             .env("CADDY_INPUT_FILE", self.ctx.caddy_config.as_os_str())
             .env("NILCC_VERSION", &self.ctx.version)
             .env("NILCC_VM_TYPE", self.ctx.vm_type.to_string())
+            .env("NILCC_DOMAIN", &self.domain)
             .env(CADDY_ACME_EAB_KEY_ID, &self.acme.eab_key_id)
             .env(CADDY_ACME_EAB_MAC_KEY, &self.acme.eab_mac_key)
             .stderr(Stdio::piped())

--- a/cvm-agent/src/resources.rs
+++ b/cvm-agent/src/resources.rs
@@ -102,6 +102,7 @@ https://foo.com {
       APP__SERVER__BIND_ENDPOINT: "0.0.0.0:80"
       APP__NILCC_VERSION: ${NILCC_VERSION}
       APP__VM_TYPE: ${NILCC_VM_TYPE}
+      APP__ATTESTATION_DOMAIN: ${NILCC_DOMAIN}
       NO_COLOR: 1
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost/health"]
@@ -144,6 +145,7 @@ https://foo.com {
       APP__SERVER__BIND_ENDPOINT: "0.0.0.0:80"
       APP__NILCC_VERSION: ${NILCC_VERSION}
       APP__VM_TYPE: ${NILCC_VM_TYPE}
+      APP__ATTESTATION_DOMAIN: ${NILCC_DOMAIN}
       NO_COLOR: 1
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost/health"]

--- a/cvm-agent/src/routes/system/bootstrap.rs
+++ b/cvm-agent/src/routes/system/bootstrap.rs
@@ -13,7 +13,7 @@ pub(crate) async fn handler(state: SharedState, request: Json<BootstrapRequest>)
     let request = request.0;
     let ctx = state.context.clone();
     *system_state = SystemState::Starting;
-    ComposeMonitor::spawn(ctx, request.acme, request.docker);
+    ComposeMonitor::spawn(ctx, request.acme, request.docker, request.domain);
     CaddyMonitor::spawn(state.docker.clone(), state.system_state.clone());
     StatusCode::OK
 }

--- a/nilcc-agent/src/services/disk.rs
+++ b/nilcc-agent/src/services/disk.rs
@@ -1,6 +1,7 @@
 use crate::clients::qemu::HardDiskFormat;
 use anyhow::{bail, Context};
 use async_trait::async_trait;
+use cvm_agent_models::bootstrap::{CADDY_ACME_EAB_KEY_ID, CADDY_ACME_EAB_MAC_KEY};
 use serde::Serialize;
 use std::{
     fmt::Write,
@@ -15,7 +16,15 @@ use tokio::{
 use tracing::info;
 
 /// The list of reserved environment variable names.
-static RESERVED_ENVIRONMENT_VARIABLES: &[&str] = &["NILCC_VERSION", "NILCC_VM_TYPE"];
+static RESERVED_ENVIRONMENT_VARIABLES: &[&str] = &[
+    "NILCC_VERSION",
+    "NILCC_VM_TYPE",
+    "NILCC_DOMAIN",
+    "FILES",
+    "CADDY_INPUT_FILE",
+    CADDY_ACME_EAB_KEY_ID,
+    CADDY_ACME_EAB_MAC_KEY,
+];
 
 #[cfg_attr(test, mockall::automock)]
 #[async_trait]

--- a/nilcc-agent/src/services/vm.rs
+++ b/nilcc-agent/src/services/vm.rs
@@ -225,6 +225,7 @@ impl VmService for DefaultVmService {
                     zerossl_config: self.zerossl_config.clone(),
                     docker_credentials,
                     event_sender: self.event_sender.clone(),
+                    domain: workload.domain,
                 };
                 let worker = VmWorker::spawn(args);
                 workers.insert(id, worker);

--- a/nilcc-agent/src/workers/vm.rs
+++ b/nilcc-agent/src/workers/vm.rs
@@ -33,6 +33,7 @@ pub(crate) struct VmWorkerArgs {
     pub(crate) zerossl_config: ZeroSslConfig,
     pub(crate) docker_credentials: Vec<DockerCredentials>,
     pub(crate) event_sender: EventSender,
+    pub(crate) domain: String,
 }
 
 pub(crate) struct VmWorker {
@@ -46,6 +47,7 @@ pub(crate) struct VmWorker {
     vm_state: VmState,
     zerossl_config: ZeroSslConfig,
     docker_credentials: Vec<DockerCredentials>,
+    domain: String,
     event_sender: EventSender,
 }
 
@@ -61,6 +63,7 @@ impl VmWorker {
             zerossl_config,
             docker_credentials,
             event_sender,
+            domain,
         } = args;
         let (sender, receiver) = channel(64);
         let join_handle = tokio::spawn(async move {
@@ -76,6 +79,7 @@ impl VmWorker {
                 zerossl_config,
                 docker_credentials,
                 event_sender,
+                domain,
             };
             worker.run().instrument(info_span!("vm_worker", workload_id = workload_id.to_string())).await;
         });
@@ -202,6 +206,7 @@ impl VmWorker {
                                 eab_mac_key: self.zerossl_config.eab_mac_key.clone(),
                             },
                             docker: self.docker_credentials.clone(),
+                            domain: self.domain.clone(),
                         };
                         if let Err(e) = self.cvm_agent_client.bootstrap(self.cvm_agent_port, &request).await {
                             warn!("Failed to bootstrap agent: {e:#}");

--- a/nilcc-attester/Cargo.toml
+++ b/nilcc-attester/Cargo.toml
@@ -12,11 +12,14 @@ config = { version = "0.15", default-features = false, features = ["yaml"] }
 hex = { version = "0.4", features = ["serde"] }
 num_cpus = "1.16"
 rand = "0.9"
-serde = { version = "1.0", features = ["derive"] }
+reqwest = { version = "0.12", features = ["rustls-tls"] }
+serde = { version = "1.0", features = ["rc", "derive"] }
 serde_with = { version = "3.14", default-features = false, features = ["hex", "macros"] }
 sev = { version = "6.1", default-features = false, features = ["snp"] }
+sha2 = "0.10"
 thiserror = "2.0"
 tokio = { version = "1.45", features = ["rt-multi-thread", "macros", "process", "signal"] }
 tower-http = { version = "0.6", features = ["cors"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
+x509-parser = "0.18"

--- a/nilcc-attester/src/cert.rs
+++ b/nilcc-attester/src/cert.rs
@@ -1,0 +1,30 @@
+use anyhow::Context;
+use reqwest::{tls::TlsInfo, ClientBuilder};
+use sha2::{Digest, Sha256};
+use std::net::ToSocketAddrs;
+use x509_parser::parse_x509_certificate;
+
+pub struct CertFetcher {
+    pub proxy_endpoint: String,
+    pub server_name: String,
+}
+
+impl CertFetcher {
+    pub async fn fetch_fingerprint(self) -> anyhow::Result<[u8; 32]> {
+        let Self { proxy_endpoint, server_name } = self;
+        let addresses: Vec<_> = proxy_endpoint.to_socket_addrs().context("Failed to resolve proxy hostname")?.collect();
+        let client = ClientBuilder::default()
+            .tls_info(true)
+            .danger_accept_invalid_certs(true)
+            .resolve_to_addrs(&server_name, &addresses)
+            .build()
+            .context("Failed to build HTTP client")?;
+        let response = client.get(format!("https://{server_name}")).send().await.context("Failed to send request")?;
+        let info = response.extensions().get::<TlsInfo>().context("No TLS information")?;
+        let cert = info.peer_certificate().context("No certificate in TLS info")?;
+        let (_, cert) = parse_x509_certificate(cert).context("Invalid TLS certificate")?;
+        let pubkey = cert.tbs_certificate.subject_pki;
+        let digest = Sha256::digest(pubkey.raw);
+        Ok(digest.into())
+    }
+}

--- a/nilcc-attester/src/config.rs
+++ b/nilcc-attester/src/config.rs
@@ -13,6 +13,9 @@ pub struct Config {
     pub vm_type: VmType,
     #[serde(default = "default_gpu_attester_path")]
     pub gpu_attester_path: PathBuf,
+    #[serde(default = "default_proxy_endpoint")]
+    pub proxy_endpoint: String,
+    pub attestation_domain: String,
 }
 
 impl Config {
@@ -52,4 +55,8 @@ fn default_bind_endpoint() -> SocketAddr {
 
 fn default_gpu_attester_path() -> PathBuf {
     "/opt/nillion/gpu-attester/main.py".into()
+}
+
+fn default_proxy_endpoint() -> String {
+    "cvm-nilcc-proxy-1:443".to_string()
 }

--- a/nilcc-attester/src/lib.rs
+++ b/nilcc-attester/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod cert;
 pub mod config;
 pub mod report;
 pub mod routes;

--- a/nilcc-attester/src/main.rs
+++ b/nilcc-attester/src/main.rs
@@ -1,10 +1,14 @@
+use anyhow::Context;
 use axum::http;
 use clap::Parser;
 use nilcc_attester::{
-    config::Config,
+    cert::CertFetcher,
+    config::{Config, VmType},
+    report::HardwareReporter,
     routes::{build_router, AppState},
 };
-use std::process::exit;
+use sev::firmware::guest::AttestationReport;
+use std::{process::exit, sync::Arc};
 use tokio::{net::TcpListener, signal};
 use tower_http::cors::CorsLayer;
 use tracing::{error, info};
@@ -35,6 +39,28 @@ async fn shutdown_signal() {
     info!("Received shutdown signal");
 }
 
+async fn generate_report(config: &Config) -> anyhow::Result<(Arc<AttestationReport>, Option<String>)> {
+    let cert_fingerprint =
+        CertFetcher { proxy_endpoint: config.proxy_endpoint.clone(), server_name: config.attestation_domain.clone() }
+            .fetch_fingerprint()
+            .await
+            .expect("Failed to fetch certificate");
+    let reporter = Arc::new(HardwareReporter::new(config.gpu_attester_path.clone()));
+
+    let mut report_data: [u8; 64] = [0; 64];
+    // Version, bump if changed
+    report_data[0] = 0;
+    // Copy over the cert fingerprint
+    report_data[1..33].copy_from_slice(&cert_fingerprint);
+
+    let report = reporter.hardware_report(report_data)?;
+    let gpu_token = match config.vm_type {
+        VmType::Cpu => None,
+        VmType::Gpu => Some(reporter.gpu_report(cert_fingerprint).await.context("Failed to get GPU report")?),
+    };
+    Ok((Arc::new(report), gpu_token))
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt().init();
@@ -50,8 +76,16 @@ async fn main() {
 
     let bind_endpoint = &config.server.bind_endpoint;
     info!("Running server on {bind_endpoint}");
+    let (hardware_report, gpu_token) = generate_report(&config).await.expect("Failed to generate report");
 
-    let state = AppState::new(config.nilcc_version, config.vm_type, config.gpu_attester_path);
+    let state = AppState {
+        nilcc_version: config.nilcc_version,
+        vm_type: config.vm_type,
+        cpu_count: num_cpus::get(),
+        hardware_report,
+        gpu_token,
+    };
+
     let listener = TcpListener::bind(bind_endpoint).await.expect("failed to bind");
     let cors = CorsLayer::new()
         .allow_methods([http::Method::GET, http::Method::POST])

--- a/nilcc-attester/src/routes/mod.rs
+++ b/nilcc-attester/src/routes/mod.rs
@@ -1,11 +1,7 @@
-use std::{path::PathBuf, sync::Arc};
-
-use axum::{
-    routing::{get, post},
-    Router,
-};
-
-use crate::{config::VmType, report::HardwareReporter};
+use crate::config::VmType;
+use axum::{routing::get, Router};
+use sev::firmware::guest::AttestationReport;
+use std::sync::Arc;
 
 pub(crate) mod health;
 pub(crate) mod report;
@@ -14,21 +10,14 @@ pub(crate) mod report;
 pub fn build_router(state: AppState) -> Router {
     Router::new()
         .route("/health", get(health::handler))
-        .nest("/api/v1", Router::new().route("/report/generate", post(report::generate::handler).with_state(state)))
+        .nest("/api/v1", Router::new().route("/report/generate", get(report::generate::handler).with_state(state)))
 }
 
 #[derive(Clone)]
 pub struct AppState {
-    pub(crate) nilcc_version: String,
-    pub(crate) vm_type: VmType,
-    pub(crate) cpu_count: usize,
-    pub(crate) hardware_reporter: Arc<HardwareReporter>,
-}
-
-impl AppState {
-    pub fn new(nilcc_version: String, vm_type: VmType, gpu_attester_path: PathBuf) -> Self {
-        let cpu_count = num_cpus::get();
-        let hardware_reporter = Arc::new(HardwareReporter::new(gpu_attester_path));
-        Self { nilcc_version, vm_type, cpu_count, hardware_reporter }
-    }
+    pub nilcc_version: String,
+    pub vm_type: VmType,
+    pub cpu_count: usize,
+    pub hardware_report: Arc<AttestationReport>,
+    pub gpu_token: Option<String>,
 }

--- a/nilcc-attester/src/routes/report/generate.rs
+++ b/nilcc-attester/src/routes/report/generate.rs
@@ -1,29 +1,12 @@
-use crate::{
-    config::VmType,
-    report::{GpuReportData, HardwareReportData},
-    routes::AppState,
-};
+use crate::{config::VmType, routes::AppState};
 use axum::{extract::State, http::StatusCode, Json};
-use serde::{Deserialize, Serialize};
-use serde_with::hex::Hex;
-use serde_with::serde_as;
+use serde::Serialize;
 use sev::firmware::guest::AttestationReport;
-use tracing::error;
-
-#[serde_as]
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct Request {
-    #[serde(with = "hex::serde")]
-    nonce: HardwareReportData,
-
-    #[serde_as(as = "Option<Hex>")]
-    gpu_nonce: Option<GpuReportData>,
-}
+use std::sync::Arc;
 
 #[derive(Serialize)]
 pub(crate) struct Response {
-    report: AttestationReport,
+    report: Arc<AttestationReport>,
     gpu_token: Option<String>,
     environment: EnvironmentSpec,
 }
@@ -35,27 +18,8 @@ pub(crate) struct EnvironmentSpec {
     cpu_count: usize,
 }
 
-pub(crate) async fn handler(state: State<AppState>, request: Json<Request>) -> Result<Json<Response>, StatusCode> {
-    let AppState { nilcc_version, vm_type, cpu_count, hardware_reporter } = state.0;
-    let Request { nonce, gpu_nonce } = request.0;
-    let report = match hardware_reporter.hardware_report(nonce) {
-        Ok(report) => report,
-        Err(e) => {
-            error!("Failed to generate hardware report: {e}");
-            return Err(StatusCode::INTERNAL_SERVER_ERROR);
-        }
-    };
-    let gpu_token = match (&vm_type, gpu_nonce) {
-        (VmType::Cpu, _) => None,
-        (VmType::Gpu, Some(nonce)) => match hardware_reporter.gpu_report(nonce).await {
-            Ok(token) => Some(token),
-            Err(e) => {
-                error!("Failed to generate GPU attestation: {e:#}");
-                return Err(StatusCode::INTERNAL_SERVER_ERROR);
-            }
-        },
-        (VmType::Gpu, None) => None,
-    };
+pub(crate) async fn handler(state: State<AppState>) -> Result<Json<Response>, StatusCode> {
+    let AppState { nilcc_version, vm_type, cpu_count, hardware_report, gpu_token } = state.0;
     let environment = EnvironmentSpec { nilcc_version, vm_type, cpu_count };
-    Ok(Json(Response { report, environment, gpu_token }))
+    Ok(Json(Response { report: hardware_report, environment, gpu_token }))
 }


### PR DESCRIPTION
This changes the attestation flow so instead of generating attestations on demand we now:

* Create a single hardware and GPU (if on a GPU host) on start.
* Include the TLS cert public key as part of the hardware report data (and use that as the GPU token nonce).
* The pubkey is fetched on start, such that the attester will be down until the pubkey is fetched successfully.