### PR TITLE
feat: expose all supported artifact versions in agent

### DIFF
--- a/crates/nilcc-agent-models/src/lib.rs
+++ b/crates/nilcc-agent-models/src/lib.rs
@@ -40,9 +40,20 @@ pub mod system {
 
     #[derive(Clone, Debug, Serialize, Deserialize, Validate)]
     #[serde(rename_all = "camelCase")]
-    pub struct VersionResponse {
+    pub struct AgentVersionResponse {
         // The version we are running.
         pub version: String,
+
+        // Information about the last upgrade, if any.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub last_upgrade: Option<LastUpgrade>,
+    }
+
+    #[derive(Clone, Debug, Serialize, Deserialize, Validate)]
+    #[serde(rename_all = "camelCase")]
+    pub struct ArtifactVersionsResponse {
+        // The versions supported.
+        pub versions: Vec<String>,
 
         // Information about the last upgrade, if any.
         #[serde(skip_serializing_if = "Option::is_none")]

--- a/nilcc-agent/src/routes/mod.rs
+++ b/nilcc-agent/src/routes/mod.rs
@@ -50,7 +50,7 @@ pub fn build_router(state: AppState, token: String) -> Router {
                 "/system",
                 Router::new()
                     .route("/artifacts/install", post(system::artifacts::install::handler))
-                    .route("/artifacts/version", get(system::artifacts::version::handler))
+                    .route("/artifacts/versions", get(system::artifacts::versions::handler))
                     .route("/artifacts/cleanup", post(system::artifacts::cleanup::handler))
                     .route("/agent/upgrade", post(system::agent::upgrade::handler))
                     .route("/agent/version", get(system::agent::version::handler)),

--- a/nilcc-agent/src/routes/system/agent/version.rs
+++ b/nilcc-agent/src/routes/system/agent/version.rs
@@ -4,9 +4,9 @@ use crate::{
 };
 use axum::response::Response;
 use axum::{extract::State, Json};
-use nilcc_agent_models::system::{LastUpgrade, VersionResponse};
+use nilcc_agent_models::system::{AgentVersionResponse, LastUpgrade};
 
-pub(crate) async fn handler(state: State<AppState>) -> Result<Json<VersionResponse>, Response> {
+pub(crate) async fn handler(state: State<AppState>) -> Result<Json<AgentVersionResponse>, Response> {
     let version = state.services.upgrade.agent_version();
     let last_upgrade = match state.services.upgrade.agent_upgrade_state().await {
         UpgradeState::None => None,
@@ -23,5 +23,5 @@ pub(crate) async fn handler(state: State<AppState>) -> Result<Json<VersionRespon
             Some(LastUpgrade { version, started_at, state })
         }
     };
-    Ok(Json(VersionResponse { version, last_upgrade }))
+    Ok(Json(AgentVersionResponse { version, last_upgrade }))
 }

--- a/nilcc-agent/src/routes/system/artifacts/mod.rs
+++ b/nilcc-agent/src/routes/system/artifacts/mod.rs
@@ -1,3 +1,3 @@
 pub(crate) mod cleanup;
 pub(crate) mod install;
-pub(crate) mod version;
+pub(crate) mod versions;

--- a/nilcc-agent/src/routes/system/artifacts/versions.rs
+++ b/nilcc-agent/src/routes/system/artifacts/versions.rs
@@ -6,12 +6,12 @@ use axum::{extract::State, response::IntoResponse, Json};
 use axum::{http::StatusCode, response::Response};
 use nilcc_agent_models::{
     errors::RequestHandlerError,
-    system::{LastUpgrade, VersionResponse},
+    system::{ArtifactVersionsResponse, LastUpgrade},
 };
 use tracing::error;
 
-pub(crate) async fn handler(state: State<AppState>) -> Result<Json<VersionResponse>, Response> {
-    let version = state.services.upgrade.artifacts_version().await.map_err(|e| {
+pub(crate) async fn handler(state: State<AppState>) -> Result<Json<ArtifactVersionsResponse>, Response> {
+    let versions = state.services.upgrade.artifacts_versions().await.map_err(|e| {
         error!("Failed to get current artifacts version: {e:#}");
         (StatusCode::INTERNAL_SERVER_ERROR, Json(RequestHandlerError::new("internal server error", "INTERNAL")))
             .into_response()
@@ -31,5 +31,5 @@ pub(crate) async fn handler(state: State<AppState>) -> Result<Json<VersionRespon
             Some(LastUpgrade { version, started_at, state })
         }
     };
-    Ok(Json(VersionResponse { version, last_upgrade }))
+    Ok(Json(ArtifactVersionsResponse { versions, last_upgrade }))
 }


### PR DESCRIPTION
This exposes all artifact versions installed in the agent. This was half done before to not introduce too many changes.