### PR TITLE
feat: drop the `current` column from artifacts

### DIFF
--- a/crates/nilcc-agent-models/src/lib.rs
+++ b/crates/nilcc-agent-models/src/lib.rs
@@ -102,7 +102,7 @@ pub mod workloads {
         #[serde(rename_all = "camelCase")]
         pub struct CreateWorkloadRequest {
             pub id: Uuid,
-            pub artifacts_version: Option<String>,
+            pub artifacts_version: String,
             pub docker_compose: String,
 
             #[serde(default)]

--- a/nilcc-agent-cli/src/main.rs
+++ b/nilcc-agent-cli/src/main.rs
@@ -381,7 +381,7 @@ fn launch(client: ApiClient, args: LaunchArgs) -> anyhow::Result<()> {
         .collect::<Result<_, _>>()?;
     let request = CreateWorkloadRequest {
         id: id.unwrap_or_else(Uuid::new_v4),
-        artifacts_version: Some(artifacts),
+        artifacts_version: artifacts,
         docker_compose,
         env_vars,
         files,

--- a/nilcc-agent/migrations/20250923211658_remove_current_from_artifacts.sql
+++ b/nilcc-agent/migrations/20250923211658_remove_current_from_artifacts.sql
@@ -1,0 +1,3 @@
+-- Remove the `current` column from the artifacts table.
+
+ALTER TABLE artifacts DROP COLUMN current;

--- a/nilcc-agent/src/config.rs
+++ b/nilcc-agent/src/config.rs
@@ -48,11 +48,8 @@ pub struct AgentConfig {
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct CvmConfigs {
-    // The base path where all configs are.
+    /// The base path where all configs are.
     pub artifacts_path: PathBuf,
-
-    /// The initial version to use.
-    pub initial_version: String,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/nilcc-agent/src/services/vm.rs
+++ b/nilcc-agent/src/services/vm.rs
@@ -471,7 +471,7 @@ mod tests {
                     gpu_verity_root_hash: Default::default(),
                 };
                 let metadata = Some(ArtifactsMetadata::legacy(legacy_meta));
-                Ok(Some(Artifacts { version: "default".into(), metadata, current: true }))
+                Ok(Some(Artifacts { version: "default".into(), metadata }))
             });
             Ok(Box::new(repo))
         });

--- a/nilcc-agent/src/workers/heartbeat.rs
+++ b/nilcc-agent/src/workers/heartbeat.rs
@@ -117,7 +117,7 @@ mod tests {
         async fn set_versions(&mut self, versions: &[&str]) {
             let artifacts = versions
                 .into_iter()
-                .map(|version| Artifacts { version: version.to_string(), metadata: None, current: false })
+                .map(|version| Artifacts { version: version.to_string(), metadata: None })
                 .collect();
             self.provider.expect_artifacts().return_once(move |_| {
                 let mut repo = MockArtifactsRepository::default();


### PR DESCRIPTION
This drops the notion of "current" version since now we support a set of versions.