### PR TITLE
feat: allow updating account names

### DIFF
--- a/nilcc-api/src/account/account.dto.ts
+++ b/nilcc-api/src/account/account.dto.ts
@@ -41,6 +41,16 @@ export const CreateAccountRequest = z
   });
 export type CreateAccountRequest = z.infer<typeof CreateAccountRequest>;
 
+export const UpdateAccountRequest = z
+  .object({
+    accountId: z.string().openapi({ description: "The account identifier." }),
+    name: z.string().openapi({ description: "The new name for this account." }),
+  })
+  .openapi({
+    ref: "UpdateAccountRequest",
+  });
+export type UpdateAccountRequest = z.infer<typeof UpdateAccountRequest>;
+
 export const AddCreditsRequest = z
   .object({
     accountId: z.string(),

--- a/nilcc-api/src/account/account.router.ts
+++ b/nilcc-api/src/account/account.router.ts
@@ -3,6 +3,7 @@ import * as AccountController from "./account.controller";
 
 export function buildAccountRouter(options: ControllerOptions): void {
   AccountController.create(options);
+  AccountController.update(options);
   AccountController.list(options);
   AccountController.me(options);
   AccountController.read(options);

--- a/nilcc-api/src/account/account.service.ts
+++ b/nilcc-api/src/account/account.service.ts
@@ -8,7 +8,11 @@ import {
 } from "#/common/errors";
 import type { AppBindings } from "#/env";
 import { WorkloadEntity } from "#/workload/workload.entity";
-import type { AddCreditsRequest, CreateAccountRequest } from "./account.dto";
+import type {
+  AddCreditsRequest,
+  CreateAccountRequest,
+  UpdateAccountRequest,
+} from "./account.dto";
 import { AccountEntity } from "./account.entity";
 
 const API_TOKEN_BYTE_LENGTH: number = 16;
@@ -43,6 +47,20 @@ export class AccountService {
       }
       throw e;
     }
+  }
+
+  async update(
+    bindings: AppBindings,
+    request: UpdateAccountRequest,
+    tx: QueryRunner,
+  ): Promise<AccountEntity> {
+    const repository = this.getRepository(bindings, tx);
+    const account = await repository.findOneBy({ id: request.accountId });
+    if (account === null) {
+      throw new EntityNotFound("account");
+    }
+    account.name = request.name;
+    return await repository.save(account);
   }
 
   async read(bindings: AppBindings, id: string): Promise<AccountEntity | null> {

--- a/nilcc-api/src/common/paths.ts
+++ b/nilcc-api/src/common/paths.ts
@@ -14,6 +14,7 @@ export const PathsV1 = {
   docs: PathSchema.parse("/openapi.json"),
   account: {
     create: PathSchema.parse("/api/v1/accounts/create"),
+    update: PathSchema.parse("/api/v1/accounts/update"),
     list: PathSchema.parse("/api/v1/accounts/list"),
     read: PathSchema.parse("/api/v1/accounts/:id"),
     me: PathSchema.parse("/api/v1/accounts/me"),

--- a/nilcc-api/tests/account.test.ts
+++ b/nilcc-api/tests/account.test.ts
@@ -49,4 +49,16 @@ describe("Account", () => {
     expected.creditRate = 0;
     expect(me).toEqual(expected);
   });
+
+  it("should allow updating", async ({ expect, clients }) => {
+    const account = await clients.admin
+      .createAccount({ name: "some name", credits: 2 })
+      .submit();
+    await clients.admin
+      .updateAccount({ accountId: account.accountId, name: "some other name" })
+      .submit();
+    const expected = { ...account, name: "some other name" };
+    const updated = await clients.admin.getAccount(account.accountId).submit();
+    expect(updated).toEqual(expected);
+  });
 });

--- a/nilcc-api/tests/fixture/test-client.ts
+++ b/nilcc-api/tests/fixture/test-client.ts
@@ -3,6 +3,7 @@ import {
   Account,
   type CreateAccountRequest,
   MyAccount,
+  type UpdateAccountRequest,
 } from "#/account/account.dto";
 import type { App } from "#/app";
 import { Artifact } from "#/artifact/artifact.dto";
@@ -133,6 +134,14 @@ export class AdminClient extends TestClient {
 
   createAccount(request: CreateAccountRequest): RequestPromise<Account> {
     const promise = this.request(PathsV1.account.create, {
+      method: "POST",
+      body: request,
+    });
+    return new RequestPromise(promise, Account);
+  }
+
+  updateAccount(request: UpdateAccountRequest): RequestPromise<Account> {
+    const promise = this.request(PathsV1.account.update, {
       method: "POST",
       body: request,
     });


### PR DESCRIPTION
This adds a `/accounts/update` that allows, for now, updating an account's name.