### PR TITLE
feat: send artifacts version in create workload request

### DIFF
--- a/nilcc-api/migrations/1758656531192-ArtifactVersionMandatory.ts
+++ b/nilcc-api/migrations/1758656531192-ArtifactVersionMandatory.ts
@@ -1,0 +1,19 @@
+import type { MigrationInterface, QueryRunner } from "typeorm";
+
+export class ArtifactVersionMandatory1758656531192
+  implements MigrationInterface
+{
+  name = "ArtifactVersionMandatory1758656531192";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      "ALTER TABLE workloads ALTER COLUMN artifacts_version SET NOT NULL",
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      "ALTER TABLE workloads ALTER COLUMN artifacts_version DROP NOT NULL",
+    );
+  }
+}

--- a/nilcc-api/src/clients/nilcc-agent.client.ts
+++ b/nilcc-api/src/clients/nilcc-agent.client.ts
@@ -93,8 +93,13 @@ export class DefaultNilccAgentClient implements NilccAgentClient {
     this.log.info(
       `Creating workload ${workload.id} in agent ${metalInstance.id}`,
     );
+    if (workload.artifactsVersion === undefined) {
+      // This is temporary
+      throw new Error("artifacts version not set");
+    }
     const request: CreateWorkloadRequest = {
       id: workload.id,
+      artifactsVersion: workload.artifactsVersion,
       dockerCompose: workload.dockerCompose,
       envVars: workload.envVars,
       files: workload.files,
@@ -288,6 +293,7 @@ export class DefaultNilccAgentClient implements NilccAgentClient {
 
 type CreateWorkloadRequest = {
   id: string;
+  artifactsVersion: string;
   dockerCompose: string;
   envVars?: Record<string, string>;
   files?: Record<string, string>;

--- a/nilcc-api/src/data-source.ts
+++ b/nilcc-api/src/data-source.ts
@@ -22,6 +22,7 @@ import { BigRename1756308586154 } from "migrations/1756308586154-BigRename";
 import { MetalInstanceIdNotNull1757713209092 } from "migrations/1757713209092-MetalInstanceIdNotNull";
 import { CreateArtifactsTable1758563696154 } from "migrations/1758563696154-CreateArtifactsTable";
 import { MetalInstanceArtifactVersions1758645450546 } from "migrations/1758645450546-MetalInstanceArtifactVersions";
+import { ArtifactVersionMandatory1758656531192 } from "migrations/1758656531192-ArtifactVersionMandatory";
 import { DataSource } from "typeorm";
 import type { EnvVars } from "#/env";
 import { MetalInstanceEntity } from "#/metal-instance/metal-instance.entity";
@@ -60,6 +61,7 @@ export async function buildDataSource(config: EnvVars): Promise<DataSource> {
       MetalInstanceIdNotNull1757713209092,
       CreateArtifactsTable1758563696154,
       MetalInstanceArtifactVersions1758645450546,
+      ArtifactVersionMandatory1758656531192,
     ],
     synchronize: false,
     logging: false,

--- a/nilcc-api/src/metal-instance/metal-instance.service.ts
+++ b/nilcc-api/src/metal-instance/metal-instance.service.ts
@@ -138,6 +138,7 @@ export class MetalInstanceService {
       memory: number;
       disk: number;
       gpus: number;
+      artifactsVersion: string;
     },
     bindings: AppBindings,
     tx: QueryRunner,
@@ -171,7 +172,10 @@ export class MetalInstanceService {
         { requiredGpu: param.gpus },
       );
 
-    return await queryBuilder.getMany();
+    const instances = await queryBuilder.getMany();
+    return instances.filter((instance) =>
+      instance.availableArtifactVersions.includes(param.artifactsVersion),
+    );
   }
 
   async update(

--- a/nilcc-api/src/workload/workload.dto.ts
+++ b/nilcc-api/src/workload/workload.dto.ts
@@ -29,13 +29,10 @@ export const CreateWorkloadRequest = z
         description: "A descriptive name for the workload",
         examples: ["my-favorite-workload"],
       }),
-    artifactsVersion: z
-      .string()
-      .optional()
-      .openapi({
-        description: "The artifact version to use for this workload.",
-        examples: ["0.1.0"],
-      }),
+    artifactsVersion: z.string().openapi({
+      description: "The artifact version to use for this workload.",
+      examples: ["0.1.0"],
+    }),
     dockerCompose: z.string().openapi({
       description:
         "The docker compose to be ran. The docker compose can contain any number of services but it must contain a single one that will act as the public entry point to the CVM.",

--- a/nilcc-api/src/workload/workload.entity.ts
+++ b/nilcc-api/src/workload/workload.entity.ts
@@ -12,8 +12,8 @@ export class WorkloadEntity {
   @Column({ type: "varchar" })
   name: string;
 
-  @Column({ type: "varchar", nullable: true })
-  artifactsVersion?: string;
+  @Column({ type: "varchar" })
+  artifactsVersion: string;
 
   @ManyToOne(
     () => AccountEntity,

--- a/nilcc-api/src/workload/workload.service.ts
+++ b/nilcc-api/src/workload/workload.service.ts
@@ -87,6 +87,7 @@ export class WorkloadService {
           memory: request.memory,
           disk: request.disk,
           gpus: request.gpus,
+          artifactsVersion: request.artifactsVersion,
         },
         bindings,
         tx,

--- a/nilcc-api/tests/metal-instance.test.ts
+++ b/nilcc-api/tests/metal-instance.test.ts
@@ -141,8 +141,10 @@ describe("Metal Instance", () => {
       .getMetalInstance(myMetalInstance.metalInstanceId)
       .submit();
 
+    await clients.admin.enableArtifactVersion("aaa").submit();
     const createWorkloadRequest: CreateWorkloadRequest = {
       name: "my-cool-workload",
+      artifactsVersion: "aaa",
       dockerCompose: `
 services:
   app:


### PR DESCRIPTION
This makes the artifacts version for workloads mandatory and propagates it down to nilcc-agent when creating a workload.