### PR TITLE
feat: validate that mounts are valid before starting CVM

### DIFF
--- a/nilcc-agent/src/routes/workloads/create.rs
+++ b/nilcc-agent/src/routes/workloads/create.rs
@@ -46,7 +46,7 @@ pub(crate) async fn handler(
     if let Some(name) = request.env_vars.keys().find(|var| RESERVED_ENVIRONMENT_VARIABLES.contains(&var.as_str())) {
         return Err(HandlerError::ReservedEnvironmentVariable(name.clone()));
     }
-    validate_docker_compose(&request.docker_compose, &request.public_container_name)?;
+    validate_docker_compose(&request.docker_compose, &request.public_container_name, &request.files)?;
 
     let id = request.id;
     state.services.workload.create_workload(request.0).await?;


### PR DESCRIPTION
Before this change if you had a `volumes` entry that pointed to a non existent mount under `$FILES`, the CVM would start but docker compose would never succeed. With this change the request to create a workload fails with a proper error message.