### PR TITLE
chore: remove deprecated fields in cvm-agent models

### DIFF
--- a/crates/cvm-agent-models/src/lib.rs
+++ b/crates/cvm-agent-models/src/lib.rs
@@ -14,12 +14,6 @@ pub mod bootstrap {
     /// A request to bootstrap the CVM.
     #[derive(Deserialize, Serialize)]
     pub struct BootstrapRequest {
-        /// Deprecated: The ACME EAB key id.
-        pub acme_eab_key_id: String,
-
-        /// Deprecated: The ACME EAB MAC key.
-        pub acme_eab_mac_key: String,
-
         /// The ACME credentials.
         pub acme: AcmeCredentials,
 
@@ -88,24 +82,8 @@ pub mod health {
         /// Whether the CVM is bootstrapped
         pub bootstrapped: bool,
 
-        /// The last error encountered.
-        pub last_error: Option<LastError>,
-
         /// The last event encountered.
         pub last_event: Option<LastEvent>,
-    }
-
-    #[derive(Clone, Deserialize, Serialize)]
-    #[serde(rename_all = "camelCase")]
-    pub struct LastError {
-        /// An incremental id for every error found.
-        pub error_id: u64,
-
-        /// An error message.
-        pub message: String,
-
-        /// The timestamp when this error was generated.
-        pub failed_at: DateTime<Utc>,
     }
 
     #[derive(Clone, Deserialize, Serialize)]

--- a/cvm-agent/src/routes/health.rs
+++ b/cvm-agent/src/routes/health.rs
@@ -1,7 +1,7 @@
 use super::SystemState;
 use crate::routes::SharedState;
 use axum::Json;
-use cvm_agent_models::health::{HealthResponse, LastError};
+use cvm_agent_models::health::HealthResponse;
 
 pub(crate) async fn handler(state: SharedState) -> Json<HealthResponse> {
     let (https, bootstrapped) = match &*state.system_state.lock().unwrap() {
@@ -11,8 +11,6 @@ pub(crate) async fn handler(state: SharedState) -> Json<HealthResponse> {
     };
 
     let last_event = state.context.event_holder.get();
-    let last_error =
-        last_event.clone().map(|e| LastError { error_id: e.id, message: e.message, failed_at: e.timestamp });
-    let response = HealthResponse { https, bootstrapped, last_error, last_event };
+    let response = HealthResponse { https, bootstrapped, last_event };
     Json(response)
 }

--- a/nilcc-agent/src/workers/vm.rs
+++ b/nilcc-agent/src/workers/vm.rs
@@ -202,10 +202,6 @@ impl VmWorker {
                     if !response.bootstrapped {
                         info!("CVM agent is running, bootstrapping it");
                         let request = BootstrapRequest {
-                            // TODO: these are deprecated and should be removed once all active
-                            // cvms are migrated
-                            acme_eab_key_id: self.zerossl_config.eab_key_id.clone(),
-                            acme_eab_mac_key: self.zerossl_config.eab_mac_key.clone(),
                             acme: AcmeCredentials {
                                 eab_key_id: self.zerossl_config.eab_key_id.clone(),
                                 eab_mac_key: self.zerossl_config.eab_mac_key.clone(),


### PR DESCRIPTION
This removes the redundant `eab` parameters on bootstrap and the deprecated `last_error` field in the health response.