### PR TITLE
feat: fetch cert/attestations periodically

### DIFF
--- a/nilcc-attester/src/cert.rs
+++ b/nilcc-attester/src/cert.rs
@@ -10,13 +10,13 @@ pub struct CertFetcher {
 }
 
 impl CertFetcher {
-    pub async fn fetch_fingerprint(self) -> anyhow::Result<[u8; 32]> {
+    pub async fn fetch_fingerprint(&self) -> anyhow::Result<[u8; 32]> {
         let Self { proxy_endpoint, server_name } = self;
         let addresses: Vec<_> = proxy_endpoint.to_socket_addrs().context("Failed to resolve proxy hostname")?.collect();
         let client = ClientBuilder::default()
             .tls_info(true)
             .danger_accept_invalid_certs(true)
-            .resolve_to_addrs(&server_name, &addresses)
+            .resolve_to_addrs(server_name, &addresses)
             .build()
             .context("Failed to build HTTP client")?;
         let response = client.get(format!("https://{server_name}")).send().await.context("Failed to send request")?;

--- a/nilcc-attester/src/main.rs
+++ b/nilcc-attester/src/main.rs
@@ -1,13 +1,11 @@
-use anyhow::Context;
 use axum::http;
 use clap::Parser;
 use nilcc_attester::{
     cert::CertFetcher,
     config::{Config, VmType},
-    report::HardwareReporter,
+    report::{GpuReportConfig, HardwareReporter},
     routes::{build_router, AppState},
 };
-use sev::firmware::guest::AttestationReport;
 use std::{process::exit, sync::Arc};
 use tokio::{net::TcpListener, signal};
 use tower_http::cors::CorsLayer;
@@ -39,28 +37,6 @@ async fn shutdown_signal() {
     info!("Received shutdown signal");
 }
 
-async fn generate_report(config: &Config) -> anyhow::Result<(Arc<AttestationReport>, Option<String>)> {
-    let cert_fingerprint =
-        CertFetcher { proxy_endpoint: config.proxy_endpoint.clone(), server_name: config.attestation_domain.clone() }
-            .fetch_fingerprint()
-            .await
-            .expect("Failed to fetch certificate");
-    let reporter = Arc::new(HardwareReporter::new(config.gpu_attester_path.clone()));
-
-    let mut report_data: [u8; 64] = [0; 64];
-    // Version, bump if changed
-    report_data[0] = 0;
-    // Copy over the cert fingerprint
-    report_data[1..33].copy_from_slice(&cert_fingerprint);
-
-    let report = reporter.hardware_report(report_data)?;
-    let gpu_token = match config.vm_type {
-        VmType::Cpu => None,
-        VmType::Gpu => Some(reporter.gpu_report(cert_fingerprint).await.context("Failed to get GPU report")?),
-    };
-    Ok((Arc::new(report), gpu_token))
-}
-
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt().init();
@@ -76,16 +52,15 @@ async fn main() {
 
     let bind_endpoint = &config.server.bind_endpoint;
     info!("Running server on {bind_endpoint}");
-    let (hardware_report, gpu_token) = generate_report(&config).await.expect("Failed to generate report");
-
-    let state = AppState {
-        nilcc_version: config.nilcc_version,
-        vm_type: config.vm_type,
-        cpu_count: num_cpus::get(),
-        hardware_report,
-        gpu_token,
+    let gpu_config = match &config.vm_type {
+        VmType::Cpu => GpuReportConfig::Disabled,
+        VmType::Gpu => GpuReportConfig::Enabled { attester_path: config.gpu_attester_path },
     };
-
+    let fetcher = CertFetcher { proxy_endpoint: config.proxy_endpoint, server_name: config.attestation_domain };
+    let reporter = HardwareReporter::new(gpu_config, fetcher).await.expect("Failed to initialize hardware reporter");
+    let reporter = Arc::new(reporter);
+    let state =
+        AppState { nilcc_version: config.nilcc_version, vm_type: config.vm_type, cpu_count: num_cpus::get(), reporter };
     let listener = TcpListener::bind(bind_endpoint).await.expect("failed to bind");
     let cors = CorsLayer::new()
         .allow_methods([http::Method::GET, http::Method::POST])

--- a/nilcc-attester/src/report.rs
+++ b/nilcc-attester/src/report.rs
@@ -1,28 +1,57 @@
+use crate::cert::CertFetcher;
 use anyhow::{bail, Context};
 use sev::firmware::guest::{AttestationReport, Firmware};
-use std::{path::PathBuf, process::Stdio};
-use tokio::process::Command;
-use tracing::info;
+use std::{path::PathBuf, process::Stdio, sync::Arc, time::Duration};
+use tokio::{process::Command, sync::Mutex, time::sleep};
+use tracing::{debug, error, info};
 
-pub const VMPL: u32 = 1;
-
-pub(crate) type HardwareReportData = [u8; 64];
-pub(crate) type GpuReportData = [u8; 32];
+const VMPL: u32 = 1;
+const CERT_FINGERPRINT_INTERVAL: Duration = Duration::from_secs(30);
 
 pub struct HardwareReporter {
-    gpu_attester_path: PathBuf,
+    inner: Arc<Mutex<Inner>>,
 }
 
 impl HardwareReporter {
-    pub fn new(gpu_attester_path: PathBuf) -> Self {
-        Self { gpu_attester_path }
+    pub async fn new(gpu: GpuReportConfig, cert_fetcher: CertFetcher) -> anyhow::Result<Self> {
+        let fingerprint = cert_fetcher.fetch_fingerprint().await.context("Failed to fetch cert fingerpring")?;
+        let inner = Inner {
+            hardware: Self::fetch_hardware_report(&fingerprint).context("Failed to fetch hardware report")?,
+            gpu_token: Self::fetch_gpu_report(&fingerprint, &gpu).await.context("Failed to fetch GPU report")?,
+        };
+        let inner = Arc::new(Mutex::new(inner));
+        Worker::spawn(gpu, cert_fetcher, fingerprint, inner.clone());
+        Ok(Self { inner })
     }
 
-    pub async fn gpu_report(&self, nonce: GpuReportData) -> anyhow::Result<String> {
-        let nonce = hex::encode(nonce);
+    pub async fn reports(&self) -> (Arc<AttestationReport>, Option<String>) {
+        let inner = self.inner.lock().await;
+        (inner.hardware.clone(), inner.gpu_token.clone())
+    }
+
+    fn fetch_hardware_report(fingerprint: &[u8; 32]) -> anyhow::Result<Arc<AttestationReport>> {
+        let mut data: [u8; 64] = [0; 64];
+        // Version, bump if changed
+        data[0] = 0;
+        // Copy over the cert fingerprint
+        data[1..33].copy_from_slice(fingerprint);
+
+        info!("Generating hardware report using nonce {}", hex::encode(data));
+        let mut fw = Firmware::open().context("unable to open /dev/sev-guest")?;
+        let raw_report = fw.get_report(None, Some(data), Some(VMPL)).context("unable to fetch attestation report")?;
+        let report = AttestationReport::from_bytes(&raw_report)?;
+        Ok(Arc::new(report))
+    }
+
+    async fn fetch_gpu_report(fingerprint: &[u8; 32], gpu: &GpuReportConfig) -> anyhow::Result<Option<String>> {
+        let gpu_attester_path = match gpu {
+            GpuReportConfig::Enabled { attester_path } => attester_path,
+            GpuReportConfig::Disabled => return Ok(None),
+        };
+        let nonce = hex::encode(fingerprint);
         info!("Generating GPU report using nonce {nonce}");
 
-        let output = Command::new(&self.gpu_attester_path)
+        let output = Command::new(gpu_attester_path)
             .arg(nonce)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -30,18 +59,70 @@ impl HardwareReporter {
             .await
             .context("failed to invoke GPU attester")?;
         if output.status.success() {
-            Ok(String::from_utf8_lossy(&output.stdout).trim().into())
+            Ok(Some(String::from_utf8_lossy(&output.stdout).trim().into()))
         } else {
             let stdout = String::from_utf8_lossy(&output.stdout);
             let stderr = String::from_utf8_lossy(&output.stderr);
             bail!("could not generate GPU report. stderr = '{stderr}', stdout = '{stdout}'")
         }
     }
+}
 
-    pub fn hardware_report(&self, data: HardwareReportData) -> anyhow::Result<AttestationReport> {
-        info!("Generating hardware report using nonce {}", hex::encode(data));
-        let mut fw = Firmware::open().context("unable to open /dev/sev-guest")?;
-        let raw_report = fw.get_report(None, Some(data), Some(VMPL)).context("unable to fetch attestation report")?;
-        Ok(AttestationReport::from_bytes(&raw_report)?)
+pub enum GpuReportConfig {
+    Enabled { attester_path: PathBuf },
+    Disabled,
+}
+
+struct Inner {
+    hardware: Arc<AttestationReport>,
+    gpu_token: Option<String>,
+}
+
+struct Worker {
+    gpu: GpuReportConfig,
+    cert_fetcher: CertFetcher,
+    fingerprint: [u8; 32],
+    inner: Arc<Mutex<Inner>>,
+}
+
+impl Worker {
+    fn spawn(gpu: GpuReportConfig, cert_fetcher: CertFetcher, fingerprint: [u8; 32], inner: Arc<Mutex<Inner>>) {
+        let worker = Self { gpu, cert_fetcher, fingerprint, inner };
+        tokio::spawn(async move {
+            worker.run().await;
+        });
+    }
+
+    async fn run(mut self) {
+        loop {
+            sleep(CERT_FINGERPRINT_INTERVAL).await;
+
+            match self.fetch().await {
+                Ok(()) => {}
+                Err(e) => {
+                    error!("Failed to fetch: {e:#}");
+                }
+            };
+        }
+    }
+
+    async fn fetch(&mut self) -> anyhow::Result<()> {
+        let fingerprint = self.cert_fetcher.fetch_fingerprint().await.context("Failed to fetch fingerprint")?;
+        if fingerprint == self.fingerprint {
+            debug!("Cert fingerprint hasn't changed");
+            return Ok(());
+        }
+        info!(
+            "Certificate fingerpring changed from {} to {}, re-generating reports",
+            hex::encode(self.fingerprint),
+            hex::encode(fingerprint)
+        );
+        let hardware =
+            HardwareReporter::fetch_hardware_report(&fingerprint).context("Failed to fetch hardware report")?;
+        let gpu_token =
+            HardwareReporter::fetch_gpu_report(&fingerprint, &self.gpu).await.context("Failed to fetch GPU report")?;
+        self.fingerprint = fingerprint;
+        *self.inner.lock().await = Inner { hardware, gpu_token };
+        Ok(())
     }
 }

--- a/nilcc-attester/src/routes/mod.rs
+++ b/nilcc-attester/src/routes/mod.rs
@@ -1,6 +1,5 @@
-use crate::config::VmType;
+use crate::{config::VmType, report::HardwareReporter};
 use axum::{routing::get, Router};
-use sev::firmware::guest::AttestationReport;
 use std::sync::Arc;
 
 pub(crate) mod health;
@@ -18,6 +17,5 @@ pub struct AppState {
     pub nilcc_version: String,
     pub vm_type: VmType,
     pub cpu_count: usize,
-    pub hardware_report: Arc<AttestationReport>,
-    pub gpu_token: Option<String>,
+    pub reporter: Arc<HardwareReporter>,
 }

--- a/nilcc-attester/src/routes/report.rs
+++ b/nilcc-attester/src/routes/report.rs
@@ -19,7 +19,8 @@ pub(crate) struct EnvironmentSpec {
 }
 
 pub(crate) async fn handler(state: State<AppState>) -> Result<Json<Response>, StatusCode> {
-    let AppState { nilcc_version, vm_type, cpu_count, hardware_report, gpu_token } = state.0;
+    let AppState { nilcc_version, vm_type, cpu_count, reporter } = state.0;
+    let (report, gpu_token) = reporter.reports().await;
     let environment = EnvironmentSpec { nilcc_version, vm_type, cpu_count };
-    Ok(Json(Response { report: hardware_report, environment, gpu_token }))
+    Ok(Json(Response { report, environment, gpu_token }))
 }


### PR DESCRIPTION
This changes the attester logic so the certificate/reporets are fetched on start, but then periodically we keep fetching the cert and if it's changed we re-generate the reports. This makes sure if the certificate is renewed, the fingerprint is still correct. There will be a tiny window where these won't match, but odds are this won't affect anyone since the cert expires after 90 days and we poll every 30 seconds.

Closes #353