### PR TITLE
feat: make validation errors look prettier

### DIFF
--- a/crates/nilcc-agent-models/src/lib.rs
+++ b/crates/nilcc-agent-models/src/lib.rs
@@ -13,7 +13,7 @@ pub mod system {
     use chrono::{DateTime, Utc};
 
     fn validate_version(version: &str) -> Result<(), ValidationError> {
-        if version.contains("/") { Err(ValidationError::new("version can't contain '/'")) } else { Ok(()) }
+        if version.contains("/") { Err(ValidationError::new("can't contain '/'")) } else { Ok(()) }
     }
 
     /// A request to install an artifacts version.


### PR DESCRIPTION
This introduces custom logic on how to convert `validator` errors to string. The default way is too close to a `Debug` impl and doesn't look great.