### PR TITLE
fix: write metadata file at the end

### DIFF
--- a/crates/nilcc-artifacts/src/downloader.rs
+++ b/crates/nilcc-artifacts/src/downloader.rs
@@ -57,7 +57,6 @@ impl ArtifactsDownloader {
         let artifact_metadata = self.fetch_metadata().await?;
         let metadata = &artifact_metadata.decoded;
         let metadata_path = target_dir.join("metadata.json");
-        fs::write(&metadata_path, artifact_metadata.raw).await.map_err(DownloadError::TargetFile)?;
         self.download_artifact(&metadata.ovmf.path, target_dir).await?;
         self.download_artifact(&metadata.initrd.path, target_dir).await?;
         for vm_type in &self.vm_types {
@@ -68,6 +67,7 @@ impl ArtifactsDownloader {
                 self.download_artifact(&metadata.verity.disk.path, target_dir).await?;
             }
         }
+        fs::write(&metadata_path, artifact_metadata.raw).await.map_err(DownloadError::TargetFile)?;
         Ok(Artifacts { metadata: artifact_metadata.decoded, metadata_hash: artifact_metadata.hash })
     }
 


### PR DESCRIPTION
The target directory when downloading artifacts is not necessarily created depending on how it's being used. Writing the metadata at the end ensures the directory exists.