### PR TITLE
ci: run artifacts builds in ubuntu-latest

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -26,7 +26,7 @@ defaults:
 jobs:
   build:
     name: Build
-    runs-on: [ "nilcc-ci" ]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -44,6 +44,10 @@ jobs:
           fi
           echo "Building version ${version}"
           echo "NILCC_VERSION=${version}" >> $GITHUB_ENV
+
+      - name: Install dependencies
+        run: |
+          sudo apt install -y jq squashfs-tools cloud-image-utils
 
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@1.85.0

--- a/.github/workflows/core-artifacts.yml
+++ b/.github/workflows/core-artifacts.yml
@@ -19,7 +19,7 @@ defaults:
 jobs:
   build:
     name: Build
-    runs-on: [ "nilcc-ci" ]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -37,6 +37,10 @@ jobs:
           fi
           echo "Building version ${version}"
           echo "NILCC_VERSION=${version}" >> $GITHUB_ENV
+
+      - name: Install dependencies
+        run: |
+          sudo apt install -y jq squashfs-tools cloud-image-utils
 
       - name: Build guest kernel
         run: artifacts/core/kernel/build.sh guest


### PR DESCRIPTION
This runs the artifacts build in ubuntu-latest instead of a custom one. It's unclear if we do still need a custom one or why it was needed in the first place.