### PR TITLE
chore: put core artifacts under different path

### DIFF
--- a/artifacts/core/generate-metadata.sh
+++ b/artifacts/core/generate-metadata.sh
@@ -7,26 +7,27 @@ SCRIPT_PATH=$(dirname $(realpath $0))
 
 BUILD_TIMESTAMP=$(date +%s)
 GIT_HASH=$(git rev-parse --short HEAD)
+BASE_ARTIFACTS_PATH=$SCRIPT_PATH/../dist
 KERNEL_COMMIT=$(cat "$SCRIPT_PATH/kernel/build.sh" | sed -n -e 's/^COMMIT="\(.*\)"/\1/p')
 QEMU_COMMIT=$(cat "$SCRIPT_PATH/qemu/build.sh" | sed -n -e 's/^COMMIT="\(.*\)"/\1/p')
-GUEST_KERNEL_HEADERS=kernel/guest/linux-headers.deb
-GUEST_KERNEL_HEADERS_HASH=$(sha256sum "$SCRIPT_PATH/../dist/$GUEST_KERNEL_HEADERS" | cut -d " " -f 1)
-GUEST_KERNEL_IMAGE=kernel/guest/linux-image.deb
-GUEST_KERNEL_IMAGE_HASH=$(sha256sum "$SCRIPT_PATH/../dist/$GUEST_KERNEL_IMAGE" | cut -d " " -f 1)
-GUEST_KERNEL_IMAGE_DBG=kernel/guest/linux-image-dbg.deb
-GUEST_KERNEL_IMAGE_DBG_HASH=$(sha256sum "$SCRIPT_PATH/../dist/$GUEST_KERNEL_IMAGE_DBG" | cut -d " " -f 1)
-GUEST_LIBC_DEV=kernel/guest/linux-libc-dev.deb
-GUEST_LIBC_DEV_HASH=$(sha256sum "$SCRIPT_PATH/../dist/$GUEST_LIBC_DEV" | cut -d " " -f 1)
-HOST_KERNEL_HEADERS=kernel/host/linux-headers.deb
-HOST_KERNEL_HEADERS_HASH=$(sha256sum "$SCRIPT_PATH/../dist/$HOST_KERNEL_HEADERS" | cut -d " " -f 1)
-HOST_KERNEL_IMAGE=kernel/host/linux-image.deb
-HOST_KERNEL_IMAGE_HASH=$(sha256sum "$SCRIPT_PATH/../dist/$HOST_KERNEL_IMAGE" | cut -d " " -f 1)
-HOST_KERNEL_IMAGE_DBG=kernel/host/linux-image-dbg.deb
-HOST_KERNEL_IMAGE_DBG_HASH=$(sha256sum "$SCRIPT_PATH/../dist/$HOST_KERNEL_IMAGE_DBG" | cut -d " " -f 1)
-HOST_LIBC_DEV=kernel/host/linux-libc-dev.deb
-HOST_LIBC_DEV_HASH=$(sha256sum "$SCRIPT_PATH/../dist/$HOST_LIBC_DEV" | cut -d " " -f 1)
-QEMU=qemu-static.tar.gz
-QEMU_HASH=$(sha256sum "$SCRIPT_PATH/../dist/$QEMU" | cut -d " " -f 1)
+GUEST_KERNEL_HEADERS=core/kernel/guest/linux-headers.deb
+GUEST_KERNEL_HEADERS_HASH=$(sha256sum "$BASE_ARTIFACTS_PATH/$GUEST_KERNEL_HEADERS" | cut -d " " -f 1)
+GUEST_KERNEL_IMAGE=core/kernel/guest/linux-image.deb
+GUEST_KERNEL_IMAGE_HASH=$(sha256sum "$BASE_ARTIFACTS_PATH/$GUEST_KERNEL_IMAGE" | cut -d " " -f 1)
+GUEST_KERNEL_IMAGE_DBG=core/kernel/guest/linux-image-dbg.deb
+GUEST_KERNEL_IMAGE_DBG_HASH=$(sha256sum "$BASE_ARTIFACTS_PATH/$GUEST_KERNEL_IMAGE_DBG" | cut -d " " -f 1)
+GUEST_LIBC_DEV=core/kernel/guest/linux-libc-dev.deb
+GUEST_LIBC_DEV_HASH=$(sha256sum "$BASE_ARTIFACTS_PATH/$GUEST_LIBC_DEV" | cut -d " " -f 1)
+HOST_KERNEL_HEADERS=core/kernel/host/linux-headers.deb
+HOST_KERNEL_HEADERS_HASH=$(sha256sum "$BASE_ARTIFACTS_PATH/$HOST_KERNEL_HEADERS" | cut -d " " -f 1)
+HOST_KERNEL_IMAGE=core/kernel/host/linux-image.deb
+HOST_KERNEL_IMAGE_HASH=$(sha256sum "$BASE_ARTIFACTS_PATH/$HOST_KERNEL_IMAGE" | cut -d " " -f 1)
+HOST_KERNEL_IMAGE_DBG=core/kernel/host/linux-image-dbg.deb
+HOST_KERNEL_IMAGE_DBG_HASH=$(sha256sum "$BASE_ARTIFACTS_PATH/$HOST_KERNEL_IMAGE_DBG" | cut -d " " -f 1)
+HOST_LIBC_DEV=core/kernel/host/linux-libc-dev.deb
+HOST_LIBC_DEV_HASH=$(sha256sum "$BASE_ARTIFACTS_PATH/$HOST_LIBC_DEV" | cut -d " " -f 1)
+QEMU=core/qemu-static.tar.gz
+QEMU_HASH=$(sha256sum "$BASE_ARTIFACTS_PATH/$QEMU" | cut -d " " -f 1)
 METADATA=$(
   cat <<EOF
 {
@@ -86,5 +87,4 @@ METADATA=$(
 EOF
 )
 
-mkdir -p "${SCRIPT_PATH}/../dist"
-echo $METADATA >"${SCRIPT_PATH}/../dist/core-metadata.json"
+echo $METADATA >"${SCRIPT_PATH}/../dist/core/metadata.json"

--- a/artifacts/core/kernel/build.sh
+++ b/artifacts/core/kernel/build.sh
@@ -37,5 +37,5 @@ mv $SCRIPT_PATH/build/$1/AMDSEV/linux/linux-libc-dev* $SCRIPT_PATH/build/$1/linu
 
 echo "Build finished, artifacts in build/$1"
 
-mkdir -p $SCRIPT_PATH/../../dist/kernel/$1
-cp $SCRIPT_PATH/build/$1/*.deb "$SCRIPT_PATH/../../dist/kernel/$1"
+mkdir -p $SCRIPT_PATH/../../dist/core/kernel/$1
+cp $SCRIPT_PATH/build/$1/*.deb "$SCRIPT_PATH/../../dist/core/kernel/$1"

--- a/artifacts/core/qemu/build.sh
+++ b/artifacts/core/qemu/build.sh
@@ -35,7 +35,7 @@ sudo chown -R $(whoami) $SCRIPT_PATH/build/
 PACKAGE_PATH="$SCRIPT_PATH/build/qemu-static.tar.gz"
 tar -czf "$PACKAGE_PATH" -C build/AMDSEV usr
 
-mkdir -p $SCRIPT_PATH/../../dist/
-cp $PACKAGE_PATH "$SCRIPT_PATH/../../dist/"
+mkdir -p $SCRIPT_PATH/../../dist/core/
+cp $PACKAGE_PATH "$SCRIPT_PATH/../../dist/core"
 
 echo "Build done, output: $PACKAGE_PATH"


### PR DESCRIPTION
This puts core artifacts in a different path so we don't mix up the artifacts for a core build vs a real one (will matter for versioning).

Part of #405