### PR TITLE
feat: add workload warning events support in nilcc-api

### DIFF
--- a/nilcc-api/src/metal-instance/metal-instance.dto.ts
+++ b/nilcc-api/src/metal-instance/metal-instance.dto.ts
@@ -69,15 +69,3 @@ export const DeleteMetalInstanceRequest = z
 export type DeleteMetalInstanceRequest = z.infer<
   typeof DeleteMetalInstanceRequest
 >;
-
-export const WorkloadEventKind = z.discriminatedUnion("kind", [
-  z.object({ kind: z.literal("created") }),
-  z.object({ kind: z.literal("starting") }),
-  z.object({ kind: z.literal("stopped") }),
-  z.object({ kind: z.literal("vmRestarted") }),
-  z.object({ kind: z.literal("forcedRestart") }),
-  z.object({ kind: z.literal("awaitingCert") }),
-  z.object({ kind: z.literal("running") }),
-  z.object({ kind: z.literal("failedToStart"), error: z.string() }),
-]);
-export type WorkloadEventKind = z.infer<typeof WorkloadEventKind>;

--- a/nilcc-api/src/workload-event/workload-event.dto.ts
+++ b/nilcc-api/src/workload-event/workload-event.dto.ts
@@ -1,6 +1,18 @@
 import { z } from "zod";
 import { Uuid } from "#/common/types";
-import { WorkloadEventKind } from "#/metal-instance/metal-instance.dto";
+
+export const WorkloadEventKind = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("created") }),
+  z.object({ kind: z.literal("starting") }),
+  z.object({ kind: z.literal("stopped") }),
+  z.object({ kind: z.literal("vmRestarted") }),
+  z.object({ kind: z.literal("forcedRestart") }),
+  z.object({ kind: z.literal("awaitingCert") }),
+  z.object({ kind: z.literal("running") }),
+  z.object({ kind: z.literal("failedToStart"), error: z.string() }),
+  z.object({ kind: z.literal("warning"), message: z.string() }),
+]);
+export type WorkloadEventKind = z.infer<typeof WorkloadEventKind>;
 
 export const WorkloadEvent = z
   .object({

--- a/nilcc-api/src/workload/workload.entity.ts
+++ b/nilcc-api/src/workload/workload.entity.ts
@@ -139,7 +139,8 @@ export class WorkloadEventEntity {
     | "stopped"
     | "vmRestarted"
     | "forcedRestart"
-    | "failedToStart";
+    | "failedToStart"
+    | "warning";
 
   @Column({ type: "varchar", nullable: true })
   details?: string;

--- a/nilcc-api/src/workload/workload.service.ts
+++ b/nilcc-api/src/workload/workload.service.ts
@@ -13,7 +13,6 @@ import {
   NotEnoughCredits,
 } from "#/common/errors";
 import type { AppBindings } from "#/env";
-import type { WorkloadEventKind } from "#/metal-instance/metal-instance.dto";
 import type {
   ListContainersRequest,
   WorkloadContainerLogsRequest,
@@ -22,6 +21,7 @@ import type {
   ListWorkloadEventsRequest,
   SubmitEventRequest,
   WorkloadEvent,
+  WorkloadEventKind,
 } from "#/workload-event/workload-event.dto";
 import { WorkloadTierEntity } from "#/workload-tier/workload-tier.entity";
 import type {
@@ -281,10 +281,15 @@ export class WorkloadService {
       case "failedToStart":
         workload.status = "error";
         break;
+      case "warning":
+        // We don't want a state change for warnings
+        break;
     }
     let details: string | undefined;
     if (request.event.kind === "failedToStart") {
       details = request.event.error;
+    } else if (request.event.kind === "warning") {
+      details = request.event.message;
     }
     const event: WorkloadEventEntity = {
       id: uuidv4(),
@@ -317,6 +322,8 @@ export class WorkloadService {
       let details: WorkloadEventKind;
       if (event.event === "failedToStart") {
         details = { kind: "failedToStart", error: event.details || "" };
+      } else if (event.event === "warning") {
+        details = { kind: "warning", message: event.details || "" };
       } else {
         details = { kind: event.event };
       }


### PR DESCRIPTION
This adds support for workload warnings in nilcc-api. This sets up the base to be able to implement #396.