### PR TITLE
chore: remove redundant fields in `Artifacts` struct

### DIFF
--- a/crates/nilcc-artifacts/src/downloader.rs
+++ b/crates/nilcc-artifacts/src/downloader.rs
@@ -57,8 +57,8 @@ impl ArtifactsDownloader {
     pub async fn download(&self, target_dir: &Path) -> Result<Artifacts, DownloadError> {
         info!("Downloading artifacts to {}", target_dir.display());
         let (metadata, metadata_hash) = self.fetch_metadata().await?;
-        let ovmf_path = self.download_artifact(&metadata.ovmf.path, target_dir).await?;
-        let initrd_path = self.download_artifact(&metadata.initrd.path, target_dir).await?;
+        self.download_artifact(&metadata.ovmf.path, target_dir).await?;
+        self.download_artifact(&metadata.initrd.path, target_dir).await?;
         for vm_type in &self.vm_types {
             let metadata = metadata.cvm.images.resolve(*vm_type);
             self.download_artifact(&metadata.kernel.path, target_dir).await?;
@@ -67,7 +67,7 @@ impl ArtifactsDownloader {
                 self.download_artifact(&metadata.verity.disk.path, target_dir).await?;
             }
         }
-        Ok(Artifacts { metadata, metadata_hash, ovmf_path, initrd_path })
+        Ok(Artifacts { metadata, metadata_hash })
     }
 
     async fn download_artifact(&self, artifact_name: &str, target_dir: &Path) -> Result<PathBuf, DownloadError> {

--- a/crates/nilcc-artifacts/src/lib.rs
+++ b/crates/nilcc-artifacts/src/lib.rs
@@ -1,5 +1,5 @@
 use crate::metadata::ArtifactsMetadata;
-use std::{fmt, path::PathBuf};
+use std::fmt;
 
 pub mod downloader;
 pub mod metadata;
@@ -19,11 +19,8 @@ impl fmt::Display for VmType {
     }
 }
 
-// TODO: remove this and use metadata instead
 #[derive(Clone, Debug)]
 pub struct Artifacts {
     pub metadata: ArtifactsMetadata,
     pub metadata_hash: [u8; 32],
-    pub ovmf_path: PathBuf,
-    pub initrd_path: PathBuf,
 }

--- a/nilcc-verifier/src/main.rs
+++ b/nilcc-verifier/src/main.rs
@@ -239,9 +239,11 @@ fn compute_measurement_hash(args: MeasurementHashArgs) -> anyhow::Result<()> {
     let runtime =
         tokio::runtime::Builder::new_current_thread().enable_all().build().context("building tokio runtime")?;
     let artifacts = runtime.block_on(downloader.download(&download_path))?;
-    let Artifacts { ovmf_path, initrd_path, metadata, .. } = artifacts;
+    let Artifacts { metadata, .. } = artifacts;
     let vm_type_metadata = metadata.cvm.images.resolve(vm_type.into());
     let filesystem_root_hash = vm_type_metadata.verity.root_hash;
+    let ovmf_path = download_path.join(&metadata.ovmf.path);
+    let initrd_path = download_path.join(&metadata.initrd.path);
     let kernel_path = download_path.join(&vm_type_metadata.kernel.path);
     let measurement = MeasurementGenerator {
         vcpus: cpus,

--- a/nilcc-verifier/src/report.rs
+++ b/nilcc-verifier/src/report.rs
@@ -99,9 +99,11 @@ impl ReportFetcher {
         let runtime =
             tokio::runtime::Builder::new_current_thread().enable_all().build().map_err(ReportBundleError::Tokio)?;
         let artifacts = runtime.block_on(downloader.download(&download_path))?;
-        let Artifacts { ovmf_path, initrd_path, metadata, .. } = artifacts;
+        let Artifacts { metadata, .. } = artifacts;
         let vm_type_metadata = metadata.cvm.images.resolve(vm_type);
         let filesystem_root_hash = vm_type_metadata.verity.root_hash;
+        let ovmf_path = download_path.join(&metadata.ovmf.path);
+        let initrd_path = download_path.join(&metadata.initrd.path);
         let kernel_path = download_path.join(&vm_type_metadata.kernel.path);
         Ok(ReportBundle {
             report,


### PR DESCRIPTION
These fields were duplicated now that `metadata` contains the paths to all files.