### PR TITLE
chore: don't require test to be updated after attester version changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,6 +872,7 @@ dependencies = [
  "clap",
  "cvm-agent-models",
  "futures",
+ "regex",
  "serde",
  "serde_json",
  "sysinfo 0.36.1",

--- a/cvm-agent/Cargo.toml
+++ b/cvm-agent/Cargo.toml
@@ -11,6 +11,7 @@ bollard = "0.19"
 chrono = "0.4"
 clap = { version = "4.5", features = ["derive", "string"] }
 futures = "0.3"
+regex = "1.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sysinfo = { version = "0.36", default-features = false, features = ["system", "disk"] }


### PR DESCRIPTION
This makes it so that tests that render the docker compose file in cvm-agent don't require the nilcc-attester version to be bumped in the test every time it's bumped in the docker compose file.