### PR TITLE
fix: don't allow null metal instance ids

### DIFF
--- a/nilcc-api/migrations/1757713209092-MetalInstanceIdNotNull.ts
+++ b/nilcc-api/migrations/1757713209092-MetalInstanceIdNotNull.ts
@@ -1,0 +1,17 @@
+import type { MigrationInterface, QueryRunner } from "typeorm";
+
+export class MetalInstanceIdNotNull1757713209092 implements MigrationInterface {
+  name = "MetalInstanceIdNotNull1757713209092";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "workloads" ALTER COLUMN metal_instance_id SET NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "workloads" ALTER COLUMN metal_instance_id DROP NOT NULL`,
+    );
+  }
+}

--- a/nilcc-api/src/workload/workload.service.ts
+++ b/nilcc-api/src/workload/workload.service.ts
@@ -87,8 +87,10 @@ export class WorkloadService {
       throw new NoInstancesAvailable();
     }
 
-    const metalInstance =
-      metalInstances[Math.floor(Math.random() * metalInstances.length)];
+    // Get the first instance after sorting by id
+    const metalInstance = metalInstances.sort((a, b) =>
+      a.id.localeCompare(b.id),
+    )[0];
 
     // Assign the first available metal instance to the workload
     const eventRepository = tx.manager.getRepository(WorkloadEventEntity);


### PR DESCRIPTION
After creating lots of workloads in a loop, I hit a case where the metal instance id is null. This was allowed to happen because the table didn't restrict to `NOT NULL` ids. But also the way the metal instance was selected was by doing a floor(random() * number_of_metal_instances)` which I guess we got `1` as the random number, so we had `floor(1 * 1) == 1` which was out of bounds.

To prevent the out of bounds access I also changed this to sort metal instances by id and then get the first one. It's probably not the best way of doing this (e.g. would be better to balance by load) but at least it won't fail.

Note that I'm still not quite sure what happened here. The workload did run successfully and got to create a certificate, meaning the DNS record was done (and this is the last thing we do when creating the workload). But then there's something that doesn't add up since for nilcc-api to be able to talk to nilcc-agent it needs to know its identity, which is fetched from the db. So we somehow knew where to reach the agent but at the same time we didn't associate the workload to it. Weird. Will keep running creation in a loop and see what pops up.