### PR TITLE
fix: respect git tag when setting attestation version

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -28,6 +28,18 @@ jobs:
         with:
           submodules: 'true'
 
+      - name: Generate version
+        run: |
+          if [[ "$GITHUB_REF" =~ ^refs/tags/nilcc-artifacts-.* ]]; then
+            # Remove the 'refs/tags/nilcc-artifacts-' prefix and keep the version
+            version=${GITHUB_REF:26}
+          else
+            # Or the short git hash otherwise.
+            version=$(git rev-parse --short HEAD)
+          fi
+          echo "Building version ${NILCC_VERSION}" >> $GITHUB_STEP_SUMMARY
+          echo "NILCC_VERSION=${version}" >> $GITHUB_ENV
+
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@1.85.0
 
@@ -68,12 +80,6 @@ jobs:
       - name: Publish
         if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags')
         run: |
-          if [[ "$GITHUB_REF" =~ ^refs/tags/nilcc-artifacts-.* ]]; then
-            # Remove the 'refs/tags/nilcc-artifacts-' prefix and keep the version
-            version=${GITHUB_REF:26}
-          else
-            # Or the short git hash otherwise.
-            version=$(git rev-parse --short HEAD)
-          fi
+          export NILCC_VERSION=${{ env.NILCC_VERSION }}
           ./artifacts/upload.sh "${version}"
 

--- a/artifacts/cvm-image/build.sh
+++ b/artifacts/cvm-image/build.sh
@@ -35,6 +35,7 @@ BASE_IMG_PATH="$SCRIPT_PATH/build/base-image.img"
 IMG_PATH="$BUILD_PATH/image.qcow2"
 SEED_PATH=$(mktemp /tmp/nilcc.XXXXX)
 CDROM_PATH=$(mktemp /tmp/nilcc.XXXXX)
+NILCC_VERSION=${NILCC_VERSION:-$(git rev-parse --short HEAD)}
 
 sudo rm -rf "$ISO_SOURCES_PATH/packages"
 
@@ -54,7 +55,7 @@ cp "$CVM_AGENT_PATH" "$ISO_SOURCES_PATH/nillion/"
 cp "$SCRIPT_PATH/cvm-agent.service" "$ISO_SOURCES_PATH/nillion/"
 
 # Store version and type so the VM can store this persistently.
-echo "$(git rev-parse --short HEAD)" >"$ISO_SOURCES_PATH/nillion/nilcc-version"
+echo "$NILCC_VERSION" >"$ISO_SOURCES_PATH/nillion/nilcc-version"
 echo "$VM_TYPE" >"$ISO_SOURCES_PATH/nillion/nilcc-vm-type"
 
 [[ ! -f "${BASE_IMG_PATH}" ]] && curl -L "$IMAGE_URL" -o "$BASE_IMG_PATH"


### PR DESCRIPTION
When using a git tag we weren't using that as the version inside the cvm (used for attestations).