### PR TITLE
feat: trust cpu randomness and distrust bootloader's

### DIFF
--- a/artifacts/generate-metadata.sh
+++ b/artifacts/generate-metadata.sh
@@ -26,6 +26,7 @@ GPU_VERITY_ROOT_HASH=$(cat "$SCRIPT_PATH/dist/gpu/root-hash")
 GPU_VERITY_HASHES_DISK=gpu/disk.verity
 GPU_KERNEL=gpu/kernel
 GPU_KERNEL_HASH=$(sha256sum "$SCRIPT_PATH/dist/$GPU_KERNEL" | cut -d " " -f 1)
+KERNEL_CMDLINE="root=/dev/sda verity_disk=/dev/sdb verity_roothash={VERITY_ROOT_HASH} state_disk=/dev/sdc docker_compose_disk=/dev/sr0 docker_compose_hash={DOCKER_COMPOSE_HASH} panic=-1 random.trust_cpu=on random.trust_bootloader=off"
 
 METADATA=$(
   cat <<EOF
@@ -47,7 +48,7 @@ METADATA=$(
     "sha256": "${INITRD_HASH}"
   },
   "cvm": {
-    "cmdline": "panic=-1 root=/dev/sda verity_disk=/dev/sdb verity_roothash={VERITY_ROOT_HASH} state_disk=/dev/sdc docker_compose_disk=/dev/sr0 docker_compose_hash={DOCKER_COMPOSE_HASH}",
+    "cmdline": "$KERNEL_CMDLINE",
     "images": {
       "cpu": {
         "disk": {


### PR DESCRIPTION
This trusts the CPU's randomness by passing `random.trust_cpu=on` and distrusts the bootloader's by passing `random.trust_bootloader=off`.