### PR TITLE
chore: return specific error type if reserved env var is used

### DIFF
--- a/nilcc-api/src/clients/nilcc-agent.client.ts
+++ b/nilcc-api/src/clients/nilcc-agent.client.ts
@@ -10,6 +10,7 @@ const ALLOWED_CREATE_WORKLOAD_ERRORS: string[] = [
   "DOMAIN_EXISTS",
   "AGENT_DOMAIN",
   "RESOURCE_LIMIT",
+  "RESERVED_ENVIRONMENT_VARIABLE",
 ];
 
 export interface NilccAgentClient {


### PR DESCRIPTION
The check for reserved env vars was done too deep where it was too hard to specify a useful error code. This moves the check up to the controller and allows that error kind to be propagated to the user in nilcc-api.