### PR TITLE
feat: API key management and fixes, workload tier updates, and admin CLI improvements

### DIFF
--- a/.github/workflows/nilcc-api-ci.yml
+++ b/.github/workflows/nilcc-api-ci.yml
@@ -27,7 +27,7 @@ jobs:
           package_json_file: nilcc-api/package.json
       - run: pnpm install
       - run: pnpm exec biome ci
-      - run: tsc
+      - run: pnpm exec tsc
 
   test:
     needs: check

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ postgres_data/
 localstack_data/
 nilcc-attester/gpu-attester/verifier.log
 .env
+.vscode/

--- a/nilcc-admin-cli/src/api.rs
+++ b/nilcc-admin-cli/src/api.rs
@@ -40,6 +40,16 @@ impl ApiClient {
         Self::handle_response(response)
     }
 
+    pub fn put<T, O>(&self, path: &str, request: &T) -> Result<O, RequestError>
+    where
+        T: Serialize,
+        O: DeserializeOwned,
+    {
+        let url = self.make_url(path);
+        let response = self.client.put(url).json(request).send()?;
+        Self::handle_response(response)
+    }
+
     fn handle_response<O>(response: Response) -> Result<O, RequestError>
     where
         O: DeserializeOwned,

--- a/nilcc-admin-cli/src/main.rs
+++ b/nilcc-admin-cli/src/main.rs
@@ -1,5 +1,5 @@
 use crate::api::{ApiClient, RequestError};
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 use serde_json::json;
 use uuid::Uuid;
 
@@ -31,6 +31,10 @@ enum Command {
     #[clap(subcommand)]
     Accounts(AccountsCommand),
 
+    /// Manage account API keys.
+    #[clap(subcommand)]
+    ApiKeys(ApiKeysCommand),
+
     /// Manage tiers.
     #[clap(subcommand)]
     Tiers(TiersCommand),
@@ -57,6 +61,44 @@ enum AccountsCommand {
 
     /// Rename an account.
     Rename(RenameAccountArgs),
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
+enum ApiKeyTypeArg {
+    #[value(name = "account-admin")]
+    AccountAdmin,
+    #[value(name = "user")]
+    User,
+}
+
+impl ApiKeyTypeArg {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::AccountAdmin => "account-admin",
+            Self::User => "user",
+        }
+    }
+}
+
+#[derive(Subcommand)]
+enum ApiKeysCommand {
+    /// Create an API key for an account.
+    Create(CreateApiKeyArgs),
+
+    /// List the API keys for an account.
+    List {
+        /// The account id.
+        account_id: Uuid,
+    },
+
+    /// Update an API key.
+    Update(UpdateApiKeyArgs),
+
+    /// Delete an API key.
+    Delete {
+        /// The identifier of the API key to be deleted.
+        id: Uuid,
+    },
 }
 
 #[derive(Args)]
@@ -90,6 +132,34 @@ struct RenameAccountArgs {
     name: String,
 }
 
