### PR TITLE
feat: expose a warning when caddy fails to generate TLS cert

### DIFF
--- a/crates/cvm-agent-models/src/lib.rs
+++ b/crates/cvm-agent-models/src/lib.rs
@@ -90,6 +90,9 @@ pub mod health {
 
         /// The last error encountered.
         pub last_error: Option<LastError>,
+
+        /// The last event encountered.
+        pub last_event: Option<LastEvent>,
     }
 
     #[derive(Clone, Deserialize, Serialize)]
@@ -103,6 +106,28 @@ pub mod health {
 
         /// The timestamp when this error was generated.
         pub failed_at: DateTime<Utc>,
+    }
+
+    #[derive(Clone, Deserialize, Serialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct LastEvent {
+        /// An incremental id for every event found.
+        pub id: u64,
+
+        /// The event kind.
+        pub kind: EventKind,
+
+        /// A message for this event.
+        pub message: String,
+
+        /// The timestamp when this event was generated.
+        pub timestamp: DateTime<Utc>,
+    }
+
+    #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+    pub enum EventKind {
+        Error,
+        Warning,
     }
 }
 

--- a/cvm-agent/src/main.rs
+++ b/cvm-agent/src/main.rs
@@ -97,7 +97,7 @@ fn build_bootstrap_context(cli: &Cli) -> (TempDir, BootstrapContext) {
         version,
         vm_type,
         iso_mount: cli.iso_mount_path.clone(),
-        error_holder: Default::default(),
+        event_holder: Default::default(),
     };
     (state_dir, context)
 }

--- a/cvm-agent/src/monitors/compose.rs
+++ b/cvm-agent/src/monitors/compose.rs
@@ -1,6 +1,9 @@
 use crate::routes::BootstrapContext;
 use anyhow::{bail, Context};
-use cvm_agent_models::bootstrap::{AcmeCredentials, DockerCredentials, CADDY_ACME_EAB_KEY_ID, CADDY_ACME_EAB_MAC_KEY};
+use cvm_agent_models::{
+    bootstrap::{AcmeCredentials, DockerCredentials, CADDY_ACME_EAB_KEY_ID, CADDY_ACME_EAB_MAC_KEY},
+    health::EventKind,
+};
 use std::{io, process::Stdio, time::Duration};
 use tokio::{
     fs,
@@ -195,7 +198,7 @@ impl ComposeMonitor {
 
     fn report_error(&self, message: String) {
         error!("{message}");
-        self.ctx.error_holder.set(message);
+        self.ctx.event_holder.set(message, EventKind::Error);
     }
 }
 

--- a/cvm-agent/src/routes/health.rs
+++ b/cvm-agent/src/routes/health.rs
@@ -1,7 +1,7 @@
 use super::SystemState;
 use crate::routes::SharedState;
 use axum::Json;
-use cvm_agent_models::health::HealthResponse;
+use cvm_agent_models::health::{HealthResponse, LastError};
 
 pub(crate) async fn handler(state: SharedState) -> Json<HealthResponse> {
     let (https, bootstrapped) = match &*state.system_state.lock().unwrap() {
@@ -10,7 +10,9 @@ pub(crate) async fn handler(state: SharedState) -> Json<HealthResponse> {
         SystemState::Ready => (true, true),
     };
 
-    let last_error = state.context.error_holder.get();
-    let response = HealthResponse { https, bootstrapped, last_error };
+    let last_event = state.context.event_holder.get();
+    let last_error =
+        last_event.clone().map(|e| LastError { error_id: e.id, message: e.message, failed_at: e.timestamp });
+    let response = HealthResponse { https, bootstrapped, last_error, last_event };
     Json(response)
 }

--- a/cvm-agent/src/routes/mod.rs
+++ b/cvm-agent/src/routes/mod.rs
@@ -1,3 +1,4 @@
+use crate::monitors::EventHolder;
 use axum::{
     extract::State,
     routing::{get, post},
@@ -10,8 +11,6 @@ use std::{
     path::PathBuf,
     sync::{Arc, Mutex},
 };
-
-use crate::monitors::ErrorHolder;
 
 pub(crate) mod containers;
 pub(crate) mod health;
@@ -35,7 +34,7 @@ pub struct BootstrapContext {
     pub version: String,
     pub vm_type: VmType,
     pub iso_mount: PathBuf,
-    pub error_holder: ErrorHolder,
+    pub event_holder: EventHolder,
 }
 
 #[derive(Clone, Serialize, Deserialize)]

--- a/cvm-agent/src/routes/system/bootstrap.rs
+++ b/cvm-agent/src/routes/system/bootstrap.rs
@@ -12,8 +12,10 @@ pub(crate) async fn handler(state: SharedState, request: Json<BootstrapRequest>)
     }
     let request = request.0;
     let ctx = state.context.clone();
+    let event_holder = ctx.event_holder.clone();
     *system_state = SystemState::Starting;
+
     ComposeMonitor::spawn(ctx, request.acme, request.docker, request.domain);
-    CaddyMonitor::spawn(state.docker.clone(), state.system_state.clone());
+    CaddyMonitor::spawn(state.docker.clone(), state.system_state.clone(), event_holder);
     StatusCode::OK
 }

--- a/nilcc-agent-cli/src/main.rs
+++ b/nilcc-agent-cli/src/main.rs
@@ -4,7 +4,7 @@ use anyhow::anyhow;
 use anyhow::Context;
 use clap::{Args, Parser, Subcommand};
 use cvm_agent_models::health::HealthResponse;
-use cvm_agent_models::health::LastError;
+use cvm_agent_models::health::LastEvent;
 use cvm_agent_models::logs::SystemLogsRequest;
 use cvm_agent_models::logs::SystemLogsResponse;
 use cvm_agent_models::logs::SystemLogsSource;
@@ -443,16 +443,16 @@ fn restart(client: ApiClient, args: RestartArgs) -> anyhow::Result<()> {
 fn health(client: ApiClient, args: HealthArgs) -> anyhow::Result<()> {
     let HealthArgs { id } = args;
     let response: HealthResponse = client.get(&format!("/api/v1/workloads/{id}/health"))?;
-    let HealthResponse { https, bootstrapped, last_error } = response;
+    let HealthResponse { https, bootstrapped, last_event, .. } = response;
     let color = bool_to_color(bootstrapped);
     println!("bootstrapped: {}", color.paint(bootstrapped.to_string()));
 
     let color = bool_to_color(https);
     println!("https up:     {}", color.paint(https.to_string()));
 
-    if let Some(last_error) = last_error {
-        let LastError { message, failed_at, .. } = last_error;
-        let text = format!("cvm failed to start at {failed_at}: {message}");
+    if let Some(last_event) = last_event {
+        let LastEvent { message, timestamp, kind, .. } = last_event;
+        let text = format!("cvm reported {kind:?} event at {timestamp}: {message}");
         println!("{}", Color::Red.paint(text));
     }
     Ok(())

--- a/nilcc-agent/src/clients/nilcc_api.rs
+++ b/nilcc-agent/src/clients/nilcc_api.rs
@@ -44,6 +44,7 @@ pub enum VmEvent {
     ForcedRestart,
     VmRestarted,
     FailedToStart { error: String },
+    Warning { message: String },
 }
 
 pub struct NilccApiClientArgs {


### PR DESCRIPTION
This adds a check to caddy's monitoring worker in cvm-agent to expose a warning when the TLS cert fails to be generated.

Closes #396