### PR TITLE
fix: persist older api keys and prevent missing values

### DIFF
--- a/nilcc-api/migrations/1772193140109-Payments.ts
+++ b/nilcc-api/migrations/1772193140109-Payments.ts
@@ -1,7 +1,7 @@
 import type { MigrationInterface, QueryRunner } from "typeorm";
 
-export class Payments1772193140110 implements MigrationInterface {
-  name = "Payments1772193140110";
+export class Payments1772193140109 implements MigrationInterface {
+  name = "Payments1772193140109";
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`

--- a/nilcc-api/migrations/1772193140110-ApiKeys.ts
+++ b/nilcc-api/migrations/1772193140110-ApiKeys.ts
@@ -1,7 +1,7 @@
 import type { MigrationInterface, QueryRunner } from "typeorm";
 
-export class ApiKeys1773000000000 implements MigrationInterface {
-  name = "ApiKeys1773000000000";
+export class ApiKeys1772193140110 implements MigrationInterface {
+  name = "ApiKeys1772193140110";
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`

--- a/nilcc-api/migrations/1773000000000-WalletAuth.ts
+++ b/nilcc-api/migrations/1773000000000-WalletAuth.ts
@@ -1,12 +1,28 @@
 import type { MigrationInterface, QueryRunner } from "typeorm";
 
-export class WalletAuth1772193140109 implements MigrationInterface {
-  name = "WalletAuth1772193140109";
+export class WalletAuth1773000000000 implements MigrationInterface {
+  name = "WalletAuth1773000000000";
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
       "ALTER TABLE accounts ADD COLUMN wallet_address VARCHAR",
     );
+
+    // Migrate existing api_token values into api_keys before dropping the column.
+    // Uses the api_token as the api_key id so existing clients can continue using it.
+    await queryRunner.query(`
+      INSERT INTO api_keys (id, account_id, type, active, created_at, updated_at)
+      SELECT
+        CAST(api_token AS UUID),
+        id,
+        'account-admin',
+        true,
+        NOW(),
+        NOW()
+      FROM accounts
+      WHERE api_token IS NOT NULL
+        AND api_token ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+    `);
 
     await queryRunner.query("ALTER TABLE accounts DROP COLUMN api_token");
 
@@ -30,6 +46,17 @@ export class WalletAuth1772193140109 implements MigrationInterface {
     await queryRunner.query(
       "ALTER TABLE accounts ADD COLUMN api_token VARCHAR UNIQUE",
     );
+    // Restore api_token from migrated api_keys
+    await queryRunner.query(`
+      UPDATE accounts SET api_token = ak.id::VARCHAR
+      FROM (
+        SELECT DISTINCT ON (account_id) id, account_id
+        FROM api_keys
+        WHERE type = 'account-admin'
+        ORDER BY account_id, created_at ASC
+      ) ak
+      WHERE accounts.id = ak.account_id
+    `);
     await queryRunner.query("ALTER TABLE accounts DROP COLUMN wallet_address");
   }
 }

--- a/nilcc-api/migrations/1774000000000-UsdBasedPricing.ts
+++ b/nilcc-api/migrations/1774000000000-UsdBasedPricing.ts
@@ -7,7 +7,7 @@ export class UsdBasedPricing1774000000000 implements MigrationInterface {
       `ALTER TABLE "accounts" ADD "balance" bigint NOT NULL DEFAULT 0`,
     );
     await queryRunner.query(
-      `UPDATE "accounts" SET "balance" = "credits" * 1000000`,
+      `UPDATE "accounts" SET "balance" = COALESCE("credits", 0)::bigint * 1000000`,
     );
     await queryRunner.query(`ALTER TABLE "accounts" DROP COLUMN "credits"`);
 
@@ -16,12 +16,12 @@ export class UsdBasedPricing1774000000000 implements MigrationInterface {
       `ALTER TABLE "workloads" RENAME COLUMN "credit_rate" TO "usd_cost_per_min"`,
     );
     await queryRunner.query(
-      `ALTER TABLE "workloads" ALTER COLUMN "usd_cost_per_min" TYPE bigint USING "usd_cost_per_min" * 1000000`,
+      `ALTER TABLE "workloads" ALTER COLUMN "usd_cost_per_min" TYPE bigint USING COALESCE("usd_cost_per_min", 0)::bigint * 1000000`,
     );
 
     // Change workload_tiers.cost type from int to bigint (microdollars)
     await queryRunner.query(
-      `ALTER TABLE "workload_tiers" ALTER COLUMN "cost" TYPE bigint USING "cost" * 1000000`,
+      `ALTER TABLE "workload_tiers" ALTER COLUMN "cost" TYPE bigint USING COALESCE("cost", 0)::bigint * 1000000`,
     );
 
     // Replace payments.credited_amount with USD-based columns and audit fields
@@ -37,16 +37,16 @@ export class UsdBasedPricing1774000000000 implements MigrationInterface {
     // Backfill from existing credited balances so migrated payment history stays
     // consistent with migrated account balances.
     await queryRunner.query(
-      `UPDATE "payments" SET "nil_amount" = CAST("amount" AS double precision) / 1000000`,
+      `UPDATE "payments" SET "nil_amount" = COALESCE(CAST("amount" AS double precision), 0) / 1000000`,
     );
     await queryRunner.query(
       `UPDATE "payments" SET "nil_price_at_deposit" = CASE
-        WHEN CAST("amount" AS double precision) = 0 THEN 1.0
-        ELSE CAST("credited_amount" AS double precision) / (CAST("amount" AS double precision) / 1000000)
+        WHEN COALESCE(CAST("amount" AS double precision), 0) = 0 THEN 1.0
+        ELSE CAST(COALESCE("credited_amount", 0) AS double precision) / NULLIF(CAST("amount" AS double precision) / 1000000, 0)
       END`,
     );
     await queryRunner.query(
-      `UPDATE "payments" SET "deposited_amount_usd" = CAST("credited_amount" AS bigint) * 1000000`,
+      `UPDATE "payments" SET "deposited_amount_usd" = COALESCE("credited_amount", 0)::bigint * 1000000::bigint`,
     );
     await queryRunner.query(
       `ALTER TABLE "payments" DROP COLUMN "credited_amount"`,
@@ -59,7 +59,7 @@ export class UsdBasedPricing1774000000000 implements MigrationInterface {
       `ALTER TABLE "payments" ADD "credited_amount" integer`,
     );
     await queryRunner.query(
-      `UPDATE "payments" SET "credited_amount" = CAST("nil_amount" * 1000 AS integer)`,
+      `UPDATE "payments" SET "credited_amount" = CAST(COALESCE("nil_amount", 0) * "nil_price_at_deposit" AS integer)`,
     );
     await queryRunner.query(
       `ALTER TABLE "payments" ALTER COLUMN "credited_amount" SET NOT NULL`,
@@ -74,12 +74,12 @@ export class UsdBasedPricing1774000000000 implements MigrationInterface {
 
     // Restore workload_tiers.cost type to int (divide by 1,000,000)
     await queryRunner.query(
-      `ALTER TABLE "workload_tiers" ALTER COLUMN "cost" TYPE integer USING ("cost" / 1000000)::integer`,
+      `ALTER TABLE "workload_tiers" ALTER COLUMN "cost" TYPE integer USING (COALESCE("cost", 0) / 1000000)::integer`,
     );
 
     // Restore workloads.usd_cost_per_min back to credit_rate as int
     await queryRunner.query(
-      `ALTER TABLE "workloads" ALTER COLUMN "usd_cost_per_min" TYPE integer USING ("usd_cost_per_min" / 1000000)::integer`,
+      `ALTER TABLE "workloads" ALTER COLUMN "usd_cost_per_min" TYPE integer USING (COALESCE("usd_cost_per_min", 0) / 1000000)::integer`,
     );
     await queryRunner.query(
       `ALTER TABLE "workloads" RENAME COLUMN "usd_cost_per_min" TO "credit_rate"`,
@@ -90,7 +90,7 @@ export class UsdBasedPricing1774000000000 implements MigrationInterface {
       `ALTER TABLE "accounts" ADD "credits" integer NOT NULL DEFAULT 0`,
     );
     await queryRunner.query(
-      `UPDATE "accounts" SET "credits" = ("balance" / 1000000)::integer`,
+      `UPDATE "accounts" SET "credits" = (COALESCE("balance", 0) / 1000000)::integer`,
     );
     await queryRunner.query(`ALTER TABLE "accounts" DROP COLUMN "balance"`);
   }

--- a/nilcc-api/src/data-source.ts
+++ b/nilcc-api/src/data-source.ts
@@ -24,9 +24,9 @@ import { CreateArtifactsTable1758563696154 } from "migrations/1758563696154-Crea
 import { MetalInstanceArtifactVersions1758645450546 } from "migrations/1758645450546-MetalInstanceArtifactVersions";
 import { ArtifactVersionMandatory1758656531192 } from "migrations/1758656531192-ArtifactVersionMandatory";
 import { WorkloadHeartbeats1765485856928 } from "migrations/1765485856928-WorkloadHeartbeats";
-import { WalletAuth1772193140109 } from "migrations/1772193140109-WalletAuth";
-import { Payments1772193140110 } from "migrations/1772193140110-Payments";
-import { ApiKeys1773000000000 } from "migrations/1773000000000-ApiKeys";
+import { Payments1772193140109 } from "migrations/1772193140109-Payments";
+import { ApiKeys1772193140110 } from "migrations/1772193140110-ApiKeys";
+import { WalletAuth1773000000000 } from "migrations/1773000000000-WalletAuth";
 import { UsdBasedPricing1774000000000 } from "migrations/1774000000000-UsdBasedPricing";
 import { DataSource } from "typeorm";
 import { ApiKeyEntity } from "#/api-key/api-key.entity";
@@ -76,9 +76,9 @@ export async function buildDataSource(config: EnvVars): Promise<DataSource> {
       MetalInstanceArtifactVersions1758645450546,
       ArtifactVersionMandatory1758656531192,
       WorkloadHeartbeats1765485856928,
-      WalletAuth1772193140109,
-      Payments1772193140110,
-      ApiKeys1773000000000,
+      Payments1772193140109,
+      ApiKeys1772193140110,
+      WalletAuth1773000000000,
       UsdBasedPricing1774000000000,
     ],
     synchronize: false,

--- a/nilcc-api/tests/migrations.test.ts
+++ b/nilcc-api/tests/migrations.test.ts
@@ -12,7 +12,7 @@ describe("UsdBasedPricing1774000000000", () => {
 
     expect(queryRunner.query).toHaveBeenCalledWith(
       expect.stringContaining(
-        'SET "deposited_amount_usd" = CAST("credited_amount" AS bigint) * 1000000',
+        'SET "deposited_amount_usd" = COALESCE("credited_amount", 0)::bigint * 1000000::bigint',
       ),
     );
   });


### PR DESCRIPTION
This is a modification to the migrations of nilcc-api that prevents losing the old api keys of users when doing the migrations. It also fixes other potential migrations issues that could arise such as empty values or 0 balannce.