### PR TITLE
chore: don't panic when starting attester and caddy is down

### DIFF
--- a/nilcc-attester/src/cert.rs
+++ b/nilcc-attester/src/cert.rs
@@ -4,6 +4,7 @@ use sha2::{Digest, Sha256};
 use std::net::ToSocketAddrs;
 use x509_parser::parse_x509_certificate;
 
+#[derive(Clone)]
 pub struct CertFetcher {
     pub proxy_endpoint: String,
     pub server_name: String,

--- a/nilcc-attester/src/report.rs
+++ b/nilcc-attester/src/report.rs
@@ -68,6 +68,7 @@ impl HardwareReporter {
     }
 }
 
+#[derive(Clone)]
 pub enum GpuReportConfig {
     Enabled { attester_path: PathBuf },
     Disabled,


### PR DESCRIPTION
We currently panic when the attester starts and anything goes wrong when fetching the attestation (e.g. caddy is down/doesn't have a cert set up yet). This is not an issue since the docker container restarts anyway, but it looks dramatic when looking at the logs. This PR instead makes it retry a few times and `warn` in between.