### PR TITLE
feat: report an error when docker compose fails to pull/start

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,6 +873,7 @@ dependencies = [
  "axum",
  "axum-valid",
  "bollard",
+ "chrono",
  "clap",
  "cvm-agent-models",
  "futures",
@@ -891,6 +892,7 @@ dependencies = [
 name = "cvm-agent-models"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "serde",
  "validator",
 ]

--- a/crates/cvm-agent-models/Cargo.toml
+++ b/crates/cvm-agent-models/Cargo.toml
@@ -4,5 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 validator = { version = "0.20", features = ["derive"] }

--- a/crates/cvm-agent-models/src/lib.rs
+++ b/crates/cvm-agent-models/src/lib.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use validator::Validate;
 
@@ -86,6 +87,22 @@ pub mod health {
 
         /// Whether the CVM is bootstrapped
         pub bootstrapped: bool,
+
+        /// The last error encountered.
+        pub last_error: Option<LastError>,
+    }
+
+    #[derive(Clone, Deserialize, Serialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct LastError {
+        /// An incremental id for every error found.
+        pub error_id: u64,
+
+        /// An error message.
+        pub message: String,
+
+        /// The timestamp when this error was generated.
+        pub failed_at: DateTime<Utc>,
     }
 }
 

--- a/cvm-agent/Cargo.toml
+++ b/cvm-agent/Cargo.toml
@@ -8,6 +8,7 @@ axum = { version = "0.8", features = ["json"] }
 axum-valid = "0.24"
 anyhow = "1"
 bollard = "0.19"
+chrono = "0.4"
 clap = { version = "4.5", features = ["derive", "string"] }
 futures = "0.3"
 serde = { version = "1.0", features = ["derive"] }

--- a/cvm-agent/src/main.rs
+++ b/cvm-agent/src/main.rs
@@ -97,6 +97,7 @@ fn build_bootstrap_context(cli: &Cli) -> (TempDir, BootstrapContext) {
         version,
         vm_type,
         iso_mount: cli.iso_mount_path.clone(),
+        error_holder: Default::default(),
     };
     (state_dir, context)
 }

--- a/cvm-agent/src/monitors/mod.rs
+++ b/cvm-agent/src/monitors/mod.rs
@@ -1,2 +1,40 @@
+use chrono::Utc;
+use cvm_agent_models::health::LastError;
+use std::sync::{Arc, Mutex};
+
 pub(crate) mod caddy;
 pub(crate) mod compose;
+
+#[derive(Clone, Default)]
+pub struct ErrorHolder(Arc<Mutex<Option<LastError>>>);
+
+impl ErrorHolder {
+    pub(crate) fn set<S: Into<String>>(&self, message: S) {
+        let mut inner = self.0.lock().expect("lock poisoned");
+        let error_id = inner.as_ref().map(|e| e.error_id.wrapping_add(1)).unwrap_or_default();
+        *inner = Some(LastError { message: message.into(), failed_at: Utc::now(), error_id });
+    }
+
+    pub(crate) fn get(&self) -> Option<LastError> {
+        self.0.lock().expect("lock poisoned").clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn set() {
+        let holder = ErrorHolder::default();
+        assert!(holder.get().is_none());
+
+        holder.set("beep");
+        assert_eq!(holder.get().unwrap().error_id, 0);
+
+        holder.set("boop");
+        let err = holder.get().unwrap();
+        assert_eq!(err.error_id, 1);
+        assert_eq!(err.message, "boop");
+    }
+}

--- a/cvm-agent/src/resources.rs
+++ b/cvm-agent/src/resources.rs
@@ -91,7 +91,7 @@ https://foo.com {
         let compose = Resources::render(&metadata, &VmType::Cpu).docker_compose;
         let expected = r#"services:
   nilcc-attester:
-    image: ghcr.io/nillionnetwork/nilcc-attester:latest
+    image: ghcr.io/nillionnetwork/nilcc-attester:0.1.0
     restart: unless-stopped
     privileged: true
     volumes:
@@ -134,7 +134,7 @@ https://foo.com {
         let compose = Resources::render(&metadata, &VmType::Gpu).docker_compose;
         let expected = r#"services:
   nilcc-attester:
-    image: ghcr.io/nillionnetwork/nilcc-attester:latest
+    image: ghcr.io/nillionnetwork/nilcc-attester:0.1.0
     restart: unless-stopped
     privileged: true
     volumes:

--- a/cvm-agent/src/routes/health.rs
+++ b/cvm-agent/src/routes/health.rs
@@ -1,8 +1,7 @@
+use super::SystemState;
 use crate::routes::SharedState;
 use axum::Json;
 use cvm_agent_models::health::HealthResponse;
-
-use super::SystemState;
 
 pub(crate) async fn handler(state: SharedState) -> Json<HealthResponse> {
     let (https, bootstrapped) = match &*state.system_state.lock().unwrap() {
@@ -10,6 +9,8 @@ pub(crate) async fn handler(state: SharedState) -> Json<HealthResponse> {
         SystemState::Starting => (false, true),
         SystemState::Ready => (true, true),
     };
-    let response = HealthResponse { https, bootstrapped };
+
+    let last_error = state.context.error_holder.get();
+    let response = HealthResponse { https, bootstrapped, last_error };
     Json(response)
 }

--- a/cvm-agent/src/routes/mod.rs
+++ b/cvm-agent/src/routes/mod.rs
@@ -11,6 +11,8 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+use crate::monitors::ErrorHolder;
+
 pub(crate) mod containers;
 pub(crate) mod health;
 pub(crate) mod system;
@@ -33,6 +35,7 @@ pub struct BootstrapContext {
     pub version: String,
     pub vm_type: VmType,
     pub iso_mount: PathBuf,
+    pub error_holder: ErrorHolder,
 }
 
 #[derive(Clone, Serialize, Deserialize)]

--- a/nilcc-agent-cli/src/main.rs
+++ b/nilcc-agent-cli/src/main.rs
@@ -4,6 +4,7 @@ use anyhow::anyhow;
 use anyhow::Context;
 use clap::{Args, Parser, Subcommand};
 use cvm_agent_models::health::HealthResponse;
+use cvm_agent_models::health::LastError;
 use cvm_agent_models::logs::SystemLogsRequest;
 use cvm_agent_models::logs::SystemLogsResponse;
 use cvm_agent_models::logs::SystemLogsSource;
@@ -442,12 +443,18 @@ fn restart(client: ApiClient, args: RestartArgs) -> anyhow::Result<()> {
 fn health(client: ApiClient, args: HealthArgs) -> anyhow::Result<()> {
     let HealthArgs { id } = args;
     let response: HealthResponse = client.get(&format!("/api/v1/workloads/{id}/health"))?;
-    let HealthResponse { https, bootstrapped } = response;
+    let HealthResponse { https, bootstrapped, last_error } = response;
     let color = bool_to_color(bootstrapped);
     println!("bootstrapped: {}", color.paint(bootstrapped.to_string()));
 
     let color = bool_to_color(https);
     println!("https up:     {}", color.paint(https.to_string()));
+
+    if let Some(last_error) = last_error {
+        let LastError { message, failed_at, .. } = last_error;
+        let text = format!("cvm failed to start at {failed_at}: {message}");
+        println!("{}", Color::Red.paint(text));
+    }
     Ok(())
 }
 


### PR DESCRIPTION
This reports docker compose pull/up errors via cvm-agent's health endpoint, which are reported by nilcc-agent to nilcc-api so they show up in the db/ui.

Closes #375