### PR TITLE
fix: install openssl/libgcc in runtime docker layer

### DIFF
--- a/docker/nilcc-verifier.dockerfile
+++ b/docker/nilcc-verifier.dockerfile
@@ -1,13 +1,15 @@
 FROM rust:1.88-alpine AS build
 WORKDIR /opt/nillion
 
-RUN apk add --no-cache musl-dev git pkgconf openssl-dev libgcc
+RUN apk add --no-cache musl-dev git pkgconf openssl-dev
 
 COPY . .
 RUN RUSTFLAGS="-Ctarget-feature=-crt-static" cargo build --release --locked -p nilcc-verifier
 
 FROM alpine
 WORKDIR /opt/nillion
+
+RUN apk add libgcc openssl
 
 COPY --from=build /opt/nillion/target/release/nilcc-verifier /opt/nillion
 ENTRYPOINT ["/opt/nillion/nilcc-verifier"]


### PR DESCRIPTION
This installs libgcc/openssl in the final/runtime layer of the nilcc-verifier docker image.