+#[derive(Args)]
+struct CreateApiKeyArgs {
+    /// The account id.
+    account_id: Uuid,
+
+    /// The type of API key to create.
+    #[clap(long, value_enum)]
+    key_type: ApiKeyTypeArg,
+
+    /// Create the key as inactive.
+    #[clap(long, default_value_t = false)]
+    inactive: bool,
+}
+
+#[derive(Args)]
+struct UpdateApiKeyArgs {
+    /// The identifier of the API key to update.
+    id: Uuid,
+
+    /// Set the API key type.
+    #[clap(long, value_enum)]
+    key_type: Option<ApiKeyTypeArg>,
+
+    /// Set whether the API key is active.
+    #[clap(long)]
+    active: Option<bool>,
+}
+
 #[derive(Subcommand)]
 enum TiersCommand {
     /// Create a tier.
@@ -97,6 +167,9 @@ enum TiersCommand {
 
     /// List tiers.
     List,
+
+    /// Update a tier.
+    Update(UpdateTierArgs),
 
     /// Delete a tier.
     Delete {
@@ -107,6 +180,35 @@ enum TiersCommand {
 
 #[derive(Args)]
 struct CreateTierArgs {
+    /// The tier name.
+    name: String,
+
+    /// The tier cost in USD/minute.
+    #[clap(long)]
+    cost: f64,
+
+    /// The number of CPUs that are granted with this tier.
+    #[clap(long)]
+    cpus: u64,
+
+    /// The number of GPUs that are granted with this tier.
+    #[clap(long)]
+    gpus: u64,
+
+    /// The amount of memory in this tier, in MBs.
+    #[clap(long)]
+    memory_mb: u64,
+
+    /// The amount of disk in this tier, in GBs.
+    #[clap(long)]
+    disk_gb: u64,
+}
+
+#[derive(Args)]
+struct UpdateTierArgs {
+    /// The identifier of the tier to be updated.
+    id: Uuid,
+
     /// The tier name.
     name: String,
 
@@ -192,6 +294,35 @@ impl Runner {
         self.client.post("/api/v1/accounts/update", &request)
     }
 
+    fn create_api_key(&self, args: CreateApiKeyArgs) -> Result<serde_json::Value, RequestError> {
+        let CreateApiKeyArgs { account_id, key_type, inactive } = args;
+        let request = models::api_keys::CreateApiKeyRequest {
+            account_id,
+            r#type: key_type.as_str().to_string(),
+            active: !inactive,
+        };
+        self.client.post("/api/v1/api-keys/create", &request)
+    }
+
+    fn list_api_keys(&self, account_id: Uuid) -> Result<serde_json::Value, RequestError> {
+        self.client.get(&format!("/api/v1/api-keys/account/{account_id}"))
+    }
+
+    fn update_api_key(&self, args: UpdateApiKeyArgs) -> Result<serde_json::Value, RequestError> {
+        let UpdateApiKeyArgs { id, key_type, active } = args;
+        let request = models::api_keys::UpdateApiKeyRequest {
+            id,
+            r#type: key_type.map(|value| value.as_str().to_string()),
+            active,
+        };
+        self.client.put("/api/v1/api-keys/update", &request)
+    }
+
+    fn delete_api_key(&self, id: Uuid) -> Result<serde_json::Value, RequestError> {
+        let request = models::api_keys::DeleteApiKeyRequest { id };
+        self.client.post("/api/v1/api-keys/delete", &request)
+    }
+
     fn create_tier(&self, args: CreateTierArgs) -> Result<serde_json::Value, RequestError> {
         let CreateTierArgs { name, cost, cpus, gpus, memory_mb, disk_gb } = args;
         let request = models::tiers::CreateTierRequest { name, cost, cpus, gpus, memory_mb, disk_gb };
@@ -200,6 +331,12 @@ impl Runner {
 
     fn list_tiers(&self) -> Result<serde_json::Value, RequestError> {
         self.client.get("/api/v1/workload-tiers/list")
+    }
+
+    fn update_tier(&self, args: UpdateTierArgs) -> Result<serde_json::Value, RequestError> {
+        let UpdateTierArgs { id, name, cost, cpus, gpus, memory_mb, disk_gb } = args;
+        let request = models::tiers::UpdateTierRequest { tier_id: id, name, cost, cpus, gpus, memory_mb, disk_gb };
+        self.client.put("/api/v1/workload-tiers/update", &request)
     }
 
     fn delete_tier(&self, tier_id: Uuid) -> Result<serde_json::Value, RequestError> {
@@ -239,8 +376,13 @@ fn main() {
         Command::Accounts(AccountsCommand::List) => runner.list_accounts(),
         Command::Accounts(AccountsCommand::AddBalance(args)) => runner.add_balance(args),
         Command::Accounts(AccountsCommand::Rename(args)) => runner.rename(args),
+        Command::ApiKeys(ApiKeysCommand::Create(args)) => runner.create_api_key(args),
+        Command::ApiKeys(ApiKeysCommand::List { account_id }) => runner.list_api_keys(account_id),
+        Command::ApiKeys(ApiKeysCommand::Update(args)) => runner.update_api_key(args),
+        Command::ApiKeys(ApiKeysCommand::Delete { id }) => runner.delete_api_key(id),
         Command::Tiers(TiersCommand::Create(args)) => runner.create_tier(args),
         Command::Tiers(TiersCommand::List) => runner.list_tiers(),
+        Command::Tiers(TiersCommand::Update(args)) => runner.update_tier(args),
         Command::Tiers(TiersCommand::Delete { id }) => runner.delete_tier(id),
         Command::Artifacts(ArtifactsCommand::Enable { version }) => runner.enable_artifact_version(version),
         Command::Artifacts(ArtifactsCommand::List) => runner.list_artifact_versions(),

--- a/nilcc-admin-cli/src/models.rs
+++ b/nilcc-admin-cli/src/models.rs
@@ -27,12 +27,52 @@ pub mod accounts {
     }
 }
 
+pub mod api_keys {
+    use super::*;
+
+    #[derive(Serialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct CreateApiKeyRequest {
+        pub account_id: Uuid,
+        pub r#type: String,
+        pub active: bool,
+    }
+
+    #[derive(Serialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct UpdateApiKeyRequest {
+        pub id: Uuid,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub r#type: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub active: Option<bool>,
+    }
+
+    #[derive(Serialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct DeleteApiKeyRequest {
+        pub id: Uuid,
+    }
+}
+
 pub mod tiers {
     use super::*;
 
     #[derive(Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct CreateTierRequest {
+        pub name: String,
+        pub cost: f64,
+        pub cpus: u64,
+        pub gpus: u64,
+        pub memory_mb: u64,
+        pub disk_gb: u64,
+    }
+
+    #[derive(Serialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct UpdateTierRequest {
+        pub tier_id: Uuid,
         pub name: String,
         pub cost: f64,
         pub cpus: u64,

--- a/nilcc-api/migrations/1772193140110-ApiKeys.ts
+++ b/nilcc-api/migrations/1772193140110-ApiKeys.ts
@@ -6,7 +6,7 @@ export class ApiKeys1772193140110 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
       CREATE TABLE api_keys (
-        id UUID PRIMARY KEY,
+        id VARCHAR PRIMARY KEY,
         account_id VARCHAR NOT NULL,
         type VARCHAR NOT NULL,
         active BOOLEAN NOT NULL DEFAULT true,

--- a/nilcc-api/migrations/1773000000000-WalletAuth.ts
+++ b/nilcc-api/migrations/1773000000000-WalletAuth.ts
@@ -13,7 +13,7 @@ export class WalletAuth1773000000000 implements MigrationInterface {
     await queryRunner.query(`
       INSERT INTO api_keys (id, account_id, type, active, created_at, updated_at)
       SELECT
-        CAST(api_token AS UUID),
+        api_token,
         id,
         'account-admin',
         true,
@@ -21,7 +21,6 @@ export class WalletAuth1773000000000 implements MigrationInterface {
         NOW()
       FROM accounts
       WHERE api_token IS NOT NULL
-        AND api_token ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
     `);
 
     await queryRunner.query("ALTER TABLE accounts DROP COLUMN api_token");

--- a/nilcc-api/migrations/1775000000000-ApiKeyIdVarchar.ts
+++ b/nilcc-api/migrations/1775000000000-ApiKeyIdVarchar.ts
@@ -1,0 +1,36 @@
+import type { MigrationInterface, QueryRunner } from "typeorm";
+
+const UUID_PATTERN =
+  "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$";
+
+export class ApiKeyIdVarchar1775000000000 implements MigrationInterface {
+  name = "ApiKeyIdVarchar1775000000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE api_keys
+      ALTER COLUMN id TYPE VARCHAR USING id::VARCHAR
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DO $$
+      BEGIN
+        IF EXISTS (
+          SELECT 1
+          FROM api_keys
+          WHERE id !~* '${UUID_PATTERN}'
+        ) THEN
+          RAISE EXCEPTION 'cannot narrow api_keys.id back to UUID while non-UUID API keys exist';
+        END IF;
+      END
+      $$;
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE api_keys
+      ALTER COLUMN id TYPE UUID USING id::UUID
+    `);
+  }
+}

--- a/nilcc-api/src/account/account.controller.ts
+++ b/nilcc-api/src/account/account.controller.ts
@@ -3,9 +3,9 @@ import { resolver } from "hono-openapi/zod";
 import { z } from "zod";
 import {
   accountIdentityAdminAuthentication,
+  accountIdentityAuthentication,
   adminAuthentication,
   assertCanManageIdentityAccount,
-  jwtAuthentication,
 } from "#/common/auth";
 import { EntityNotFound } from "#/common/errors";
 import { microdollarsToUsd } from "#/common/nil";
@@ -169,7 +169,7 @@ export function me(options: ControllerOptions) {
         ...OpenApiSpecCommonErrorResponses,
       },
     }),
-    jwtAuthentication(bindings),
+    accountIdentityAuthentication(bindings),
     async (c) => {
       const account = c.get("account");
       const outputAccount = accountMapper.entityToResponse(account);

--- a/nilcc-api/src/api-key/api-key.dto.ts
+++ b/nilcc-api/src/api-key/api-key.dto.ts
@@ -5,7 +5,7 @@ export type ApiKeyType = z.infer<typeof ApiKeyType>;
 
 export const ApiKey = z
   .object({
-    id: z.string().uuid(),
+    id: z.string().min(1),
     accountId: z.string().uuid(),
     type: ApiKeyType,
     active: z.boolean(),
@@ -26,7 +26,7 @@ export type CreateApiKeyRequest = z.infer<typeof CreateApiKeyRequest>;
 
 export const UpdateApiKeyRequest = z
   .object({
-    id: z.string().uuid(),
+    id: z.string().min(1),
     type: ApiKeyType.optional(),
     active: z.boolean().optional(),
   })
@@ -38,7 +38,7 @@ export type UpdateApiKeyRequest = z.infer<typeof UpdateApiKeyRequest>;
 
 export const DeleteApiKeyRequest = z
   .object({
-    id: z.string().uuid(),
+    id: z.string().min(1),
   })
   .openapi({ ref: "DeleteApiKeyRequest" });
 export type DeleteApiKeyRequest = z.infer<typeof DeleteApiKeyRequest>;

--- a/nilcc-api/src/api-key/api-key.entity.ts
+++ b/nilcc-api/src/api-key/api-key.entity.ts
@@ -11,7 +11,7 @@ import type { ApiKeyType } from "./api-key.dto";
 
 @Entity({ name: "api_keys" })
 export class ApiKeyEntity {
-  @PrimaryColumn({ type: "uuid" })
+  @PrimaryColumn({ type: "varchar" })
   id: string;
 
   @Column({ type: "varchar" })

--- a/nilcc-api/src/api-key/api-key.service.ts
+++ b/nilcc-api/src/api-key/api-key.service.ts
@@ -5,9 +5,6 @@ import type { AppBindings } from "#/env";
 import type { CreateApiKeyRequest, UpdateApiKeyRequest } from "./api-key.dto";
 import { ApiKeyEntity } from "./api-key.entity";
 
-const UUID_V4_PATTERN =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-
 export class ApiKeyService {
   getRepository(
     bindings: AppBindings,
@@ -97,9 +94,6 @@ export class ApiKeyService {
     bindings: AppBindings,
     id: string,
   ): Promise<ApiKeyEntity | null> {
-    if (!UUID_V4_PATTERN.test(id)) {
-      return null;
-    }
     const repository = this.getRepository(bindings);
     return await repository.findOne({
       where: { id, active: true },

--- a/nilcc-api/src/common/auth.ts
+++ b/nilcc-api/src/common/auth.ts
@@ -71,6 +71,27 @@ export function userAuthentication(bindings: AppBindings) {
   };
 }
 
+export function accountIdentityAuthentication(bindings: AppBindings) {
+  return async (c: Context, next: Next) => {
+    const auth = await resolveAuthentication(c, bindings);
+    if (!auth || auth.principal === AuthPrincipal.GLOBAL_ADMIN) {
+      return c.json(authError("unauthorized"), 401);
+    }
+
+    if (
+      auth.principal === AuthPrincipal.ACCOUNT_API_KEY &&
+      auth.apiKeyType !== "account-admin"
+    ) {
+      return c.json(authError("unauthorized"), 401);
+    }
+
+    c.set("auth", auth);
+    c.set("account", auth.account);
+    await next();
+    return;
+  };
+}
+
 export function jwtAuthentication(bindings: AppBindings) {
   return async (c: Context, next: Next) => {
     const token = extractBearerToken(c);

--- a/nilcc-api/src/common/paths.ts
+++ b/nilcc-api/src/common/paths.ts
@@ -57,6 +57,7 @@ export const PathsV1 = {
   workloadTiers: {
     create: PathSchema.parse("/api/v1/workload-tiers/create"),
     list: PathSchema.parse("/api/v1/workload-tiers/list"),
+    update: PathSchema.parse("/api/v1/workload-tiers/update"),
     delete: PathSchema.parse("/api/v1/workload-tiers/delete"),
   },
   metalInstance: {

--- a/nilcc-api/src/data-source.ts
+++ b/nilcc-api/src/data-source.ts
@@ -28,6 +28,7 @@ import { Payments1772193140109 } from "migrations/1772193140109-Payments";
 import { ApiKeys1772193140110 } from "migrations/1772193140110-ApiKeys";
 import { WalletAuth1773000000000 } from "migrations/1773000000000-WalletAuth";
 import { UsdBasedPricing1774000000000 } from "migrations/1774000000000-UsdBasedPricing";
+import { ApiKeyIdVarchar1775000000000 } from "migrations/1775000000000-ApiKeyIdVarchar";
 import { DataSource } from "typeorm";
 import { ApiKeyEntity } from "#/api-key/api-key.entity";
 import { NonceEntity } from "#/auth/nonce.entity";
@@ -80,6 +81,7 @@ export async function buildDataSource(config: EnvVars): Promise<DataSource> {
       ApiKeys1772193140110,
       WalletAuth1773000000000,
       UsdBasedPricing1774000000000,
+      ApiKeyIdVarchar1775000000000,
     ],
     synchronize: false,
     logging: false,

--- a/nilcc-api/src/workload-tier/workload-tier.controllers.ts
+++ b/nilcc-api/src/workload-tier/workload-tier.controllers.ts
@@ -5,9 +5,11 @@ import { OpenApiSpecCommonErrorResponses } from "#/common/openapi";
 import { PathsV1 } from "#/common/paths";
 import type { ControllerOptions } from "#/common/types";
 import { payloadValidator } from "#/common/zod-utils";
+import { transactionMiddleware } from "#/data-source";
 import {
   CreateWorkloadTierRequest,
   DeleteWorkloadTierRequest,
+  UpdateWorkloadTierRequest,
   WorkloadTier,
 } from "./workload-tier.dto";
 import { workloadTierMapper } from "./workload-tier.mapper";
@@ -70,6 +72,41 @@ export function list(options: ControllerOptions) {
       const tiers = await bindings.services.workloadTier.list(bindings);
       tiers.sort((a, b) => a.cost - b.cost);
       return c.json(tiers.map(workloadTierMapper.entityToResponse));
+    },
+  );
+}
+
+export function update(options: ControllerOptions) {
+  const { app, bindings } = options;
+  app.put(
+    PathsV1.workloadTiers.update,
+    describeRoute({
+      tags: ["workload-tier"],
+      summary: "Update a workload tier",
+      description: "This updates a workload tier.",
+      responses: {
+        200: {
+          description: "The workload tier was updated successfully",
+          content: {
+            "application/json": {
+              schema: resolver(WorkloadTier),
+            },
+          },
+        },
+        ...OpenApiSpecCommonErrorResponses,
+      },
+    }),
+    adminAuthentication(bindings),
+    payloadValidator(UpdateWorkloadTierRequest),
+    transactionMiddleware(bindings.dataSource),
+    async (c) => {
+      const payload = c.req.valid("json");
+      const tier = await bindings.services.workloadTier.update(
+        bindings,
+        payload,
+        c.get("txQueryRunner"),
+      );
+      return c.json(workloadTierMapper.entityToResponse(tier));
     },
   );
 }

--- a/nilcc-api/src/workload-tier/workload-tier.dto.ts
+++ b/nilcc-api/src/workload-tier/workload-tier.dto.ts
@@ -49,6 +49,32 @@ export type CreateWorkloadTierRequest = z.infer<
   typeof CreateWorkloadTierRequest
 >;
 
+export const UpdateWorkloadTierRequest = z
+  .object({
+    tierId: Uuid.openapi({ description: "The identifier of the tier." }),
+    name: z.string().openapi({ description: "The name of the tier." }),
+    cpus: z
+      .number()
+      .openapi({ description: "The number of CPUs included in the tier." }),
+    gpus: z
+      .number()
+      .openapi({ description: "The number of GPUs included in the tier." }),
+    memoryMb: z.number().openapi({
+      description: "The amount of MB of RAM included in the tier.",
+    }),
+    diskGb: z.number().openapi({
+      description: "The amount of GB of disk included in the tier.",
+    }),
+    cost: z
+      .number()
+      .positive()
+      .openapi({ description: "The cost per minute in USD for the tier." }),
+  })
+  .openapi({ description: "A request to update a tier." });
+export type UpdateWorkloadTierRequest = z.infer<
+  typeof UpdateWorkloadTierRequest
+>;
+
 export const DeleteWorkloadTierRequest = z
   .object({
     tierId: z.string().openapi({ description: "The tier identifier." }),

--- a/nilcc-api/src/workload-tier/workload-tier.router.ts
+++ b/nilcc-api/src/workload-tier/workload-tier.router.ts
@@ -4,5 +4,6 @@ import * as WorkloadTierController from "./workload-tier.controllers";
 export function buildWorkloadTierRouter(options: ControllerOptions): void {
   WorkloadTierController.create(options);
   WorkloadTierController.list(options);
+  WorkloadTierController.update(options);
   WorkloadTierController.remove(options);
 }

--- a/nilcc-api/src/workload-tier/workload-tier.service.ts
+++ b/nilcc-api/src/workload-tier/workload-tier.service.ts
@@ -1,9 +1,16 @@
 import type { QueryRunner, Repository } from "typeorm";
 import { v4 as uuidv4 } from "uuid";
-import { EntityAlreadyExists, isUniqueConstraint } from "#/common/errors";
+import {
+  EntityAlreadyExists,
+  EntityNotFound,
+  isUniqueConstraint,
+} from "#/common/errors";
 import { usdToMicrodollars } from "#/common/nil";
 import type { AppBindings } from "#/env";
-import type { CreateWorkloadTierRequest } from "./workload-tier.dto";
+import type {
+  CreateWorkloadTierRequest,
+  UpdateWorkloadTierRequest,
+} from "./workload-tier.dto";
 import { WorkloadTierEntity } from "./workload-tier.entity";
 
 export class WorkloadTierService {
@@ -43,6 +50,34 @@ export class WorkloadTierService {
   async remove(bindings: AppBindings, id: string): Promise<void> {
     const repository = this.getRepository(bindings);
     await repository.delete({ id });
+  }
+
+  async update(
+    bindings: AppBindings,
+    request: UpdateWorkloadTierRequest,
+    tx: QueryRunner,
+  ): Promise<WorkloadTierEntity> {
+    const repository = this.getRepository(bindings, tx);
+    const tier = await repository.findOneBy({ id: request.tierId });
+    if (tier === null) {
+      throw new EntityNotFound("workload tier");
+    }
+
+    tier.name = request.name;
+    tier.cpus = request.cpus;
+    tier.gpus = request.gpus;
+    tier.memory = request.memoryMb;
+    tier.disk = request.diskGb;
+    tier.cost = usdToMicrodollars(request.cost);
+
+    try {
+      return await repository.save(tier);
+    } catch (e: unknown) {
+      if (isUniqueConstraint(e)) {
+        throw new EntityAlreadyExists("workload tier");
+      }
+      throw e;
+    }
   }
 
   async list(bindings: AppBindings): Promise<WorkloadTierEntity[]> {

--- a/nilcc-api/tests/api-key.test.ts
+++ b/nilcc-api/tests/api-key.test.ts
@@ -1,5 +1,6 @@
 import * as crypto from "node:crypto";
 import { describe } from "vitest";
+import { ApiKeyEntity } from "#/api-key/api-key.entity";
 import { PathsV1 } from "#/common/paths";
 import { createTestFixtureExtension } from "./fixture/it";
 
@@ -221,6 +222,71 @@ describe("API keys", () => {
       },
     });
     expect(tierInactiveResponse.status).toBe(401);
+  });
+
+  it("authenticates and manages legacy non-UUID api keys", async ({
+    expect,
+    clients,
+    app,
+    bindings,
+  }) => {
+    const me = await clients.user.myAccount().submit();
+    const legacyKeyId = "sandbox-legacy-api-key";
+    const repository = bindings.dataSource.getRepository(ApiKeyEntity);
+    const now = new Date();
+
+    await repository.save({
+      id: legacyKeyId,
+      accountId: me.accountId,
+      type: "account-admin",
+      active: true,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const listResponse = await app.request(
+      PathsV1.apiKeys.listByAccount.replace(":accountId", me.accountId),
+      {
+        method: "GET",
+        headers: {
+          authorization: `Bearer ${legacyKeyId}`,
+        },
+      },
+    );
+    expect(listResponse.status).toBe(200);
+    const keys = (await listResponse.json()) as Array<{ id: string }>;
+    expect(keys.map((key) => key.id)).toContain(legacyKeyId);
+
+    const updateResponse = await app.request(PathsV1.apiKeys.update, {
+      method: "PUT",
+      headers: {
+        authorization: `Bearer ${legacyKeyId}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        id: legacyKeyId,
+        active: false,
+      }),
+    });
+    expect(updateResponse.status).toBe(200);
+
+    const tierResponse = await app.request(PathsV1.workloadTiers.list, {
+      method: "GET",
+      headers: {
+        authorization: `Bearer ${legacyKeyId}`,
+      },
+    });
+    expect(tierResponse.status).toBe(401);
+
+    const deleteResponse = await app.request(PathsV1.apiKeys.delete, {
+      method: "POST",
+      headers: {
+        "x-api-key": bindings.config.adminApiKey,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ id: legacyKeyId }),
+    });
+    expect(deleteResponse.status).toBe(200);
   });
 
   it("denies account-admin api key from other accounts", async ({

--- a/nilcc-api/tests/docker/docker-compose.yml
+++ b/nilcc-api/tests/docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - "35432:5432"
 
   localstack:
-    image: localstack/localstack
+    image: localstack/localstack:4.14.0
     ports:
       - "14566:4566"
 

--- a/nilcc-api/tests/fixture/global-setup.ts
+++ b/nilcc-api/tests/fixture/global-setup.ts
@@ -1,4 +1,6 @@
+import { connect } from "node:net";
 import { dirname } from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
 import dockerCompose from "docker-compose";
 import type { TestProject } from "vitest/node";
@@ -31,18 +33,19 @@ export async function setup(_project: TestProject) {
     for (; retry < MAX_RETRIES; retry++) {
       const result = await dockerCompose.ps(composeOptions);
       if (
-        result.data.services.every((service) => service.state.includes("Up"))
+        result.data.services.every((service) => service.state.includes("Up")) &&
+        (await allEndpointsReady())
       ) {
         break;
       }
-      await new Promise((f) => setTimeout(f, 200));
+      await sleep(200);
     }
     if (retry >= MAX_RETRIES) {
       console.error("Error starting containers: timeout");
       process.exit(1);
     }
     // We need sleep 1 sec to be sure that the AboutResponse.started is at least 1 sec earlier than the tests start.
-    await new Promise((f) => setTimeout(f, 2000));
+    await sleep(2000);
     console.log("Containers started successfully.");
   } catch (error) {
     console.error("Error starting containers: ", error);
@@ -65,4 +68,70 @@ export async function teardown(_project: TestProject) {
     console.error("Error removing containers: ", error);
     process.exit(1);
   }
+}
+
+async function allEndpointsReady(): Promise<boolean> {
+  const checks = [
+    waitForTcpPort("127.0.0.1", 35432),
+    waitForHttp("http://127.0.0.1:14566/_localstack/health"),
+    waitForJsonRpc("http://127.0.0.1:38545"),
+    waitForHttp("http://127.0.0.1:35435"),
+    waitForHttp("http://127.0.0.1:35436"),
+  ];
+
+  const results = await Promise.all(checks);
+  return results.every(Boolean);
+}
+
+async function waitForHttp(url: string): Promise<boolean> {
+  try {
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(1000),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForJsonRpc(url: string): Promise<boolean> {
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        method: "eth_chainId",
+        params: [],
+        id: 1,
+      }),
+      signal: AbortSignal.timeout(1000),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForTcpPort(host: string, port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = connect({ host, port });
+
+    socket.setTimeout(1000);
+
+    socket.once("connect", () => {
+      socket.end();
+      resolve(true);
+    });
+
+    socket.once("timeout", () => {
+      socket.destroy();
+      resolve(false);
+    });
+
+    socket.once("error", () => {
+      socket.destroy();
+      resolve(false);
+    });
+  });
 }

--- a/nilcc-api/tests/fixture/test-client.ts
+++ b/nilcc-api/tests/fixture/test-client.ts
@@ -42,6 +42,7 @@ import {
 } from "#/workload-event/workload-event.dto";
 import {
   type CreateWorkloadTierRequest,
+  type UpdateWorkloadTierRequest,
   WorkloadTier,
 } from "#/workload-tier/workload-tier.dto";
 
@@ -172,6 +173,14 @@ export class AdminClient extends TestClient {
   createTier(request: CreateWorkloadTierRequest): RequestPromise<WorkloadTier> {
     const promise = this.request(PathsV1.workloadTiers.create, {
       method: "POST",
+      body: request,
+    });
+    return new RequestPromise(promise, WorkloadTier);
+  }
+
+  updateTier(request: UpdateWorkloadTierRequest): RequestPromise<WorkloadTier> {
+    const promise = this.request(PathsV1.workloadTiers.update, {
+      method: "PUT",
       body: request,
     });
     return new RequestPromise(promise, WorkloadTier);

--- a/nilcc-api/tests/migrations.test.ts
+++ b/nilcc-api/tests/migrations.test.ts
@@ -1,6 +1,8 @@
 import type { QueryRunner } from "typeorm";
 import { describe, expect, it, vi } from "vitest";
+import { WalletAuth1773000000000 } from "../migrations/1773000000000-WalletAuth";
 import { UsdBasedPricing1774000000000 } from "../migrations/1774000000000-UsdBasedPricing";
+import { ApiKeyIdVarchar1775000000000 } from "../migrations/1775000000000-ApiKeyIdVarchar";
 
 describe("UsdBasedPricing1774000000000", () => {
   it("backfills deposited USD from credited amounts", async () => {
@@ -14,6 +16,56 @@ describe("UsdBasedPricing1774000000000", () => {
       expect.stringContaining(
         'SET "deposited_amount_usd" = COALESCE("credited_amount", 0)::bigint * 1000000::bigint',
       ),
+    );
+  });
+});
+
+describe("WalletAuth1773000000000", () => {
+  it("migrates all legacy api_token values without UUID filtering", async () => {
+    const queryRunner = {
+      query: vi.fn().mockResolvedValue(undefined),
+    } as unknown as QueryRunner;
+
+    await new WalletAuth1773000000000().up(queryRunner);
+
+    const insertCall = vi
+      .mocked(queryRunner.query)
+      .mock.calls.find(([sql]) => sql.includes("INSERT INTO api_keys"));
+
+    expect(insertCall?.[0]).toContain("api_token,");
+    expect(insertCall?.[0]).toContain("WHERE api_token IS NOT NULL");
+    expect(insertCall?.[0]).not.toContain("CAST(api_token AS UUID)");
+    expect(insertCall?.[0]).not.toContain("api_token ~");
+  });
+});
+
+describe("ApiKeyIdVarchar1775000000000", () => {
+  it("widens api_keys.id to varchar in up migration", async () => {
+    const queryRunner = {
+      query: vi.fn().mockResolvedValue(undefined),
+    } as unknown as QueryRunner;
+
+    await new ApiKeyIdVarchar1775000000000().up(queryRunner);
+
+    expect(queryRunner.query).toHaveBeenCalledWith(
+      expect.stringContaining("ALTER COLUMN id TYPE VARCHAR USING id::VARCHAR"),
+    );
+  });
+
+  it("guards non-UUID keys before narrowing on down migration", async () => {
+    const queryRunner = {
+      query: vi.fn().mockResolvedValue(undefined),
+    } as unknown as QueryRunner;
+
+    await new ApiKeyIdVarchar1775000000000().down(queryRunner);
+
+    expect(queryRunner.query).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining("cannot narrow api_keys.id back to UUID"),
+    );
+    expect(queryRunner.query).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining("ALTER COLUMN id TYPE UUID USING id::UUID"),
     );
   });
 });

--- a/nilcc-api/tests/workload-tier.test.ts
+++ b/nilcc-api/tests/workload-tier.test.ts
@@ -1,5 +1,8 @@
 import { describe } from "vitest";
-import type { CreateWorkloadTierRequest } from "#/workload-tier/workload-tier.dto";
+import type {
+  CreateWorkloadTierRequest,
+  UpdateWorkloadTierRequest,
+} from "#/workload-tier/workload-tier.dto";
 import { createTestFixtureExtension } from "./fixture/it";
 
 describe("WorkloadTier", () => {
@@ -38,5 +41,41 @@ describe("WorkloadTier", () => {
     await clients.admin.deleteTier(tier.tierId).submit();
     expect(await clients.user.listTiers().submit()).toEqual([]);
     expect(await clients.admin.listTiers().submit()).toEqual([]);
+  });
+
+  it("should update an existing workload tier", async ({ expect, clients }) => {
+    const created = await clients.admin
+      .createTier({
+        name: "tier-to-update",
+        cpus: 1,
+        memoryMb: 1024,
+        gpus: 0,
+        diskGb: 10,
+        cost: 1,
+      })
+      .submit();
+
+    const request: UpdateWorkloadTierRequest = {
+      tierId: created.tierId,
+      name: "tier-updated",
+      cpus: 4,
+      memoryMb: 8192,
+      gpus: 1,
+      diskGb: 40,
+      cost: 7.5,
+    };
+
+    const updated = await clients.admin.updateTier(request).submit();
+
+    expect(updated).toEqual({
+      tierId: created.tierId,
+      name: request.name,
+      cpus: request.cpus,
+      memoryMb: request.memoryMb,
+      gpus: request.gpus,
+      diskGb: request.diskGb,
+      cost: request.cost,
+    });
+    expect(await clients.user.listTiers().submit()).toEqual([updated]);
   });
 });


### PR DESCRIPTION
## Summary

- **API key ID type change**: Widen `api_keys.id` from UUID to VARCHAR to support legacy non-UUID key identifiers (e.g. sandbox keys). Includes a new migration, updated entity/DTOs, and removal of the UUID-only regex filter from key lookups. This fixes an issue where in Sandbox, API Keys were removed when migrating forward.
- **Auth middleware**: Add `accountIdentityAuthentication` middleware that accepts both JWT and account-admin API key auth, used on the GET account endpoint.
- **Workload tier update endpoint**: Add `PUT /api/v1/workload-tiers/update` to allow modifying tier properties (name, cpus, gpus, memory, disk, cost). This allows us to change tiers live when workloads are running on that tier.
- **Admin CLI commands**: Add CRUD commands for API keys and an update command for workload tiers, with a new generic PUT method on the API client. This allows managing API Keys from the `nilcc-admin-cli`.
- **Test reliability**: Pin localstack to v4.14.0 and add TCP/HTTP readiness checks for all test services to prevent race conditions on container startup.
- **CI fix**: Use `pnpm exec tsc` instead of bare `tsc` to avoid picking up a system TypeScript on newer GitHub Actions runner images.