### PR TITLE
feat: allow cleaning up unused artifact versions

### DIFF
--- a/crates/nilcc-agent-models/src/lib.rs
+++ b/crates/nilcc-agent-models/src/lib.rs
@@ -60,6 +60,13 @@ pub mod system {
         Success { finished_at: DateTime<Utc> },
         Error { finished_at: DateTime<Utc>, error: String },
     }
+
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct ArtifactsCleanupResponse {
+        /// The versions that were deleted.
+        pub versions_deleted: Vec<String>,
+    }
 }
 
 pub mod workloads {

--- a/nilcc-agent/src/main.rs
+++ b/nilcc-agent/src/main.rs
@@ -393,6 +393,7 @@ async fn run_daemon(config_path: PathBuf) -> Result<()> {
     let upgrade_service = Arc::new(DefaultUpgradeService::new(DefaultUpgradeServiceArgs {
         repository_provider: repository_provider.clone(),
         config_file_path: config_path,
+        cvm_artifacts_path: config.cvm.artifacts_path.clone(),
     }));
     let state = AppState {
         services: Services { workload: workload_service.clone(), upgrade: upgrade_service },
@@ -400,7 +401,6 @@ async fn run_daemon(config_path: PathBuf) -> Result<()> {
         resource_limits: config.resources.limits,
         agent_domain: config.api.domain.clone(),
         vm_types,
-        cvm_artifacts_path: config.cvm.artifacts_path,
     };
     let router = build_router(state, config.api.token);
     let handle = Handle::new();

--- a/nilcc-agent/src/routes/mod.rs
+++ b/nilcc-agent/src/routes/mod.rs
@@ -17,7 +17,6 @@ use nilcc_agent_models::errors::RequestHandlerError;
 use nilcc_artifacts::VmType;
 use serde::Serialize;
 use std::ops::Deref;
-use std::path::PathBuf;
 use std::sync::Arc;
 use tower::ServiceBuilder;
 use validator::Validate;
@@ -43,17 +42,21 @@ pub struct AppState {
     pub resource_limits: ResourceLimitsConfig,
     pub agent_domain: String,
     pub vm_types: Vec<VmType>,
-    pub cvm_artifacts_path: PathBuf,
 }
 
 pub fn build_router(state: AppState, token: String) -> Router {
     Router::new().route("/health", get(health)).nest(
         "/api/v1",
         Router::new()
-            .route("/system/artifacts/upgrade", post(system::artifacts::upgrade::handler))
-            .route("/system/artifacts/version", get(system::artifacts::version::handler))
-            .route("/system/agent/upgrade", post(system::agent::upgrade::handler))
-            .route("/system/agent/version", get(system::agent::version::handler))
+            .nest(
+                "/system",
+                Router::new()
+                    .route("/artifacts/upgrade", post(system::artifacts::upgrade::handler))
+                    .route("/artifacts/version", get(system::artifacts::version::handler))
+                    .route("/artifacts/cleanup", post(system::artifacts::cleanup::handler))
+                    .route("/agent/upgrade", post(system::agent::upgrade::handler))
+                    .route("/agent/version", get(system::agent::version::handler)),
+            )
             .nest(
                 "/workloads",
                 Router::new()

--- a/nilcc-agent/src/routes/system/artifacts/cleanup.rs
+++ b/nilcc-agent/src/routes/system/artifacts/cleanup.rs
@@ -1,0 +1,12 @@
+use crate::{
+    routes::{AppState, Json},
+    services::upgrade::CleanupError,
+};
+use axum::extract::State;
+use nilcc_agent_models::system::ArtifactsCleanupResponse;
+
+pub(crate) async fn handler(state: State<AppState>) -> Result<Json<ArtifactsCleanupResponse>, CleanupError> {
+    let versions_deleted = state.services.upgrade.cleanup_artifacts().await?;
+    let response = ArtifactsCleanupResponse { versions_deleted };
+    Ok(Json(response))
+}

--- a/nilcc-agent/src/routes/system/artifacts/mod.rs
+++ b/nilcc-agent/src/routes/system/artifacts/mod.rs
@@ -1,2 +1,3 @@
+pub(crate) mod cleanup;
 pub(crate) mod upgrade;
 pub(crate) mod version;

--- a/nilcc-agent/src/routes/system/artifacts/upgrade.rs
+++ b/nilcc-agent/src/routes/system/artifacts/upgrade.rs
@@ -7,7 +7,6 @@ use nilcc_agent_models::system::UpgradeRequest;
 
 pub(crate) async fn handler(state: State<AppState>, request: Json<UpgradeRequest>) -> Result<Json<()>, UpgradeError> {
     let UpgradeRequest { version } = request.0;
-    let path = state.cvm_artifacts_path.join(&version);
-    state.services.upgrade.upgrade_artifacts(version, state.vm_types.clone(), path).await?;
+    state.services.upgrade.upgrade_artifacts(version, state.vm_types.clone()).await?;
     Ok(Json(()))
 }


### PR DESCRIPTION
This allows cleaning up unused artifact versions (e.g. not current one and not any that is in use by a workload).