### PR TITLE
chore!: require metadata.json to be up to date

### DIFF
--- a/crates/nilcc-artifacts/src/metadata.rs
+++ b/crates/nilcc-artifacts/src/metadata.rs
@@ -23,59 +23,6 @@ pub struct ArtifactsMetadata {
     pub cvm: Cvm,
 }
 
-impl ArtifactsMetadata {
-    pub fn legacy(meta: LegacyMetadata) -> Self {
-        Self {
-            kernel: PackageMetadata { commit: "".into() },
-            qemu: PackageMetadata { commit: "".into() },
-            ovmf: Artifact { path: "vm_images/ovmf/OVMF.fd".into(), sha256: [0; 32] },
-            initrd: Artifact { path: "initramfs/initramfs.cpio.gz".into(), sha256: [0; 32] },
-            cvm: Cvm {
-                cmdline: KernelCommandLine("panic=-1 root=/dev/sda2 verity_disk=/dev/sdb verity_roothash={VERITY_ROOT_HASH} state_disk=/dev/sdc docker_compose_disk=/dev/sr0 docker_compose_hash={DOCKER_COMPOSE_HASH}".into()),
-                images: CvmImages {
-                    cpu: CvmImage {
-                        disk: CvmDisk {
-                            artifact: Artifact { path: "vm_images/cvm-cpu.qcow2".into(), sha256: [0; 32] },
-                            format: DiskFormat::Qcow2,
-                        },
-                        verity: Verity {
-                            disk: VerityDisk {
-                                path: "vm_images/cvm-cpu-verity/verity-hash-dev".into(),
-                                format: DiskFormat::Raw,
-                            },
-                            root_hash: meta.cpu_verity_root_hash,
-                        },
-                        kernel: Artifact { path: "vm_images/kernel/cpu-vmlinuz".into(), sha256: [0; 32] },
-                    },
-                    gpu: CvmImage {
-                        disk: CvmDisk {
-                            artifact: Artifact { path: "vm_images/cvm-gpu.qcow2".into(), sha256: [0; 32] },
-                            format: DiskFormat::Qcow2,
-                        },
-                        verity: Verity {
-                            disk: VerityDisk {
-                                path: "vm_images/cvm-gpu-verity/verity-hash-dev".into(),
-                                format: DiskFormat::Raw,
-                            },
-                            root_hash: meta.gpu_verity_root_hash,
-                        },
-                        kernel: Artifact { path: "vm_images/kernel/gpu-vmlinuz".into(), sha256: [0; 32] },
-                    },
-                },
-            },
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct LegacyMetadata {
-    /// The CPU verity root hash.
-    pub cpu_verity_root_hash: [u8; 32],
-
-    /// The GPU verity root hash.
-    pub gpu_verity_root_hash: [u8; 32],
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct PackageMetadata {
     /// The git commit that this package was built from.
@@ -108,7 +55,7 @@ pub struct KernelArgs<'a> {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct KernelCommandLine(String);
+pub struct KernelCommandLine(pub String);
 
 impl KernelCommandLine {
     /// Render these command line arguments.

--- a/nilcc-agent/migrations/20251002154846_not_null_artifact_metadata.sql
+++ b/nilcc-agent/migrations/20251002154846_not_null_artifact_metadata.sql
@@ -1,0 +1,14 @@
+-- Make the metadata column required in the `artifacts` table.
+
+ALTER TABLE artifacts RENAME TO artifacts_old;
+
+CREATE TABLE artifacts(
+  version VARCHAR(64) PRIMARY KEY,
+  updated_at DATETIME WITH TIMEZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  metadata TEXT NOT NULL
+);
+
+INSERT INTO artifacts(version, updated_at, metadata) SELECT version, updated_at, metadata FROM artifacts_old;
+
+DROP TABLE artifacts_old;
+

--- a/nilcc-agent/src/repositories/artifacts.rs
+++ b/nilcc-agent/src/repositories/artifacts.rs
@@ -36,7 +36,7 @@ pub trait ArtifactsRepository: Send + Sync {
 pub struct Artifacts {
     pub version: String,
     #[sqlx(json)]
-    pub metadata: Option<ArtifactsMetadata>,
+    pub metadata: ArtifactsMetadata,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -104,10 +104,62 @@ impl<'a> ArtifactsRepository for SqliteArtifactsRepository<'a> {
 }
 
 #[cfg(test)]
+pub(crate) mod utils {
+    use nilcc_artifacts::metadata::{
+        Artifact, ArtifactsMetadata, Cvm, CvmDisk, CvmImage, CvmImages, DiskFormat, KernelCommandLine, PackageMetadata,
+        Verity, VerityDisk,
+    };
+
+    pub(crate) fn make_artifacts_metadata() -> ArtifactsMetadata {
+        ArtifactsMetadata {
+            kernel: PackageMetadata { commit: "".into() },
+            qemu: PackageMetadata { commit: "".into() },
+            ovmf: Artifact { path: "".into(), sha256: [0; 32] },
+            initrd: Artifact { path: "".into(), sha256: [0; 32] },
+            cvm: Cvm {
+                cmdline: KernelCommandLine("panic=-1 root=/dev/sda2 verity_disk=/dev/sdb verity_roothash={VERITY_ROOT_HASH} state_disk=/dev/sdc docker_compose_disk=/dev/sr0 docker_compose_hash={DOCKER_COMPOSE_HASH}".into()),
+                images: CvmImages {
+                    cpu: CvmImage {
+                        disk: CvmDisk {
+                            artifact: Artifact { path: "vm_images/cvm-cpu.qcow2".into(), sha256: [0; 32] },
+                            format: DiskFormat::Qcow2,
+                        },
+                        verity: Verity {
+                            disk: VerityDisk {
+                                path: "vm_images/cvm-cpu-verity/verity-hash-dev".into(),
+                                format: DiskFormat::Raw,
+                            },
+                            root_hash: [0; 32],
+                        },
+                        kernel: Artifact { path: "vm_images/kernel/cpu-vmlinuz".into(), sha256: [0; 32] },
+                    },
+                    gpu: CvmImage {
+                        disk: CvmDisk {
+                            artifact: Artifact { path: "vm_images/cvm-gpu.qcow2".into(), sha256: [0; 32] },
+                            format: DiskFormat::Qcow2,
+                        },
+                        verity: Verity {
+                            disk: VerityDisk {
+                                path: "vm_images/cvm-gpu-verity/verity-hash-dev".into(),
+                                format: DiskFormat::Raw,
+                            },
+                            root_hash: [0; 32],
+                        },
+                        kernel: Artifact { path: "vm_images/kernel/gpu-vmlinuz".into(), sha256: [0; 32] },
+                    },
+                },
+            },
+        }
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
-    use crate::repositories::sqlite::{SqliteDb, SqliteTransactionContextInner};
-    use nilcc_artifacts::metadata::LegacyMetadata;
+    use crate::repositories::{
+        artifacts::utils::make_artifacts_metadata,
+        sqlite::{SqliteDb, SqliteTransactionContextInner},
+    };
 
     #[tokio::test]
     async fn crud() {
@@ -115,10 +167,7 @@ mod tests {
         let connection = db.0.acquire().await.expect("failed to acquire");
         let mut repo = SqliteArtifactsRepository::new(SqliteTransactionContextInner::Connection(connection).into());
 
-        let meta = ArtifactsMetadata::legacy(LegacyMetadata {
-            cpu_verity_root_hash: Default::default(),
-            gpu_verity_root_hash: Default::default(),
-        });
+        let meta = make_artifacts_metadata();
         repo.create("aaa", &meta).await.expect("failed to set");
         repo.create("bbb", &meta).await.expect("failed to set");
 

--- a/nilcc-agent/src/workers/heartbeat.rs
+++ b/nilcc-agent/src/workers/heartbeat.rs
@@ -133,7 +133,7 @@ mod tests {
     use crate::{
         clients::nilcc_api::{HeartbeatResponse, MockNilccApiClient},
         repositories::{
-            artifacts::{Artifacts, MockArtifactsRepository},
+            artifacts::{Artifacts, MockArtifactsRepository, utils::make_artifacts_metadata},
             sqlite::MockRepositoryProvider,
             workload::MockWorkloadRepository,
         },
@@ -161,7 +161,7 @@ mod tests {
         async fn set_existing_artifact_versions(&mut self, versions: &[&str]) {
             let artifacts = versions
                 .into_iter()
-                .map(|version| Artifacts { version: version.to_string(), metadata: None })
+                .map(|version| Artifacts { version: version.to_string(), metadata: make_artifacts_metadata() })
                 .collect();
             self.provider.expect_artifacts().return_once(move |_| {
                 let mut repo = MockArtifactsRepository::default();

--- a/nilcc-verifier/src/main.rs
+++ b/nilcc-verifier/src/main.rs
@@ -326,10 +326,8 @@ impl From<ValidateError> for ErrorCode {
                 | ReportBundleError::MalformedPayload(_) => Request,
                 ReportBundleError::DownloadArtifacts(e) => match e {
                     DownloadError::NoParent => Internal,
-                    DownloadError::TargetDirectory(_)
-                    | DownloadError::TargetFile(_)
-                    | DownloadError::ReadRootHash(_) => Filesystem,
-                    DownloadError::DecodeRootHash(_) => InvalidArtifacts,
+                    DownloadError::TargetDirectory(_) | DownloadError::TargetFile(_) => Filesystem,
+                    DownloadError::DecodeMetadata(_) => InvalidArtifacts,
                     DownloadError::Download(_) => Request,
                 },
             },


### PR DESCRIPTION
This removes the flexibility we had before where the metadata wasn't necessary for an artifact version to be used. All instances that were still using artifacts old enough to not have an up to date metadata have been updated so we no longer need this fallback logic.