### PR TITLE
feat: allow downloading artifacts for via nilcc-verifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2236,6 +2236,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "sha2",
  "thiserror 2.0.16",
  "tokio",
  "tracing",

--- a/crates/nilcc-artifacts/Cargo.toml
+++ b/crates/nilcc-artifacts/Cargo.toml
@@ -7,7 +7,9 @@ edition = "2024"
 hex = "0.4"
 futures-util = "0.3"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 serde_with = { version = "3.14", features = ["hex"] }
+sha2 = "0.10"
 thiserror = "2.0"
 tracing = "0.1"
 tokio = { version = "1.47", features = ["fs"] }

--- a/crates/nilcc-artifacts/src/lib.rs
+++ b/crates/nilcc-artifacts/src/lib.rs
@@ -23,6 +23,7 @@ impl fmt::Display for VmType {
 #[derive(Clone, Debug)]
 pub struct Artifacts {
     pub metadata: ArtifactsMetadata,
+    pub metadata_hash: [u8; 32],
     pub ovmf_path: PathBuf,
     pub initrd_path: PathBuf,
 }

--- a/nilcc-verifier/src/report.rs
+++ b/nilcc-verifier/src/report.rs
@@ -15,9 +15,9 @@ use x509_parser::parse_x509_certificate;
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[derive(Deserialize)]
-struct ReportResponse {
-    report: attestation_report::v2::AttestationReport,
-    environment: EnvironmentSpec,
+pub struct ReportResponse {
+    pub report: attestation_report::v2::AttestationReport,
+    pub environment: EnvironmentSpec,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
This adds a `download-artifacts` command to nilcc-verifier that allows downloading 