### PR TITLE
Revert "ci: publish git tag versions in nilcc-agent and artifact builds"

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -7,8 +7,6 @@ on:
       - 'crates/cvm-agent-models/**'
     branches:
       - main
-    tags:
-      - 'nilcc-artifacts-*'
 
 permissions:
   id-token: write
@@ -65,21 +63,13 @@ jobs:
           echo "Metadata hash: ${hash}" >> $GITHUB_STEP_SUMMARY
 
       - name: Configure AWS credentials
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags')
+        if: github.ref == 'refs/heads/main'
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: "arn:aws:iam::592920173613:role/github-runners-productionnilcc-ci-nilcc-bucket"
           aws-region: eu-west-1
 
       - name: Publish
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags')
-        run: |
-          if [[ "$GITHUB_REF" =~ ^refs/tags/nilcc-artifacts-.* ]]; then
-            # Remove the 'refs/tags/nilcc-artifacts-' prefix and keep the version
-            version=${GITHUB_REF:26}
-          else
-            # Or the short git hash otherwise.
-            version=$(git rev-parse --short HEAD)
-          fi
-          ./artifacts/upload.sh "${version}"
+        if: github.ref == 'refs/heads/main'
+        run: artifacts/upload.sh
 

--- a/.github/workflows/nilcc-agent-cd.yml
+++ b/.github/workflows/nilcc-agent-cd.yml
@@ -1,8 +1,6 @@
 name: nilcc-agent build/push
 on:
   push:
-    tags:
-      - 'nilcc-agent-*'
     branches:
       - main
 
@@ -31,11 +29,5 @@ jobs:
 
       - name: Publish
         run: |
-          if [[ "$GITHUB_REF" =~ ^refs/tags/nilcc-agent-.* ]]; then
-            # Remove the 'refs/tags/nilcc-agent-' prefix and keep the version
-            version=${GITHUB_REF:22}
-          else
-            # Or the short git hash otherwise.
-            version=$(git rev-parse --short HEAD)
-          fi
-          aws s3 cp "target/release/nilcc-agent" "s3://nilcc/${version}/nilcc-agent/x86-64/nilcc-agent"
+          COMMIT=$(git rev-parse --short HEAD)
+          aws s3 cp "target/release/nilcc-agent" "s3://nilcc/${COMMIT}/nilcc-agent/x86-64/nilcc-agent"

--- a/artifacts/generate-metadata.sh
+++ b/artifacts/generate-metadata.sh
@@ -6,7 +6,6 @@ set -euo pipefail
 SCRIPT_PATH=$(dirname $(realpath $0))
 
 BUILD_TIMESTAMP=$(date +%s)
-GIT_HASH=$(git rev-parse --short HEAD)
 KERNEL_COMMIT=$(cat "$SCRIPT_PATH/kernel/build.sh" | sed -n -e 's/^COMMIT="\(.*\)"/\1/p')
 QEMU_COMMIT=$(cat "$SCRIPT_PATH/qemu/build.sh" | sed -n -e 's/^COMMIT="\(.*\)"/\1/p')
 INITRD=initramfs/initramfs.cpio.gz
@@ -30,7 +29,6 @@ METADATA=$(
   cat <<EOF
 {
   "built_at": ${BUILD_TIMESTAMP},
-  "git_hash": "${GIT_HASH}",
   "kernel": {
     "commit": "${KERNEL_COMMIT}"
   },

--- a/artifacts/upload.sh
+++ b/artifacts/upload.sh
@@ -3,13 +3,7 @@
 
 set -euo pipefail
 
-if [ $# -ne 1 ]; then
-  echo "Usage: $0 <version>"
-  exit 1
-fi
-
 SCRIPT_PATH=$(dirname $(realpath $0))
-TARGET_URL="s3://nilcc/${1}/"
 
-echo "Uploading to ${TARGET_URL}"
-aws s3 cp --recursive "$SCRIPT_PATH/dist" "${TARGET_URL}"
+COMMIT=$(git rev-parse --short HEAD)
+aws s3 cp --recursive "$SCRIPT_PATH/dist" "s3://nilcc/${COMMIT}/"


### PR DESCRIPTION
This reverts commit 5850af7c9c91ef339fb5ee7a37cfc8acb9f6b121 because builds started failing after that but I think this is github being broken without admitting it