### PR TITLE
feat: persist `metadata.json` when downloading a artifacts

### DIFF
--- a/.github/workflows/nilcc-admin-cli-docker.yml
+++ b/.github/workflows/nilcc-admin-cli-docker.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - 'nilcc-admin-cli/**'
       - 'Cargo.lock'
+      - 'crates/**'
 
 jobs:
   docker-build-nilcc-admin-cli:

--- a/.github/workflows/nilcc-agent-cd.yml
+++ b/.github/workflows/nilcc-agent-cd.yml
@@ -7,6 +7,7 @@ on:
       - main
     paths:
       - 'nilcc-agent/**'
+      - 'crates/**'
       - 'Cargo.lock'
 
 permissions:

--- a/.github/workflows/nilcc-agent-cli-docker.yml
+++ b/.github/workflows/nilcc-agent-cli-docker.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - 'nilcc-agent-cli/**'
       - 'Cargo.lock'
+      - 'crates/**'
 
 jobs:
   docker-build-nilcc-agent-cli:

--- a/.github/workflows/nilcc-attester-docker.yml
+++ b/.github/workflows/nilcc-attester-docker.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - 'nilcc-attester/**'
       - 'Cargo.lock'
+      - 'crates/**'
 
 jobs:
   docker-build-nilcc-attester:

--- a/.github/workflows/nilcc-verifier-docker.yml
+++ b/.github/workflows/nilcc-verifier-docker.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - 'nilcc-verifier/**'
       - 'Cargo.lock'
+      - 'crates/**'
 
 jobs:
   docker-build-nilcc-verifier:


### PR DESCRIPTION
This downloads `metadata.json` when downloading a set of artifacts. This affects both `nilcc-agent` and `nilcc-verifier download-artifacts`.