### PR TITLE
feat: expose information about report validation in verifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2271,10 +2271,10 @@ dependencies = [
 name = "nilcc-artifacts"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "futures-util",
  "hex",
  "reqwest",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -2313,6 +2313,7 @@ dependencies = [
  "clap",
  "hex",
  "nilcc-artifacts",
+ "nom",
  "openssl",
  "reqwest",
  "rstest",

--- a/crates/nilcc-artifacts/Cargo.toml
+++ b/crates/nilcc-artifacts/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-anyhow = "1"
 hex = "0.4"
 futures-util = "0.3"
+thiserror = "2.0"
 tracing = "0.1"
 tokio = { version = "1.47", features = ["fs"] }
 reqwest = { version = "0.12", features = ["rustls-tls", "stream"] }

--- a/nilcc-verifier/Cargo.toml
+++ b/nilcc-verifier/Cargo.toml
@@ -8,6 +8,7 @@ anyhow = "1.0"
 bincode = "1.3"
 clap = { version = "4.5", features = ["derive", "string", "env"] }
 hex = { version = "0.4", features = ["serde"] }
+nom = "7.1"
 openssl = { version = "^0.10", features = ["vendored"] }
 reqwest = { version = "0.12", features = ["blocking", "rustls-tls", "json"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/nilcc-verifier/src/measurement.rs
+++ b/nilcc-verifier/src/measurement.rs
@@ -1,8 +1,10 @@
-use anyhow::Context;
-use sev::measurement::{
-    snp::{snp_calc_launch_digest, SnpMeasurementArgs},
-    vcpu_types::CpuType,
-    vmsa::{GuestFeatures, VMMType},
+use sev::{
+    error::MeasurementError,
+    measurement::{
+        snp::{snp_calc_launch_digest, SnpMeasurementArgs},
+        vcpu_types::CpuType,
+        vmsa::{GuestFeatures, VMMType},
+    },
 };
 use std::path::PathBuf;
 use tracing::info;
@@ -19,7 +21,7 @@ pub struct MeasurementGenerator {
 }
 
 impl MeasurementGenerator {
-    pub fn generate(self) -> anyhow::Result<Vec<u8>> {
+    pub fn generate(self) -> Result<Vec<u8>, MeasurementError> {
         let Self {
             ovmf,
             kernel,
@@ -49,8 +51,8 @@ impl MeasurementGenerator {
             ovmf_hash_str: None,
             vmm_type: Some(VMMType::QEMU),
         };
-        let digest = snp_calc_launch_digest(args).context("generating SNP measurement")?;
-        let digest = bincode::serialize(&digest).context("bindecoding SNP measurement")?;
+        let digest = snp_calc_launch_digest(args)?;
+        let digest = bincode::serialize(&digest).expect("bindecoding SNP measurement");
         Ok(digest)
     }
 }


### PR DESCRIPTION
This changes nilcc-verifier so when you run a validation it emits JSON output indicating whether there was success/failure, including metadata about the report on success, and an error code and message on error.

Closes #361