### PR TITLE
fix: apply metal instance id `NOT NULL` migration

### DIFF
--- a/nilcc-api/src/data-source.ts
+++ b/nilcc-api/src/data-source.ts
@@ -19,6 +19,7 @@ import { Tiers1756136984989 } from "migrations/1756136984989-Tiers";
 import { AccountCredits1756146720184 } from "migrations/1756146720184-AccountCredits";
 import { WorkloadCreditRate1756151064011 } from "migrations/1756151064011-WorkloadTier";
 import { BigRename1756308586154 } from "migrations/1756308586154-BigRename";
+import { MetalInstanceIdNotNull1757713209092 } from "migrations/1757713209092-MetalInstanceIdNotNull";
 import { DataSource } from "typeorm";
 import type { EnvVars } from "#/env";
 import { MetalInstanceEntity } from "#/metal-instance/metal-instance.entity";
@@ -52,6 +53,7 @@ export async function buildDataSource(config: EnvVars): Promise<DataSource> {
       AccountCredits1756146720184,
       WorkloadCreditRate1756151064011,
       BigRename1756308586154,
+      MetalInstanceIdNotNull1757713209092,
     ],
     synchronize: false,
     logging: false,

--- a/nilcc-api/src/workload/workload.service.ts
+++ b/nilcc-api/src/workload/workload.service.ts
@@ -108,6 +108,9 @@ export class WorkloadService {
       creditRate: tier.cost,
     });
     const createdWorkload = await repository.save(entity);
+    bindings.log.info(
+      `Assigning workload ${createdWorkload.id} to metal instance ${metalInstance.id}`,
+    );
 
     const event: WorkloadEventEntity = {
       id: uuidv4(),
@@ -131,6 +134,9 @@ export class WorkloadService {
         metalInstance.id,
       );
     }
+    bindings.log.info(
+      `Created workload ${createdWorkload.id} on metal instance ${metalInstance.id}`,
+    );
     return createdWorkload;
   }
 


### PR DESCRIPTION
The change on #395 wasn't applied because, ultimately, typescript sucks.