### PR TITLE
chore: clear environment before invoking docker compose

### DIFF
--- a/cvm-agent/src/monitors/compose.rs
+++ b/cvm-agent/src/monitors/compose.rs
@@ -149,6 +149,7 @@ impl ComposeMonitor {
     fn base_docker_command(&self) -> Command {
         let mut command = Command::new("docker");
         command
+            .env_clear()
             .current_dir(&self.ctx.iso_mount)
             // pass in `FILES` which points to `<iso>/files`
             .env("FILES", self.ctx.external_files.as_os_str())


### PR DESCRIPTION
This clears the environment before invoking docker compose inside the CVM. There's nothing sensitive in there but there's no reason not to do this.