### PR TITLE
feat: strip path and query from workload URL in verifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2323,6 +2323,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "url",
  "x509-parser 0.17.0",
 ]
 

--- a/nilcc-verifier/Cargo.toml
+++ b/nilcc-verifier/Cargo.toml
@@ -18,6 +18,7 @@ thiserror = "2.0"
 tokio = { version = "1.45", features = ["rt"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+url = "2.5"
 x509-parser = { version = "0.17.0", features = ["verify"] } 
 
 nilcc-artifacts = { path = "../crates/nilcc-artifacts" }

--- a/nilcc-verifier/src/main.rs
+++ b/nilcc-verifier/src/main.rs
@@ -261,6 +261,8 @@ impl From<ValidateError> for ErrorCode {
                 ReportBundleError::FetchAttestation(_)
                 | ReportBundleError::NoTlsInfo
                 | ReportBundleError::TlsCertificate(_)
+                | ReportBundleError::NotHttpsScheme
+                | ReportBundleError::InvalidUrl(_)
                 | ReportBundleError::MalformedPayload(_) => Request,
                 ReportBundleError::DownloadArtifacts(e) => match e {
                     DownloadError::NoParent => Internal,


### PR DESCRIPTION
This prevents unexpected workload URLs in nilcc-verifier by:

* Replaces the path, if any non `/` path is used, for the workload URL in nilcc-verifier.
* Removing the query string, if any.
* Enforcing the URL uses https scheme (although this would fail later on anyway otherwise).