### PR TITLE
feat: support raw base disk images in nilcc-agent

### DIFF
--- a/crates/nilcc-artifacts/src/metadata.rs
+++ b/crates/nilcc-artifacts/src/metadata.rs
@@ -194,7 +194,7 @@ pub struct VerityDisk {
     pub format: DiskFormat,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum DiskFormat {
     /// A disk in raw format.


### PR DESCRIPTION
This handles base disk images being `raw`. The difference here is: for qcow2 images we create a snapshot and mount the snapshot as rw and for `raw` images we mount them directly as read only.