### PR TITLE
feat: make some user endpoints available to admin user

### DIFF
--- a/nilcc-api/src/artifact/artifact.controller.ts
+++ b/nilcc-api/src/artifact/artifact.controller.ts
@@ -1,7 +1,7 @@
 import { describeRoute } from "hono-openapi";
 import { resolver } from "hono-openapi/zod";
 import semver, { SemVer } from "semver";
-import { adminAuthentication, userAuthentication } from "#/common/auth";
+import { adminAuthentication, adminOrUserAuthentication } from "#/common/auth";
 import {
   OpenApiSpecCommonErrorResponses,
   OpenApiSpecEmptySuccessResponses,
@@ -71,7 +71,7 @@ export function list(options: ControllerOptions) {
         ...OpenApiSpecCommonErrorResponses,
       },
     }),
-    userAuthentication(bindings),
+    adminOrUserAuthentication(bindings),
     async (c) => {
       const accounts = await bindings.services.artifact.list(bindings);
       const makeSortable = (artifact: ArtifactEntity): number | SemVer => {

--- a/nilcc-api/src/workload-tier/workload-tier.controllers.ts
+++ b/nilcc-api/src/workload-tier/workload-tier.controllers.ts
@@ -1,6 +1,6 @@
 import { describeRoute } from "hono-openapi";
 import { resolver } from "hono-openapi/zod";
-import { adminAuthentication, userAuthentication } from "#/common/auth";
+import { adminAuthentication, adminOrUserAuthentication } from "#/common/auth";
 import { OpenApiSpecCommonErrorResponses } from "#/common/openapi";
 import { PathsV1 } from "#/common/paths";
 import type { ControllerOptions } from "#/common/types";
@@ -65,7 +65,7 @@ export function list(options: ControllerOptions) {
         ...OpenApiSpecCommonErrorResponses,
       },
     }),
-    userAuthentication(bindings),
+    adminOrUserAuthentication(bindings),
     async (c) => {
       const tiers = await bindings.services.workloadTier.list(bindings);
       tiers.sort((a, b) => a.cost - b.cost);

--- a/nilcc-api/tests/fixture/test-client.ts
+++ b/nilcc-api/tests/fixture/test-client.ts
@@ -178,6 +178,13 @@ export class AdminClient extends TestClient {
     return new RequestPromise(promise, z.unknown());
   }
 
+  listTiers(): RequestPromise<WorkloadTier[]> {
+    const promise = this.request(PathsV1.workloadTiers.list, {
+      method: "GET",
+    });
+    return new RequestPromise(promise, WorkloadTier.array());
+  }
+
   enableArtifactVersion(version: string): RequestPromise<Artifact> {
     const promise = this.request(PathsV1.artifacts.enable, {
       method: "POST",

--- a/nilcc-api/tests/workload-tier.test.ts
+++ b/nilcc-api/tests/workload-tier.test.ts
@@ -37,5 +37,6 @@ describe("WorkloadTier", () => {
 
     await clients.admin.deleteTier(tier.tierId).submit();
     expect(await clients.user.listTiers().submit()).toEqual([]);
+    expect(await clients.admin.listTiers().submit()).toEqual([]);
   });
 });


### PR DESCRIPTION
This makes `/artifacts/list` and `/workload-tiers/list` available to admin users as well because why not.